### PR TITLE
Migrate to fastmcp 3.x (supersedes #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ ENV/
 # OS
 .DS_Store
 Thumbs.db
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@
 - `src/sas_mcp_server/config.py` — Added SSL verification bypass via httpx monkey-patch when `SSL_VERIFY=false`
 - `src/sas_mcp_server/viya_utils.py` — Respects `SSL_VERIFY` setting for Viya API calls
 - `examples/configuration.md` — Added Python registration script instructions and `SSL_VERIFY` to environment variables table
+- **Bumped `fastmcp` from `>=2.13.0.2` to `>=3.0.0,<4.0.0`** (major version). v3 made several APIs async and renamed some module paths. The migration in this repo touches:
+  - `OAuthProxy(upstream_client_secret=None, ...)` — `""` is no longer accepted.
+  - `Context.set_state` / `Context.get_state` are now `async def` (carried from PR #9).
+  - `from fastmcp.utilities.logging import get_logger` — top-level `fastmcp.utilities` is no longer re-exported.
+  - `from fastmcp.prompts import Message` — module path flattened.
+  - `from fastmcp.tools import ToolResult` — module path flattened.
+- **`OAuthProxy(valid_scopes=["openid"])`** — required so containerized deployments accept tokens issued only with `openid` (carried from PR #9; fixes OAuth2 under Podman/Docker).
+- **SSL monkey-patch in `config.py` is now idempotent** — guarded by `_sas_mcp_ssl_patched` so reloading the module doesn't stack wrappers around `httpx.AsyncClient.__init__`.
 
 ### Fixed
 - `upload_data` — Rewrote to use the CAS Management REST API (`POST /casManagement/servers/{server}/caslibs/{caslib}/tables` with `multipart/form-data`) instead of a SAS DATA step workaround; handles 409 (table already exists) gracefully
@@ -44,3 +52,12 @@
 - `.dockerignore` — Added `!README.md` exception so `uv build` can find the readme during container builds
 - `.env.sample` — Corrected `CONTEXT_NAME` to `COMPUTE_CONTEXT_NAME` to match the actual env var read by config
 - `examples/configuration.md` — Corrected `CONTEXT_NAME` to `COMPUTE_CONTEXT_NAME` in environment variables table
+- **HTTP auth middleware** correctly `await`s `Context.set_state` / `get_state` under v3's async state API (PR #9).
+
+### Tests
+- Updated `test_prompts.py` to use the public `mcp.get_prompt()` / `mcp.list_prompts()` API; v3 removed the private `_prompt_manager` attribute the prior tests reached into.
+- Updated `test_mcp_server.py` to `await` mocked `Context.get_state`, since v3 makes the method async.
+- Switched `test_config.py` from `del sys.modules + import` to `importlib.reload()`. The old pattern created orphan config modules that polluted `httpx.AsyncClient.__init__` and broke later integration tests with empty-message `ConnectError`s.
+- `conftest.py` now calls `load_dotenv()` at module top so `SSL_VERIFY` (and friends) are read from `.env` before any `sas_mcp_server` module is first imported; the `viya_token` fixture also gets an explicit `timeout=60.0` on the password-grant request.
+- `test_integration.py` pinned to a session-scoped asyncio loop (`@pytest.mark.asyncio(loop_scope="session")`) so the session-scoped `integration_mcp_server` fixture and per-test `Client` share one loop.
+- `test_cas_discovery_workflow` now targets `Public.HMEQ` directly (skips if not loaded) instead of picking `caslibs[0]`/`tables[0]`, which was brittle on Viyas with many tables or unloaded source tables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{name = "SAS Institute Inc."}]
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp>=2.13.0.2",
+    "fastmcp>=3.0.0,<4.0.0",
     "httpx>=0.28.1",
     "pydantic>=2.12.4",
     "python-dotenv>=1.2.1",

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -63,5 +63,5 @@ viya_auth = OAuthProxy(
     base_url=MCP_BASE_URL,
     forward_pkce=True,
     token_verifier=token_verifier,
-    valid_scopes=[],
+    valid_scopes=["openid"],
 )

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -15,25 +15,32 @@ SSL_VERIFY = os.getenv("SSL_VERIFY", "true").lower() not in ("false", "0", "no")
 if not SSL_VERIFY:
     # Disable SSL verification for self-signed Viya certificates
     import httpx
-    _ssl_context = ssl.create_default_context()
-    _ssl_context.check_hostname = False
-    _ssl_context.verify_mode = ssl.CERT_NONE
-    # Monkey-patch httpx to use our permissive SSL context by default
-    _original_async_client_init = httpx.AsyncClient.__init__
+    # Guard against re-patching when this module is reloaded (e.g. by tests
+    # that del sys.modules['sas_mcp_server.config'] and re-import). Without
+    # this, each reload stacks another wrapper around the existing one,
+    # eventually breaking outbound httpx connections in the same process.
+    if not getattr(httpx.AsyncClient.__init__, "_sas_mcp_ssl_patched", False):
+        _ssl_context = ssl.create_default_context()
+        _ssl_context.check_hostname = False
+        _ssl_context.verify_mode = ssl.CERT_NONE
+        # Monkey-patch httpx to use our permissive SSL context by default
+        _original_async_client_init = httpx.AsyncClient.__init__
 
-    def _patched_async_client_init(self, *args, **kwargs):
-        kwargs.setdefault("verify", _ssl_context)
-        _original_async_client_init(self, *args, **kwargs)
+        def _patched_async_client_init(self, *args, **kwargs):
+            kwargs.setdefault("verify", _ssl_context)
+            _original_async_client_init(self, *args, **kwargs)
 
-    httpx.AsyncClient.__init__ = _patched_async_client_init
+        _patched_async_client_init._sas_mcp_ssl_patched = True
+        httpx.AsyncClient.__init__ = _patched_async_client_init
 
-    _original_client_init = httpx.Client.__init__
+        _original_client_init = httpx.Client.__init__
 
-    def _patched_client_init(self, *args, **kwargs):
-        kwargs.setdefault("verify", _ssl_context)
-        _original_client_init(self, *args, **kwargs)
+        def _patched_client_init(self, *args, **kwargs):
+            kwargs.setdefault("verify", _ssl_context)
+            _original_client_init(self, *args, **kwargs)
 
-    httpx.Client.__init__ = _patched_client_init
+        _patched_client_init._sas_mcp_ssl_patched = True
+        httpx.Client.__init__ = _patched_client_init
 
 VIYA_ENDPOINT = os.getenv("VIYA_ENDPOINT", "").rstrip("/")
 CLIENT_ID = os.getenv("CLIENT_ID", "sas-mcp")
@@ -58,7 +65,7 @@ viya_auth = OAuthProxy(
     upstream_authorization_endpoint=AUTHORIZATION_ENDPOINT,
     upstream_token_endpoint=TOKEN_ENDPOINT,
     upstream_client_id=CLIENT_ID,
-    upstream_client_secret="",
+    upstream_client_secret=None,
     jwt_signing_key=MCP_SIGNING_KEY,
     base_url=MCP_BASE_URL,
     forward_pkce=True,

--- a/src/sas_mcp_server/mcp_server.py
+++ b/src/sas_mcp_server/mcp_server.py
@@ -47,7 +47,7 @@ class AuthMiddleware(Middleware):
             if viya_access_info:
                 logger.info("Viya access info retrieved successfully!")
                 viya_access_token = viya_access_info.token
-                ctx.fastmcp_context.set_state("access_token", viya_access_token)
+                await ctx.fastmcp_context.set_state("access_token", viya_access_token)
             else:
                 logger.error("Could not retrieve upstream access token!")
         else:
@@ -71,7 +71,7 @@ async def health_check(request):
 
 # Token getter for HTTP mode: reads from context state set by AuthMiddleware
 async def _http_get_token(ctx: Context) -> str:
-    token = ctx.get_state("access_token")
+    token = await ctx.get_state("access_token")
     if not token:
         raise AuthenticationError("No auth header found. Cannot authenticate to Viya")
     return token

--- a/src/sas_mcp_server/prompts.py
+++ b/src/sas_mcp_server/prompts.py
@@ -7,7 +7,7 @@ Registered via ``register_prompts(mcp)`` on the FastMCP instance.
 """
 
 from typing import Optional
-from fastmcp.prompts.prompt import Message
+from fastmcp.prompts import Message
 
 
 def register_prompts(mcp):

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -9,7 +9,7 @@ All tools are registered via ``register_tools(mcp, get_token)``.
 from typing import Optional
 import httpx as _httpx
 from fastmcp import Context
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 from .viya_utils import (
     _get_json,
     _get_paged_items,

--- a/src/sas_mcp_server/viya_utils.py
+++ b/src/sas_mcp_server/viya_utils.py
@@ -3,10 +3,10 @@
 
 import asyncio
 import httpx
-from fastmcp import utilities
+from fastmcp.utilities.logging import get_logger
 from .config import VIYA_ENDPOINT, CONTEXT_NAME, SSL_VERIFY
 
-logger = utilities.logging.get_logger(__name__)
+logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,13 @@ import os
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
+from dotenv import load_dotenv
+
+# Load .env once, before any sas_mcp_server module is imported, so that
+# SSL_VERIFY and other config values captured at import time reflect the
+# developer's local environment rather than the bare OS env.
+load_dotenv()
+
 from fastmcp import FastMCP, Client
 
 
@@ -208,6 +215,7 @@ def viya_token(viya_credentials):
             "password": viya_credentials["password"],
         },
         verify=SSL_VERIFY,
+        timeout=60.0,
     )
     resp.raise_for_status()
     return resp.json()["access_token"]
@@ -215,7 +223,12 @@ def viya_token(viya_credentials):
 
 @pytest.fixture(scope="session")
 def integration_mcp_server(viya_token):
-    """Create an MCP server with real Viya auth for integration tests."""
+    """Create an MCP server with real Viya auth for integration tests.
+
+    Must be created within the same event loop the integration tests run in.
+    test_integration.py pins itself to a session-scoped loop so this fixture
+    and the per-test Client both share the same loop.
+    """
     mcp = FastMCP("Integration Test Server")
 
     _token = viya_token

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,93 +3,79 @@
 
 """
 Tests for the config module.
+
+These tests use ``importlib.reload`` (which preserves the module object's
+identity and just re-runs its top-level code) rather than
+``del sys.modules[...]`` + import, which would create a NEW module instance
+and leave the old one orphaned. Orphaned config modules carry their own
+``viya_auth = OAuthProxy(...)`` instance — each holding internal httpx
+state. Accumulating orphans across multiple tests in the same pytest session
+corrupts the event-loop-bound httpx state used by later integration tests,
+producing empty-message ``httpcore.ConnectError``s on real Viya calls.
 """
-import pytest
-import os
 import importlib
 import sys
+import pytest
 from unittest.mock import patch
+
+
+def _reload_config():
+    """Reload sas_mcp_server.config in place. Imports first if not yet loaded."""
+    if 'sas_mcp_server.config' in sys.modules:
+        return importlib.reload(sys.modules['sas_mcp_server.config'])
+    import sas_mcp_server.config as cfg
+    return cfg
+
 
 def test_config_loading_with_env_vars(mock_env_vars):
     """Test that configuration values are loaded from environment variables."""
-    # Remove config module from cache if it exists
-    if 'sas_mcp_server.config' in sys.modules:
-        del sys.modules['sas_mcp_server.config']
-    
-    # Import after setting env vars
-    from sas_mcp_server.config import (
-        VIYA_ENDPOINT,
-        CLIENT_ID,
-        HOST_PORT,
-        MCP_SIGNING_KEY,
-        CONTEXT_NAME,
-        AUTHORIZATION_ENDPOINT,
-        TOKEN_ENDPOINT,
-        JWKS_URI
-    )
-    
-    assert VIYA_ENDPOINT == "https://test.viya.com"
-    assert CLIENT_ID == "test-client"
-    assert HOST_PORT == 8134
-    assert MCP_SIGNING_KEY == "test-key"
-    assert CONTEXT_NAME == "Test Context"
-    
-    # Test derived endpoints
-    assert AUTHORIZATION_ENDPOINT == "https://test.viya.com/SASLogon/oauth/authorize"
-    assert TOKEN_ENDPOINT == "https://test.viya.com/SASLogon/oauth/token"
-    assert JWKS_URI == "https://test.viya.com/SASLogon/token_keys"
+    cfg = _reload_config()
+    assert cfg.VIYA_ENDPOINT == "https://test.viya.com"
+    assert cfg.CLIENT_ID == "test-client"
+    assert cfg.HOST_PORT == 8134
+    assert cfg.MCP_SIGNING_KEY == "test-key"
+    assert cfg.CONTEXT_NAME == "Test Context"
+
+    # Derived endpoints
+    assert cfg.AUTHORIZATION_ENDPOINT == "https://test.viya.com/SASLogon/oauth/authorize"
+    assert cfg.TOKEN_ENDPOINT == "https://test.viya.com/SASLogon/oauth/token"
+    assert cfg.JWKS_URI == "https://test.viya.com/SASLogon/token_keys"
+
 
 def test_config_viya_endpoint_trailing_slash(monkeypatch):
     """Test that trailing slashes are removed from VIYA_ENDPOINT."""
-    # Remove config module from cache if it exists
-    if 'sas_mcp_server.config' in sys.modules:
-        del sys.modules['sas_mcp_server.config']
-    
     monkeypatch.setenv("VIYA_ENDPOINT", "https://test.viya.com/")
     monkeypatch.setenv("CLIENT_ID", "test-client")
     monkeypatch.setenv("HOST_PORT", "8134")
     monkeypatch.setenv("MCP_SIGNING_KEY", "test-key")
-    
-    # Import fresh config
-    from sas_mcp_server import config as config_module
-    
-    assert config_module.VIYA_ENDPOINT == "https://test.viya.com"
+    cfg = _reload_config()
+    assert cfg.VIYA_ENDPOINT == "https://test.viya.com"
+
 
 def test_config_missing_viya_endpoint(monkeypatch):
     """Test that missing VIYA_ENDPOINT raises an exception."""
-    # Remove config module from cache if it exists
-    if 'sas_mcp_server.config' in sys.modules:
-        del sys.modules['sas_mcp_server.config']
-    
-    # Also remove dependent modules that might have cached the config
-    for mod in list(sys.modules.keys()):
-        if mod.startswith('sas_mcp_server'):
-            del sys.modules[mod]
-    
-    # Must unset VIYA_ENDPOINT before importing
     monkeypatch.delenv("VIYA_ENDPOINT", raising=False)
     monkeypatch.setenv("CLIENT_ID", "test-client")
-    
-    # Patch load_dotenv in dotenv module BEFORE importing config
+    # Block module-level load_dotenv from reloading VIYA_ENDPOINT from .env.
     with patch('dotenv.load_dotenv'):
         with pytest.raises(Exception, match="VIYA_ENDPOINT is not set"):
-            import sas_mcp_server.config as config_module
+            _reload_config()
+    # Restore a valid module state for subsequent tests in the session, since
+    # the failed reload leaves the module in a partially-initialised state.
+    _reload_config()
+
 
 def test_config_default_values(monkeypatch):
     """Test default values when optional env vars are not set."""
-    # Remove config module from cache if it exists
-    if 'sas_mcp_server.config' in sys.modules:
-        del sys.modules['sas_mcp_server.config']
-    
     monkeypatch.setenv("VIYA_ENDPOINT", "https://test.viya.com")
     monkeypatch.delenv("CLIENT_ID", raising=False)
     monkeypatch.delenv("HOST_PORT", raising=False)
     monkeypatch.delenv("MCP_SIGNING_KEY", raising=False)
     monkeypatch.delenv("COMPUTE_CONTEXT_NAME", raising=False)
-    
-    import sas_mcp_server.config as config_module
-    
-    assert config_module.CLIENT_ID == "sas-mcp"
-    assert config_module.HOST_PORT == 8134
-    assert config_module.MCP_SIGNING_KEY == "default"
-    assert config_module.CONTEXT_NAME == "SAS Job Execution compute context"
+    # Block module-level load_dotenv from repopulating from .env.
+    with patch('dotenv.load_dotenv'):
+        cfg = _reload_config()
+    assert cfg.CLIENT_ID == "sas-mcp"
+    assert cfg.HOST_PORT == 8134
+    assert cfg.MCP_SIGNING_KEY == "default"
+    assert cfg.CONTEXT_NAME == "SAS Job Execution compute context"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,7 +12,12 @@ import time
 import pytest
 from fastmcp import Client
 
-pytestmark = pytest.mark.integration
+# Pin all integration tests to a single session-scoped event loop. The
+# session-scoped fixtures (viya_token, integration_mcp_server) and the
+# in-memory fastmcp transport must share the same loop they were created in;
+# otherwise the second test's tool call fails with ConnectError when it
+# touches httpx state bound to the prior, now-closed loop.
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
 
 _SUFFIX = str(int(time.time()))[-6:]
 
@@ -23,7 +28,11 @@ _SUFFIX = str(int(time.time()))[-6:]
 
 
 async def test_cas_discovery_workflow(integration_mcp_server):
-    """list_cas_servers → list_caslibs → list_castables → table info/columns/data"""
+    """list_cas_servers → list_caslibs → list_castables → table info/columns/data
+
+    Targets a known, loaded sample table — ``HMEQ`` in caslib ``Public`` — so
+    the columns/data assertions don't fall over an unloaded source table.
+    """
     async with Client(integration_mcp_server) as client:
         servers = (await client.call_tool("list_cas_servers", {})).data
         assert isinstance(servers, list)
@@ -31,32 +40,36 @@ async def test_cas_discovery_workflow(integration_mcp_server):
         server_id = servers[0]["name"]
 
         caslibs = (await client.call_tool("list_caslibs", {
-            "server_id": server_id, "limit": 10
+            "server_id": server_id, "limit": 50
         })).data
         assert isinstance(caslibs, list)
-        assert len(caslibs) > 0, "No caslibs found"
+        if not any(c["name"] == "Public" for c in caslibs):
+            pytest.skip("Public caslib not present on this Viya")
 
-        caslib_name = None
-        table_name = None
-        for cl in caslibs:
-            tables = (await client.call_tool("list_castables", {
-                "server_id": server_id,
-                "caslib_name": cl["name"],
-                "limit": 5,
-            })).data
-            if tables:
-                caslib_name = cl["name"]
-                table_name = tables[0]["name"]
-                break
-
-        if not table_name:
-            pytest.skip("No tables found in any caslib")
-
-        info = (await client.call_tool("get_castable_info", {
+        # Also exercise list_castables so the workflow stays end-to-end, but
+        # don't depend on HMEQ appearing in the listing (Public can hold
+        # hundreds of tables and the listing is paginated).
+        tables = (await client.call_tool("list_castables", {
             "server_id": server_id,
-            "caslib_name": caslib_name,
-            "table_name": table_name,
+            "caslib_name": "Public",
+            "limit": 50,
         })).data
+        assert isinstance(tables, list)
+
+        caslib_name = "Public"
+        table_name = "HMEQ"
+        # Fetch HMEQ metadata. Skip if HMEQ isn't loaded on this Viya;
+        # otherwise the test proceeds to the columns/data assertions.
+        try:
+            info = (await client.call_tool("get_castable_info", {
+                "server_id": server_id,
+                "caslib_name": caslib_name,
+                "table_name": table_name,
+            })).data
+        except Exception as e:
+            if "404" in str(e):
+                pytest.skip("HMEQ not loaded in Public caslib on this Viya")
+            raise
         assert isinstance(info, dict)
 
         columns = (await client.call_tool("get_castable_columns", {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,7 +5,7 @@
 Tests for the MCP server and tools.
 """
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 from fastmcp import Context
 from sas_mcp_server.mcp_server import AuthenticationError
 
@@ -19,7 +19,7 @@ async def test_execute_sas_code_success(sample_sas_code, mock_access_token):
     with patch('sas_mcp_server.tools.run_one_snippet') as mock_run:
         mock_run.return_value = ("1", "completed", "Log output", "Listing output")
 
-        token = mock_context.get_state("access_token")
+        token = await mock_context.get_state("access_token")
         output = await mock_run(sample_sas_code, "1", token)
 
         mock_run.assert_called_once_with(sample_sas_code, "1", mock_access_token)
@@ -32,7 +32,7 @@ async def test_execute_sas_code_no_token():
     mock_context = MagicMock(spec=Context)
     mock_context.get_state.return_value = None
 
-    token = mock_context.get_state("access_token")
+    token = await mock_context.get_state("access_token")
     assert token is None
 
 
@@ -45,7 +45,7 @@ async def test_execute_sas_code_propagates_errors(sample_sas_code, mock_access_t
     with patch('sas_mcp_server.tools.run_one_snippet') as mock_run:
         mock_run.side_effect = Exception("API Error")
 
-        token = mock_context.get_state("access_token")
+        token = await mock_context.get_state("access_token")
         with pytest.raises(Exception, match="API Error"):
             await mock_run(sample_sas_code, "1", token)
 
@@ -80,7 +80,7 @@ async def test_execute_sas_code_with_multiline_code(mock_access_token):
     with patch('sas_mcp_server.tools.run_one_snippet') as mock_run:
         mock_run.return_value = ("1", "completed", "PROC MEANS output", "Statistics")
 
-        token = mock_context.get_state("access_token")
+        token = await mock_context.get_state("access_token")
         result = await mock_run(multiline_code, "1", token)
 
         mock_run.assert_called_once()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,7 +5,6 @@
 Tests for prompt template rendering.
 """
 import pytest
-from unittest.mock import MagicMock
 from fastmcp import FastMCP
 from sas_mcp_server.prompts import register_prompts
 
@@ -18,12 +17,17 @@ def prompt_mcp():
     return mcp
 
 
+async def _prompt_fn(mcp, name):
+    prompt = await mcp.get_prompt(name)
+    return prompt.fn
+
+
 # ---------------------------------------------------------------------------
 # Test that all prompts are registered
 # ---------------------------------------------------------------------------
 
 
-def test_all_prompts_registered(prompt_mcp):
+async def test_all_prompts_registered(prompt_mcp):
     """Verify every expected prompt is registered."""
     expected = {
         "debug_sas_log",
@@ -35,7 +39,8 @@ def test_all_prompts_registered(prompt_mcp):
         "sas_macro_builder",
         "generate_report",
     }
-    registered = set(prompt_mcp._prompt_manager._prompts.keys())
+    prompts = await prompt_mcp.list_prompts()
+    registered = {p.name for p in prompts}
     assert expected.issubset(registered), f"Missing prompts: {expected - registered}"
 
 
@@ -44,47 +49,47 @@ def test_all_prompts_registered(prompt_mcp):
 # ---------------------------------------------------------------------------
 
 
-def test_debug_sas_log_basic(prompt_mcp):
+async def test_debug_sas_log_basic(prompt_mcp):
     """Test debug_sas_log renders with required params."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["debug_sas_log"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "debug_sas_log")
     messages = prompt_fn(log_text="ERROR: File not found.")
     assert len(messages) == 1
     assert "ERROR: File not found." in messages[0].content.text
 
 
-def test_debug_sas_log_with_filter(prompt_mcp):
+async def test_debug_sas_log_with_filter(prompt_mcp):
     """Test debug_sas_log renders with severity filter."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["debug_sas_log"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "debug_sas_log")
     messages = prompt_fn(log_text="some log", severity_filter="ERROR")
     assert "ERROR" in messages[0].content.text
 
 
-def test_explore_dataset(prompt_mcp):
+async def test_explore_dataset(prompt_mcp):
     """Test explore_dataset prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["explore_dataset"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "explore_dataset")
     messages = prompt_fn(library="WORK", dataset="CARS")
     assert "WORK.CARS" in messages[0].content.text
     assert "PROC CONTENTS" in messages[0].content.text
 
 
-def test_explore_dataset_with_focus_vars(prompt_mcp):
+async def test_explore_dataset_with_focus_vars(prompt_mcp):
     """Test explore_dataset with focus variables."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["explore_dataset"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "explore_dataset")
     messages = prompt_fn(library="WORK", dataset="CARS", focus_vars="mpg, weight")
     assert "mpg, weight" in messages[0].content.text
 
 
-def test_data_quality_check(prompt_mcp):
+async def test_data_quality_check(prompt_mcp):
     """Test data_quality_check prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["data_quality_check"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "data_quality_check")
     messages = prompt_fn(library="SASHELP", dataset="CLASS")
     assert "SASHELP.CLASS" in messages[0].content.text
     assert "completeness" in messages[0].content.text
 
 
-def test_statistical_analysis(prompt_mcp):
+async def test_statistical_analysis(prompt_mcp):
     """Test statistical_analysis prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["statistical_analysis"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "statistical_analysis")
     messages = prompt_fn(
         analysis_type="linear regression",
         response_variable="price",
@@ -97,31 +102,31 @@ def test_statistical_analysis(prompt_mcp):
     assert "sqft, bedrooms" in content
 
 
-def test_optimize_sas_code(prompt_mcp):
+async def test_optimize_sas_code(prompt_mcp):
     """Test optimize_sas_code prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["optimize_sas_code"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "optimize_sas_code")
     messages = prompt_fn(sas_code="data test; set big; run;")
     assert "data test; set big; run;" in messages[0].content.text
 
 
-def test_explain_sas_code(prompt_mcp):
+async def test_explain_sas_code(prompt_mcp):
     """Test explain_sas_code prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["explain_sas_code"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "explain_sas_code")
     messages = prompt_fn(sas_code="proc sql; quit;", audience_level="beginner")
     assert "beginner" in messages[0].content.text
 
 
-def test_sas_macro_builder(prompt_mcp):
+async def test_sas_macro_builder(prompt_mcp):
     """Test sas_macro_builder prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["sas_macro_builder"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "sas_macro_builder")
     messages = prompt_fn(macro_name="load_data", purpose="Load CSV into CAS")
     assert "%load_data" in messages[0].content.text
     assert "Load CSV into CAS" in messages[0].content.text
 
 
-def test_generate_report(prompt_mcp):
+async def test_generate_report(prompt_mcp):
     """Test generate_report prompt."""
-    prompt_fn = prompt_mcp._prompt_manager._prompts["generate_report"].fn
+    prompt_fn = await _prompt_fn(prompt_mcp, "generate_report")
     messages = prompt_fn(dataset="WORK.SALES", report_type="detailed", output_format="PDF")
     content = messages[0].content.text
     assert "detailed" in content

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -62,6 +74,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -280,15 +313,6 @@ wheels = [
 ]
 
 [[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
-]
-
-[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -342,27 +366,44 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.13.0.2"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
+    { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
     { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/584a152bcd174c99ddf3cfdd7e86ec4a6c696fb190a907c2a2ec9056bda2/fastmcp-2.13.0.2.tar.gz", hash = "sha256:d35386561b6f3cde195ba2b5892dc89b8919a721e6b39b98e7a16f9a7c0b8e8b", size = 7762083, upload-time = "2025-10-28T13:56:21.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/c6/95eacd687cfab64fec13bfb64e6c6e7da13d01ecd4cb7d7e991858a08119/fastmcp-2.13.0.2-py3-none-any.whl", hash = "sha256:eb381eb073a101aabbc0ac44b05e23fef0cd1619344b7703115c825c8755fa1c", size = 367511, upload-time = "2025-10-28T13:56:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -421,6 +462,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -469,6 +522,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -544,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.21.0"
+version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -558,11 +620,13 @@ dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/54/dd2330ef4611c27ae59124820863c34e1d3edb1133c58e6375e2d938c9c5/mcp-1.21.0.tar.gz", hash = "sha256:bab0a38e8f8c48080d787233343f8d301b0e1e95846ae7dead251b2421d99855", size = 452697, upload-time = "2025-11-06T23:19:58.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/47/850b6edc96c03bd44b00de9a0ca3c1cc71e0ba1cd5822955bc9e4eb3fad3/mcp-1.21.0-py3-none-any.whl", hash = "sha256:598619e53eb0b7a6513db38c426b28a4bdf57496fed04332100d2c56acade98b", size = 173672, upload-time = "2025-11-06T23:19:56.508Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -596,6 +660,19 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -611,15 +688,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
-]
-
-[[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
 ]
 
 [[package]]
@@ -642,40 +710,27 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.2.8"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/35/65310a4818acec0f87a46e5565e341c5a96fc062a9a03495ad28828ff4d7/py_key_value_aio-0.2.8.tar.gz", hash = "sha256:c0cfbb0bd4e962a3fa1a9fa6db9ba9df812899bd9312fa6368aaea7b26008b36", size = 32853, upload-time = "2025-10-24T13:31:04.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/5a/e56747d87a97ad2aff0f3700d77f186f0704c90c2da03bfed9e113dae284/py_key_value_aio-0.2.8-py3-none-any.whl", hash = "sha256:561565547ce8162128fd2bd0b9d70ce04a5f4586da8500cce79a54dfac78c46a", size = 69200, upload-time = "2025-10-24T13:31:03.81Z" },
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.2.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/79/05a1f9280cfa0709479319cbfd2b1c5beb23d5034624f548c83fb65b0b61/py_key_value_shared-0.2.8.tar.gz", hash = "sha256:703b4d3c61af124f0d528ba85995c3c8d78f8bd3d2b217377bd3278598070cc1", size = 8216, upload-time = "2025-10-24T13:31:03.601Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/7a/1726ceaa3343874f322dd83c9ec376ad81f533df8422b8b1e1233a59f8ce/py_key_value_shared-0.2.8-py3-none-any.whl", hash = "sha256:aff1bbfd46d065b2d67897d298642e80e5349eae588c6d11b48452b46b8d46ba", size = 14586, upload-time = "2025-10-24T13:31:02.838Z" },
 ]
 
 [[package]]
@@ -1125,7 +1180,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.13.0.2" },
+    { name = "fastmcp", specifier = ">=3.0.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
@@ -1208,6 +1263,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1227,6 +1291,76 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
 ]
 
 [[package]]
@@ -1258,4 +1392,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Summary

- Bumps `fastmcp` from `>=2.13.0.2` to `>=3.0.0,<4.0.0` (currently resolves to 3.2.4).
- Carries the two fixes from #9 — `await` on `Context.set_state`/`get_state` and `valid_scopes=["openid"]` — and adds the remaining edits the codebase + test suite need to run cleanly under v3.
- Under fastmcp 3.2.4: **86 / 87 tests pass, 1 legitimate skip** (no MAS `score` step on the test Viya).

## Why bump rather than revert #9's `await`s?

#9 fixes "OAuth2 inside Podman/Docker" with two `await`s and a broader `valid_scopes`. The `await`s only work when `Context.set_state`/`get_state` are async — which is **only** the case in fastmcp **3.0.0+**. Against the currently pinned `>=2.13.0.2` (resolves to 2.14.3) the methods are synchronous, and the `await`s would raise `TypeError: object NoneType can't be used in 'await' expression` on every authenticated tool call. Options:

- **(a)** Drop the `await`s and merge only the `valid_scopes` change. But then #9's original container OAuth issue may resurface, since #9's reporter was running v3.x.
- **(b)** Bump fastmcp to 3.x (this PR). Keeps both fixes correct, picks up upstream maintenance.

This PR takes path (b). The migration cost is small: one keyword in `config.py`, three import-path renames, one logger import, one idempotency guard. The test churn is larger but is mostly mechanical updates to track v3 API renames.

## Changes

### Production code (5 files)

| File | Change |
|---|---|
| `pyproject.toml` | `fastmcp>=2.13.0.2` → `fastmcp>=3.0.0,<4.0.0` |
| `src/sas_mcp_server/config.py` | `upstream_client_secret=""` → `None` (v3 rejects the empty string); SSL monkey-patch is now idempotent under module reload via a `_sas_mcp_ssl_patched` sentinel |
| `src/sas_mcp_server/viya_utils.py` | `from fastmcp.utilities.logging import get_logger` (v3 dropped the top-level `fastmcp.utilities` re-export) |
| `src/sas_mcp_server/prompts.py` | `from fastmcp.prompts import Message` (module flattened in v3) |
| `src/sas_mcp_server/tools.py` | `from fastmcp.tools import ToolResult` (module flattened in v3) |

The two `await` lines in `src/sas_mcp_server/mcp_server.py` from #9 are kept as-is.

### Tests (5 files)

| File | Change |
|---|---|
| `tests/test_prompts.py` | Use public `mcp.get_prompt()` / `list_prompts()` instead of removed `_prompt_manager._prompts` |
| `tests/test_mcp_server.py` | `await` mocked `Context.get_state` (now async) |
| `tests/test_config.py` | Use `importlib.reload()` instead of `del sys.modules + import`. The old pattern created orphan config modules whose internal httpx state polluted `httpx.AsyncClient.__init__` and broke later integration tests with empty-message `ConnectError`s |
| `tests/conftest.py` | `load_dotenv()` at module top so `SSL_VERIFY` is read before any `sas_mcp_server` import; `viya_token` fixture gets `timeout=60s` |
| `tests/test_integration.py` | Session-scoped asyncio loop pin; `test_cas_discovery_workflow` now targets `Public.HMEQ` directly with a skip-if-not-loaded fallback (the prior `caslibs[0]`/`tables[0]` selection was brittle on Viyas with many tables or unloaded source tables) |

### Lockfile and docs

- `uv.lock` regenerated (`fastmcp` 2.13.0.2 → 3.2.4 plus its transitive updates).
- `CHANGELOG.md` entries added under `[Unreleased]` (Changed / Fixed / Tests).

## Supersedes / credits

- Closes #9. Both behavioral changes from that PR are retained.
- Credit to **@PKoot** for diagnosing the OAuth/container interaction. His two commits (`7709625` + `ce56a85`) sit at the base of this branch unchanged; the v3 migration commit sits on top.

## Test plan

- [x] `uv run python -m pytest --deselect tests/test_integration.py` → 79/79 unit tests pass
- [x] `uv run python -m pytest tests/test_integration.py` against a live Viya → 7 pass, 1 skip
- [x] Full suite `uv run python -m pytest` → 86 pass, 1 skip in ~60s
- [x] Server import smoke test: `python -c "import sas_mcp_server.mcp_server; import sas_mcp_server.stdio_server"` (both load cleanly under v3)
- [ ] *Maintainer:* `uv run app` HTTP mode end-to-end via an MCP client
- [ ] *Maintainer:* `uv run app-stdio` stdio mode end-to-end
- [ ] *Maintainer:* container build & run from `examples/docker` (no container infra locally)

## AI attestation (ContributorAgreement v1.2)

This PR was authored with **Claude Code** as an assistant. I drove the decisions:

- Choosing to accept the v3 bump over reverting #9's `await`s.
- Test strategy (`importlib.reload`, session-scoped loop pin, retarget `cas-discovery` to a known sample).
- Final scope of files included.

Claude produced the code edits, diagnosed the test-isolation root cause in `test_config.py` (orphan module accumulation), and drafted the CHANGELOG entries. I reviewed every diff before applying.

The commit on this PR carries `Assisted-by: Claude Code` per the agreement.
