### PR TITLE
ci: publish container image to GHCR + stdio auth overhaul

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,12 @@ COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
 # Set to false to disable SSL verification (e.g. for self-signed Viya certificates)
 SSL_VERIFY=true
 
+# Set to true to accept raw upstream Viya JWTs in the Authorization header
+# alongside the default OAuth2 PKCE flow. When enabled, a bearer token that
+# fails the MCP JWT swap is validated against Viya's JWKS and used as-is.
+# Useful for automation/CI clients that already hold a Viya access token.
+ALLOW_RAW_BEARER=false
+
 # Stdio mode: authenticates via OAuth 2.0 device-code flow.
 # The server reads the token cached by `sas-viya auth loginCode` from
 # ~/.sas/credentials.json by default. Set SAS_CLI_CONFIG to override the

--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,14 @@ COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
 # Set to false to disable SSL verification (e.g. for self-signed Viya certificates)
 SSL_VERIFY=true
 
-# Required for stdio mode only (on-demand startup from MCP client)
+# Stdio mode: authenticates via OAuth 2.0 device-code flow.
+# The server reads the token cached by `sas-viya auth loginCode` from
+# ~/.sas/credentials.json by default. Set SAS_CLI_CONFIG to override the
+# parent directory (the file resolves to $SAS_CLI_CONFIG/.sas/credentials.json).
+SAS_CLI_CONFIG=
+
+# Only used by the integration test suite (tests/conftest.py) to acquire a
+# Viya token via the legacy sas.cli password grant. Not used by the running
+# MCP server in either HTTP or stdio mode.
 VIYA_USERNAME=
 VIYA_PASSWORD=

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,34 @@
+name: Docker build (PR check)
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'src/**'
+      - '.github/workflows/docker-build.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (linux/amd64, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: sas-mcp-server:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,72 @@
+name: Publish container image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,enable=${{ github.ref == format('refs/heads/{0}', 'main') }},value=edge
+            type=sha,format=short,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.0] - 2026-05-12
 
 ### Added
 - **GitHub Container Registry publishing** — `.github/workflows/publish-ghcr.yml` builds and pushes multi-arch (`linux/amd64`, `linux/arm64`) images to `ghcr.io/sassoftware/sas-mcp-server` on push to `main` (`:edge`, `:sha-<short>`), on `v*` tags (`:latest`, semver tags), and on `workflow_dispatch`. Images carry build provenance and SBOM attestations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- **GitHub Container Registry publishing** — `.github/workflows/publish-ghcr.yml` builds and pushes multi-arch (`linux/amd64`, `linux/arm64`) images to `ghcr.io/sassoftware/sas-mcp-server` on push to `main` (`:edge`, `:sha-<short>`), on `v*` tags (`:latest`, semver tags), and on `workflow_dispatch`. Images carry build provenance and SBOM attestations.
+- **PR-time Dockerfile build check** — `.github/workflows/docker-build.yml` builds the image (no push, single arch) on every PR that touches Dockerfile-relevant paths.
+- **OCI image labels** on the `Dockerfile` runner stage per SAS OSPO publishing guidelines: `maintainer`, `org.opencontainers.image.source`, `org.opencontainers.image.description`, `org.opencontainers.image.licenses`. Closes upstream issue #1.
+- **`sas-mcp-login`** — Built-in OAuth 2.0 Authorization Code + PKCE login helper for stdio mode, exposed as a `uv run sas-mcp-login` console-script. Uses the built-in `vscode` Viya OAuth client (available on Viya 2022.11+) so no admin client registration and no external CLI install are needed; writes a cached access token to `~/.sas-mcp-server/credentials.json`. Supports a two-step `--code <CODE>` variant for non-TTY shells.
+- **`ALLOW_RAW_BEARER`** env var — Additive HTTP auth mode. When `true`, the server accepts raw upstream Viya JWTs in the `Authorization: Bearer` header alongside the default OAuth2 PKCE flow. PKCE clients are unaffected; the new path only fires when the standard MCP JWT swap returns `None`. Useful for automation/CI clients that already hold a Viya token.
+- **`SAS_CLI_CONFIG`** env var — Override the parent directory for the `sas-viya` CLI credential cache used by stdio mode (default: `$HOME`).
+- Native OAuth 2.0 Device Authorization Grant (RFC 8628) as the last-resort fallback in stdio mode for Viyas whose admin has not enabled CSRF protection on `/SASLogon/oauth/device_authorization`.
 - **26 new MCP tools** across five tiers:
   - **Tier 1 — Data Discovery**: `list_cas_servers`, `list_caslibs`, `list_castables`, `get_castable_info`, `get_castable_columns`, `get_castable_data`
   - **Tier 2 — Data Operations & Files**: `upload_data`, `promote_table_to_memory`, `list_files`, `upload_file`, `download_file`
@@ -27,6 +34,12 @@
 - **Gemini CLI configuration** — `examples/gemini-settings.json` with recommended `timeout` setting, Gemini CLI section in `examples/configuration.md`, and Gemini CLI snippets in README
 
 ### Changed
+- **Stdio auth model overhauled.** Replaced password-grant authentication with a chain of OAuth 2.0 paths, tried in order: (1) token cached by `sas-viya auth loginCode` at `~/.sas/credentials.json` (or `$SAS_CLI_CONFIG/.sas/credentials.json`); (2) token cached by `sas-mcp-login` at `~/.sas-mcp-server/credentials.json`; (3) native device-code flow. The first hit wins. Password grant was deprecated by OAuth 2.1 and failed with `invalid_client` for OAuth clients registered as confidential.
+- `src/sas_mcp_server/config.py` — `viya_auth` is now a `PermissiveOAuthProxy` (subclass of `fastmcp.server.auth.OAuthProxy`) so that, when `ALLOW_RAW_BEARER=true`, raw upstream JWTs fall through to the configured `token_verifier` after the standard MCP JWT swap fails. Behaviour is unchanged when the flag is `false`.
+- `src/sas_mcp_server/stdio_server.py` — Rewritten around the new auth chain; removed `VIYA_USERNAME`/`VIYA_PASSWORD` reads.
+- `examples/configuration.md` — New "Authentication modes — at a glance" overview comparing all five paths; reworked "Authenticating for stdio mode" to cover both `sas-viya` CLI and `sas-mcp-login` paths; updated Gemini CLI section to drop password-grant references; added `ALLOW_RAW_BEARER` and `SAS_CLI_CONFIG` to the environment variables table.
+- `README.md` — Added a "Pull pre-built image" snippet with the published tag table; updated the deployment-mode comparison and "Option B: Stdio mode" instructions; new "Programmatic clients with a pre-existing Viya token" section documenting `ALLOW_RAW_BEARER`.
+- `examples/docker/setup.md` — Added a "Pulling the pre-built image" section with the tag-to-image-version mapping and a note about signed build provenance.
 - `src/sas_mcp_server/config.py` — Added SSL verification bypass via httpx monkey-patch when `SSL_VERIFY=false`
 - `src/sas_mcp_server/viya_utils.py` — Respects `SSL_VERIFY` setting for Viya API calls
 - `examples/configuration.md` — Added Python registration script instructions and `SSL_VERIFY` to environment variables table
@@ -38,6 +51,9 @@
   - `from fastmcp.tools import ToolResult` — module path flattened.
 - **`OAuthProxy(valid_scopes=["openid"])`** — required so containerized deployments accept tokens issued only with `openid` (carried from PR #9; fixes OAuth2 under Podman/Docker).
 - **SSL monkey-patch in `config.py` is now idempotent** — guarded by `_sas_mcp_ssl_patched` so reloading the module doesn't stack wrappers around `httpx.AsyncClient.__init__`.
+
+### Removed
+- **Password-grant stdio authentication.** `VIYA_USERNAME`/`VIYA_PASSWORD` are no longer read by the stdio server. They remain in `.env.sample` (with clearer wording) only because the integration test suite uses the legacy `sas.cli` password grant to acquire test tokens.
 
 ### Fixed
 - `upload_data` — Rewrote to use the CAS Management REST API (`POST /casManagement/servers/{server}/caslibs/{caslib}/tables` with `multipart/form-data`) instead of a SAS DATA step workaround; handles 409 (table already exists) gracefully

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN uv build
 FROM python:3.12-slim-bookworm AS runner
 ARG HOST_PORT=8134
 
+LABEL maintainer="david.weik@sas.com"
+LABEL org.opencontainers.image.source=https://github.com/sassoftware/sas-mcp-server
+LABEL org.opencontainers.image.description="SAS MCP Server — Model Context Protocol server for SAS Viya"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 RUN addgroup --system sas && adduser --system --ingroup sas --home /app sas
 
 COPY --from=base-builder /app/dist/ /install

--- a/README.md
+++ b/README.md
@@ -59,12 +59,19 @@ The server will be available at `http://localhost:8134/mcp` by default. Authenti
 
 **Option B: Stdio mode** (MCP client starts the server on demand)
 
-Authenticate once with the [SAS Viya CLI](https://documentation.sas.com/?cdcId=sasadmincdc&docsetId=calcli&docsetTarget=titlepage.htm):
+Authenticate once. Two equivalent options:
+
 ```sh
+# Option B1 — if you have the SAS Viya CLI installed:
 sas-viya auth loginCode
+
+# Option B2 — built-in helper, no external CLI needed (Viya 2022.11+):
+uv run sas-mcp-login
 ```
 
-Then configure your MCP client to launch the server directly (see below). The MCP server reads the cached token from `~/.sas/credentials.json`. When the token expires, re-run `sas-viya auth loginCode`.
+Both flows write an access token to a local cache (`~/.sas/credentials.json` and `~/.sas-mcp-server/credentials.json` respectively); the stdio server reads whichever it finds. When the token expires, re-run the same command.
+
+Then configure your MCP client to launch the server directly (see below).
 
 **Option C: Docker / Podman** (containerized deployment)
 
@@ -92,14 +99,14 @@ Available image tags:
 | | **HTTP** | **Stdio** | **Docker** |
 |---|---|---|---|
 | **How it runs** | Long-running server you start separately | MCP client spawns it on demand | Containerized HTTP server |
-| **Authentication** | OAuth2 PKCE flow (browser popup) | Device-code flow via `sas-viya` CLI | OAuth2 PKCE flow (browser popup) |
+| **Authentication** | OAuth2 PKCE flow (browser popup) | Cached token via `sas-viya` CLI or `sas-mcp-login` | OAuth2 PKCE flow (browser popup) |
 | **Best for** | Multi-user or shared setups; production-like environments | Single-user local development; quick experimentation | Team deployments; CI/CD; environments without Python installed |
-| **Requires** | Python + uv | Python + uv + `sas-viya` CLI | Docker or Podman only |
-| **Credentials stored?** | No — user authenticates interactively | No — `sas-viya` CLI caches an access token | No — user authenticates interactively |
+| **Requires** | Python + uv | Python + uv (+ optional `sas-viya` CLI) | Docker or Podman only |
+| **Credentials stored?** | No — user authenticates interactively | No — only an access token (not a password) is cached | No — user authenticates interactively |
 | **MCP client config** | Point client to `http://localhost:8134/mcp` | Client runs `uv run app-stdio` | Point client to `http://host:8134/mcp` |
 
 **Quick guidance:**
-- **Starting out or exploring?** Use **stdio** — one `sas-viya auth loginCode` and your MCP client manages the server lifecycle.
+- **Starting out or exploring?** Use **stdio** — one `sas-viya auth loginCode` or `uv run sas-mcp-login`, then your MCP client manages the server lifecycle.
 - **Need secure, interactive auth?** Use **HTTP** — no stored passwords, each user authenticates via browser.
 - **Deploying for a team or on a server?** Use **Docker** — portable, no Python dependency on the host, easy to integrate with orchestrators.
 - **Using Gemini CLI?** Use **stdio** — Gemini CLI does not support HTTP mode or browser-based OAuth. See [Gemini CLI configuration](examples/configuration.md#gemini-cli).

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ docker run -e VIYA_ENDPOINT=https://your-viya-server.com -p 8134:8134 sas-mcp-se
 
 Available image tags:
 - `latest` — most recent tagged release
-- `<major>.<minor>.<patch>` (e.g. `0.1.0`) — specific release
-- `<major>.<minor>` (e.g. `0.1`) — latest patch of a minor release
+- `<major>.<minor>.<patch>` (e.g. `1.0.0`) — specific release
+- `<major>.<minor>` (e.g. `1.0`) — latest patch of a minor release
 - `edge` — tip of `main` (unreleased, for testing)
 - `sha-<short>` — pinned to a specific commit
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Available image tags:
 - `edge` — tip of `main` (unreleased, for testing)
 - `sha-<short>` — pinned to a specific commit
 
+**Programmatic clients with a pre-existing Viya token**
+
+If your caller already holds a Viya access token (e.g. an automation script that obtained one via the SAS Viya CLI), start the HTTP-mode server with `ALLOW_RAW_BEARER=true` and pass the token directly:
+
+```sh
+curl -H "Authorization: Bearer $VIYA_TOKEN" http://localhost:8134/mcp ...
+```
+
+The server validates the token against Viya's JWKS and uses it upstream as-is, bypassing the MCP JWT swap. The default OAuth2 PKCE flow keeps working alongside — both client types share the same `/mcp` endpoint.
+
 ### Choosing a deployment mode
 
 | | **HTTP** | **Stdio** | **Docker** |

--- a/README.md
+++ b/README.md
@@ -298,16 +298,25 @@ Maintainers are accepting patches and contributions to this project. Please read
 
 ## License & Attribution
 
-Except for the the contents of the /static folder, this project is licensed under the [Apache 2.0 License](LICENSE). Elements in the /static folder are owned by SAS and are not released under an open source license. SAS and all other SAS Institute Inc. product or service names are registered trademarks or trademarks of SAS Institute Inc. in the USA and other countries. ® indicates USA registration.
+Except for the the contents of the `/static` folder, this project is licensed under the [Apache 2.0 License](LICENSE). 
+Elements in the `/static` folder are owned by SAS and are not released under an open source license. 
+SAS and all other SAS Institute Inc. product or service names are registered trademarks or trademarks of SAS Institute Inc. in the USA and other countries. ® indicates USA registration.
 
 Separate commercial licenses for SAS software (e.g., SAS Viya) are not included and are required to use these capabilities with SAS software.
 
+As with any container image, direct and indirect dependencies are governed by their own licenses.
+Users of the published container image are responsible for ensuring that their use complies with all applicable licenses.
+
 All third-party trademarks referenced belong to their respective owners and are only used here for identification and reference purposes, and not to imply any affiliation or endorsement by the trademark owners.
 
-This project requires the usage of the following:
+## Third-Party Dependencies
 
-- Python, see the Python license [here](https://docs.python.org/3/license.html)
-- FastMCP, under the Apache 2.0 License
-- uvicorn, under the BSD 3-Clause
-- starlette, under the BSD 3-Clause
-- httpx, under the MIT license
+This project requires the following dependencies.
+
+| Dependency | License |
+| ---------- | ------- |
+| Python | [Python Software License](https://docs.python.org/3/license.html) |
+| FastMCP | [Apache License 2.0](https://github.com/PrefectHQ/fastmcp/blob/main/LICENSE) |
+| uvicorn | [BSD 3-Clause License](https://github.com/Kludex/uvicorn/blob/main/LICENSE.md) |
+| starlette | [BSD 3-Clause License](https://github.com/Kludex/starlette/blob/main/LICENSE.md)
+| httpx | [MIT License](https://github.com/projectdiscovery/httpx/blob/dev/LICENSE.md) | 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ The server will be available at `http://localhost:8134/mcp` by default. Authenti
 
 **Option B: Stdio mode** (MCP client starts the server on demand)
 
-Set `VIYA_USERNAME` and `VIYA_PASSWORD` in your `.env` file, then configure your MCP client to launch the server directly (see below).
+Authenticate once with the [SAS Viya CLI](https://documentation.sas.com/?cdcId=sasadmincdc&docsetId=calcli&docsetTarget=titlepage.htm):
+```sh
+sas-viya auth loginCode
+```
+
+Then configure your MCP client to launch the server directly (see below). The MCP server reads the cached token from `~/.sas/credentials.json`. When the token expires, re-run `sas-viya auth loginCode`.
 
 **Option C: Docker / Podman** (containerized deployment)
 
@@ -87,14 +92,14 @@ Available image tags:
 | | **HTTP** | **Stdio** | **Docker** |
 |---|---|---|---|
 | **How it runs** | Long-running server you start separately | MCP client spawns it on demand | Containerized HTTP server |
-| **Authentication** | OAuth2 PKCE flow (browser popup) | Password grant (credentials in `.env`) | OAuth2 PKCE flow (browser popup) |
+| **Authentication** | OAuth2 PKCE flow (browser popup) | Device-code flow via `sas-viya` CLI | OAuth2 PKCE flow (browser popup) |
 | **Best for** | Multi-user or shared setups; production-like environments | Single-user local development; quick experimentation | Team deployments; CI/CD; environments without Python installed |
-| **Requires** | Python + uv | Python + uv | Docker or Podman only |
-| **Credentials stored?** | No — user authenticates interactively | Yes — username/password in `.env` | No — user authenticates interactively |
+| **Requires** | Python + uv | Python + uv + `sas-viya` CLI | Docker or Podman only |
+| **Credentials stored?** | No — user authenticates interactively | No — `sas-viya` CLI caches an access token | No — user authenticates interactively |
 | **MCP client config** | Point client to `http://localhost:8134/mcp` | Client runs `uv run app-stdio` | Point client to `http://host:8134/mcp` |
 
 **Quick guidance:**
-- **Starting out or exploring?** Use **stdio** — zero setup beyond `.env`, and your MCP client manages the server lifecycle.
+- **Starting out or exploring?** Use **stdio** — one `sas-viya auth loginCode` and your MCP client manages the server lifecycle.
 - **Need secure, interactive auth?** Use **HTTP** — no stored passwords, each user authenticates via browser.
 - **Deploying for a team or on a server?** Use **Docker** — portable, no Python dependency on the host, easy to integrate with orchestrators.
 - **Using Gemini CLI?** Use **stdio** — Gemini CLI does not support HTTP mode or browser-based OAuth. See [Gemini CLI configuration](examples/configuration.md#gemini-cli).

--- a/README.md
+++ b/README.md
@@ -62,10 +62,25 @@ The server will be available at `http://localhost:8134/mcp` by default. Authenti
 Set `VIYA_USERNAME` and `VIYA_PASSWORD` in your `.env` file, then configure your MCP client to launch the server directly (see below).
 
 **Option C: Docker / Podman** (containerized deployment)
+
+Pull the pre-built image from GitHub Container Registry:
+```sh
+docker pull ghcr.io/sassoftware/sas-mcp-server:latest
+docker run -e VIYA_ENDPOINT=https://your-viya-server.com -p 8134:8134 ghcr.io/sassoftware/sas-mcp-server:latest
+```
+
+Or build locally from source:
 ```sh
 docker build -t sas-mcp-server .
 docker run -e VIYA_ENDPOINT=https://your-viya-server.com -p 8134:8134 sas-mcp-server
 ```
+
+Available image tags:
+- `latest` — most recent tagged release
+- `<major>.<minor>.<patch>` (e.g. `0.1.0`) — specific release
+- `<major>.<minor>` (e.g. `0.1`) — latest patch of a minor release
+- `edge` — tip of `main` (unreleased, for testing)
+- `sha-<short>` — pinned to a specific commit
 
 ### Choosing a deployment mode
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,237 @@
+# Troubleshooting
+
+## OAuth: `client_id ... was not found in the server's client registry`
+
+You restart the server (or wipe its cache) and the next time you connect from your MCP client (VS Code, MCP Inspector, Claude Desktop, …) the browser shows:
+
+> OAuth 2.0 requires clients to register before authorization. This server returned a 400 error because the provided client ID was not found.
+
+…and the server log shows:
+
+```
+INFO  Unregistered client_id=<some-uuid>, returned HTML error response
+INFO  "GET /authorize?client_id=<some-uuid>..." 400 Bad Request
+```
+
+Notice that there's **no `POST /register` immediately before** that `/authorize` line — that is the diagnostic.
+
+### Why this happens
+
+Two independent caches need to agree on the client ID, and they can drift out of sync.
+
+There are also two different "client IDs" involved — they are not the same thing:
+
+| Identity | Where it's defined | What uses it |
+|---|---|---|
+| **Upstream client** (e.g. `sas-mcp`) | Registered in Viya via `register_mcp_client.py`. Set as `CLIENT_ID` in your `.env`. | Used by *this server* when it redirects to `https://<viya>/SASLogon/oauth/authorize`. Never visible to the MCP client. |
+| **Downstream DCR client** (a UUID) | Generated fresh per MCP-client by FastMCP's OAuthProxy, on `POST /register`. Stored encrypted in `cache.db`. | Used by the MCP client (VS Code, etc.) when it talks to *this server*'s `/authorize` and `/token`. |
+
+The MCP spec requires Dynamic Client Registration. Viya doesn't support DCR, so FastMCP's `OAuthProxy` provides DCR locally and translates downstream UUIDs to the single upstream `sas-mcp` credential when calling Viya.
+
+The MCP client caches its UUID after the first `POST /register`. The server caches the same UUID (encrypted) in `cache.db`. As long as both caches stay aligned, everything works.
+
+They go out of sync when **the server's cache is rebuilt** (deleted, or written under a different `MCP_SIGNING_KEY` so its Fernet entries become undecryptable). The MCP client still has the old UUID, sends it to `/authorize`, and the server has no record of it.
+
+The MCP client *should* fall back to a fresh `POST /register` when it sees a 400 — but most clients (VS Code included today) don't auto-recover. They keep sending the cached UUID until you manually clear it.
+
+### How to fix it
+
+**Step 1 — Stop the server.** Don't try to fix this with the server still running; the reloader will rewrite `cache.db` mid-edit.
+
+**Step 2 — Wipe the server-side cache** at:
+
+| OS | Path |
+|---|---|
+| Windows | `%LOCALAPPDATA%\fastmcp\oauth-proxy\cache.db` (and `cache.db-shm`, `cache.db-wal` if present) |
+| macOS | `~/Library/Application Support/fastmcp/oauth-proxy/cache.db` |
+| Linux | `~/.local/share/fastmcp/oauth-proxy/cache.db` |
+
+**Step 3 — Pin a stable `MCP_SIGNING_KEY`** in `.env`, so future restarts produce the same Fernet key and `cache.db` stays decryptable across runs:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Paste the output as `MCP_SIGNING_KEY=...`. An empty value (`MCP_SIGNING_KEY=`) is *not* the same as unset — it overrides the in-code default. Either set a real value or remove the line entirely.
+
+**Step 4 — Wipe the MCP client's cached UUID.** This is the step most people miss. Below are the locations for VS Code; other clients (Claude Desktop, MCP Inspector) have analogous stores.
+
+#### VS Code (Windows)
+
+VS Code's MCP DCR registrations live in `state.vscdb`:
+
+```
+%APPDATA%\Code\User\globalStorage\state.vscdb
+```
+
+**Close VS Code completely first** (the DB is locked while it runs). On Windows, `Get-Process Code | Stop-Process` is a hammer that works.
+
+Then run this Python snippet (adjust path for macOS/Linux — see below):
+
+```python
+import sqlite3
+db = r"C:\Users\<you>\AppData\Roaming\Code\User\globalStorage\state.vscdb"
+con = sqlite3.connect(db)
+cur = con.cursor()
+patterns = [
+    "secret://dynamicAuthProvider:clientRegistration:%localhost:8134%",
+    "secret://dynamicAuthProvider:clientRegistration:%127.0.0.1:8134%",
+    'secret://%isDynamicAuthProvider%localhost:8134%',
+    'secret://%isDynamicAuthProvider%127.0.0.1:8134%',
+    'mcpserver-http://localhost:8134%',
+    'mcpserver-http://127.0.0.1:8134%',
+    'http://localhost:8134%-mcpserver-usages',
+    'http://127.0.0.1:8134%-mcpserver-usages',
+    'dynamicAuthProviders',
+]
+for pat in patterns:
+    cur.execute("DELETE FROM ItemTable WHERE key LIKE ?", (pat,))
+con.commit()
+con.close()
+```
+
+(Replace `8134` with whatever `HOST_PORT` you use.) This removes the cached UUID + token entries but leaves your `mcp.config.ws0.*` workspace config alone, so VS Code still knows about the server.
+
+VS Code paths on the other OSes:
+- macOS: `~/Library/Application Support/Code/User/globalStorage/state.vscdb`
+- Linux: `~/.config/Code/User/globalStorage/state.vscdb`
+
+#### Quick alternative for VS Code: rename the server in `mcp.json`
+
+VS Code keys cached client IDs by server *name*. If you change the key in `mcp.json` (e.g. `sas-mcp` → `sas-mcp-fresh`) and reload the window, VS Code treats it as a brand-new server and DCR-registers from scratch. Useful for quick recovery; less useful if you accumulate stale entries over time.
+
+**Step 5 — Restart everything.**
+
+```sh
+uv run app          # restart server
+# then in VS Code: reload window, click start in mcp.json
+```
+
+You should now see this in the server log:
+
+```
+POST /register HTTP/1.1 200 OK
+GET /.well-known/oauth-protected-resource/mcp HTTP/1.1 200 OK
+GET /.well-known/oauth-authorization-server HTTP/1.1 200 OK
+GET /authorize?client_id=<new-uuid>... HTTP/1.1 302 Found
+```
+
+The `POST /register` line is the proof that the MCP client re-registered cleanly.
+
+### Avoiding it next time
+
+- **Pin `MCP_SIGNING_KEY`** to a real value in `.env` and don't change it. This alone prevents the most common cause (silent Fernet key change between runs), so deleting `cache.db` becomes a rare manual operation rather than a side effect of restarts.
+- **If you wipe `cache.db`, also wipe the MCP client's cached UUID in the same step.** They are paired; clearing only one creates the mismatch this doc exists to fix.
+
+---
+
+## Stdio: `Could not read sas-viya credentials at ...`
+
+The stdio server logs the warning when the cache files at `~/.sas/credentials.json` and `~/.sas-mcp-server/credentials.json` are both missing or malformed. The server then falls through to the native device-code flow, which either prints a SAS Logon URL on stderr or fails with the CSRF error documented below.
+
+### Fix
+
+Run one of the bootstrap commands:
+
+```sh
+sas-viya auth loginCode      # if you have the SAS Viya CLI
+uv run sas-mcp-login          # zero-prereq helper using the built-in vscode client
+```
+
+If your `sas-viya` profile lives outside `$HOME`, set `SAS_CLI_CONFIG` to its parent directory in `.env`. See [`examples/configuration.md`](examples/configuration.md#authentication-modes--at-a-glance) for the full auth chain.
+
+---
+
+## Stdio: device-code fallback fails with `403 ... CSRF token`
+
+The server log shows:
+
+```
+Viya rejected the device-authorization request (CSRF protection on /SASLogon/oauth/device_authorization).
+```
+
+SAS Logon Manager protects the device endpoint with CSRF on most deployments, so a pure RFC 8628 call from outside a browser session can't succeed. This isn't a bug — it's a deliberate Viya admin setting.
+
+### Fix
+
+Use one of the two cache-based paths instead (`sas-viya auth loginCode` or `uv run sas-mcp-login`). The device-code path is meant as a last-resort fallback for Viyas without CSRF protection on that endpoint; if yours protects it, ignore the path.
+
+---
+
+## sas-mcp-login: command exits immediately with `Aborted.` in non-TTY shells
+
+You run `uv run sas-mcp-login` inside a wrapper that does not provide an interactive stdin (CI runners, the Claude Code `!` prefix, `nohup ... &`, etc.) and the helper prints the URL then aborts at the `Authorization code:` prompt.
+
+### Fix
+
+Use the two-step variant. The first invocation persists PKCE state to `~/.sas-mcp-server/login-state.json` and exits cleanly; the second exchanges the code:
+
+```sh
+uv run sas-mcp-login                            # opens browser, prints URL, exits
+# sign in, copy the code from the SAS Logon results page
+uv run sas-mcp-login --code <PASTE-CODE-HERE>   # completes the exchange
+```
+
+---
+
+## sas-mcp-login: `Invalid redirect <uri> did not match one of the registered values`
+
+SAS Logon rejects the authorization request *after* you sign in because the `redirect_uri` you supplied isn't on the allow-list registered for your OAuth client. The built-in `vscode` client on many Viya deployments has no registered redirect URI at all.
+
+### Fix
+
+Re-run without `--redirect-uri` (this is the default). When `redirect_uri` is omitted, SAS Logon displays the authorization code on a results page for you to copy.
+
+```sh
+uv run sas-mcp-login            # no --redirect-uri
+```
+
+If your Viya admin has registered a specific redirect URI for the client you want to use, pass it explicitly with `--redirect-uri vscode://your-extension/sso` (or whatever they registered).
+
+---
+
+## HTTP: `ALLOW_RAW_BEARER=true` but raw tokens still return `401 Unauthorized`
+
+The server is configured to accept raw upstream JWTs, but your `Authorization: Bearer <token>` call is still rejected.
+
+### Likely causes
+
+1. **Token expired.** Decode the JWT at [jwt.io](https://jwt.io) and check the `exp` claim. SAS Viya access tokens typically last under an hour.
+2. **Token isn't a valid Viya JWT.** The server validates against the JWKS at `${VIYA_ENDPOINT}/SASLogon/token_keys`; tokens from a different issuer will fail.
+3. **`VIYA_ENDPOINT` in the server's env points at a different Viya** than the one that minted the token. The JWKS won't have a matching signing key.
+4. **`ALLOW_RAW_BEARER` is not actually set on the server.** Check `podman inspect <container> --format '{{.Config.Env}}'` (or the equivalent for your runtime). The env var must be read by the *running* server process, not just present in your `.env` file on the host.
+
+### Fix
+
+Verify each step. To rule out an expired token, mint a fresh one and retry. To rule out a JWKS mismatch, check that `iss` in the token matches `${VIYA_ENDPOINT}/SASLogon/oauth/token`.
+
+---
+
+## Stdio in container: token cache file isn't found
+
+You run the stdio server in a container and see `Loaded access token from ...` is *not* logged before tool calls fail.
+
+### Why
+
+`stdio_server.py` looks under the *container's* `$HOME` (typically `/app` for the `sas` user), not the host's. Without an explicit volume mount, the container has no access to the cache files on your host.
+
+### Fix
+
+Mount the cache directory and (for the `sas-viya` CLI path) set `SAS_CLI_CONFIG` to the mount point's parent:
+
+```sh
+# sas-viya CLI cache
+podman run --rm -i \
+  --env-file .env \
+  -v "$HOME/.sas:/app/.sas:ro" \
+  -e SAS_CLI_CONFIG=/app \
+  ghcr.io/sassoftware/sas-mcp-server:latest app-stdio
+
+# sas-mcp-login cache (default location inside container)
+podman run --rm -i \
+  --env-file .env \
+  -v "$HOME/.sas-mcp-server:/app/.sas-mcp-server:ro" \
+  ghcr.io/sassoftware/sas-mcp-server:latest app-stdio
+```
+
+The container reads the file on every tool call, so refreshing the host-side cache (`sas-viya auth loginCode` again, or re-running `sas-mcp-login`) is picked up without restarting the container.

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -80,6 +80,7 @@ The .env file used by the MCP Server allows for customizable options that the us
 | `MCP_BASE_URL`         | No   | `http://localhost:{HOST_PORT}`             | External URL of the MCP server (set for k8s/reverse proxy deployments) |
 | `COMPUTE_CONTEXT_NAME` | No   | `SAS Job Execution compute context`       | Viya compute context to use for code execution                |
 | `SSL_VERIFY`        | No      | `true`       | Set to `false` to disable SSL certificate verification (e.g. for self-signed Viya certificates)  |
+| `ALLOW_RAW_BEARER`  | No      | `false`      | When `true`, the HTTP-mode server also accepts a raw Viya access token in the `Authorization` header alongside the default OAuth2 PKCE flow. Useful for automation that already holds a Viya token. |
 | `SAS_CLI_CONFIG`    | Stdio (optional) | `$HOME` | Parent directory for the SAS Viya CLI credential cache. The token is read from `$SAS_CLI_CONFIG/.sas/credentials.json`. |
 | `VIYA_USERNAME`     | Tests only | —         | Used by the integration test suite to acquire a token via the legacy `sas.cli` password grant. Not used by the MCP server itself. |
 | `VIYA_PASSWORD`     | Tests only | —         | See `VIYA_USERNAME`.                                          |

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -229,25 +229,37 @@ The `timeout` field (in milliseconds) controls how long Gemini CLI waits for a t
 
 Without this setting, tool calls will appear to fail with a timeout error even though the server and authentication are working correctly.
 
-#### Authenticating with the SAS Viya CLI
+#### Authenticating for stdio mode
 
-Stdio mode uses the OAuth 2.0 device-code flow via the SAS Viya CLI. Before the first MCP tool call:
+Stdio mode reads a cached OAuth access token. Two equivalent ways to obtain one — pick whichever fits your environment.
+
+**Option 1 — SAS Viya CLI** (preferred if it's already installed):
 
 ```sh
-# One-time per Viya host
 sas-viya --profile Default profile init --sas-endpoint https://your-viya-server.com
 sas-viya auth loginCode
 ```
 
-Follow the URL the CLI prints, sign in, and approve the code. The CLI writes an access token to `~/.sas/credentials.json`, which the MCP server reads on each tool call. When the token expires, re-run `sas-viya auth loginCode`.
-
-If you keep the SAS profile somewhere other than `$HOME`, set `SAS_CLI_CONFIG` to its parent directory in your `.env`:
+This writes `~/.sas/credentials.json`. If you keep the SAS profile somewhere other than `$HOME`, set `SAS_CLI_CONFIG` to its parent directory in your `.env`:
 
 ```
-VIYA_ENDPOINT=https://your-viya-server.com
 SAS_CLI_CONFIG=/path/whose/.sas/credentials.json/lives/here
-SSL_VERIFY=false  # if using self-signed certificates
 ```
+
+**Option 2 — built-in `sas-mcp-login` helper** (no external CLI, no admin client registration; requires Viya 2022.11+):
+
+```sh
+uv run sas-mcp-login
+```
+
+The helper runs OAuth 2.0 Authorization Code + PKCE against the built-in `vscode` Viya OAuth client, opens your browser, and writes the token to `~/.sas-mcp-server/credentials.json`. After signing in, SAS Logon displays the authorization code on a results page; copy it and paste it back into the terminal.
+
+The stdio server reads whichever cache file exists, in this order:
+
+1. `~/.sas/credentials.json` (or `$SAS_CLI_CONFIG/.sas/credentials.json`)
+2. `~/.sas-mcp-server/credentials.json`
+
+When the token expires, re-run the same command you used originally.
 
 ---
 

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -80,8 +80,9 @@ The .env file used by the MCP Server allows for customizable options that the us
 | `MCP_BASE_URL`         | No   | `http://localhost:{HOST_PORT}`             | External URL of the MCP server (set for k8s/reverse proxy deployments) |
 | `COMPUTE_CONTEXT_NAME` | No   | `SAS Job Execution compute context`       | Viya compute context to use for code execution                |
 | `SSL_VERIFY`        | No      | `true`       | Set to `false` to disable SSL certificate verification (e.g. for self-signed Viya certificates)  |
-| `VIYA_USERNAME`     | Stdio only | —         | Viya username for stdio mode (password grant authentication)  |
-| `VIYA_PASSWORD`     | Stdio only | —         | Viya password for stdio mode (password grant authentication)  |
+| `SAS_CLI_CONFIG`    | Stdio (optional) | `$HOME` | Parent directory for the SAS Viya CLI credential cache. The token is read from `$SAS_CLI_CONFIG/.sas/credentials.json`. |
+| `VIYA_USERNAME`     | Tests only | —         | Used by the integration test suite to acquire a token via the legacy `sas.cli` password grant. Not used by the MCP server itself. |
+| `VIYA_PASSWORD`     | Tests only | —         | See `VIYA_USERNAME`.                                          |
 
 The defaults listed here are the variable values used in the Viya setup step. If your SAS Administrator has used a different `CLIENT_ID`, `HOST_PORT` during the OAuth Client registration. Please use those values instead.
 
@@ -200,7 +201,7 @@ When a user first invokes a tool, their browser opens for Viya login. After auth
 
 ### Gemini CLI
 
-Gemini CLI connects to MCP servers via stdio only — it does not support HTTP mode. Because it cannot participate in browser-based OAuth redirects, stdio mode with password grant credentials is required.
+Gemini CLI connects to MCP servers via stdio only — it does not support HTTP mode. Stdio mode reads an access token cached by the SAS Viya CLI's device-code flow, so no MCP-client browser redirect is involved.
 
 #### Configuration
 
@@ -228,17 +229,25 @@ The `timeout` field (in milliseconds) controls how long Gemini CLI waits for a t
 
 Without this setting, tool calls will appear to fail with a timeout error even though the server and authentication are working correctly.
 
-#### Required `.env` variables
+#### Authenticating with the SAS Viya CLI
 
-Stdio mode authenticates via password grant, so you must set these in your `.env` file:
+Stdio mode uses the OAuth 2.0 device-code flow via the SAS Viya CLI. Before the first MCP tool call:
+
+```sh
+# One-time per Viya host
+sas-viya --profile Default profile init --sas-endpoint https://your-viya-server.com
+sas-viya auth loginCode
+```
+
+Follow the URL the CLI prints, sign in, and approve the code. The CLI writes an access token to `~/.sas/credentials.json`, which the MCP server reads on each tool call. When the token expires, re-run `sas-viya auth loginCode`.
+
+If you keep the SAS profile somewhere other than `$HOME`, set `SAS_CLI_CONFIG` to its parent directory in your `.env`:
+
 ```
 VIYA_ENDPOINT=https://your-viya-server.com
-VIYA_USERNAME=your-username
-VIYA_PASSWORD=your-password
+SAS_CLI_CONFIG=/path/whose/.sas/credentials.json/lives/here
 SSL_VERIFY=false  # if using self-signed certificates
 ```
-
-The `CLIENT_ID` can remain at the default (`sas-mcp`) or be changed to match an existing OAuth client registered on your Viya instance (e.g., `sas.cli`).
 
 ---
 

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -1,5 +1,28 @@
 ## Configuration details for the SAS MCP Server
 
+### Authentication modes — at a glance
+
+The server supports five authentication paths across HTTP and stdio modes. Pick one per deployment; HTTP mode lets PKCE and raw-bearer clients share the same endpoint.
+
+| Mode | Transport | What the client does | What the server does | Admin client registration? | External CLI? | Best for |
+|---|---|---|---|---|---|---|
+| **OAuth2 PKCE** | HTTP | Browser-driven login on first tool call | Issues an MCP-signed JWT after the upstream PKCE flow; swaps it for the upstream Viya token on each request | ✅ Required (`sas-mcp` client, see [Step 2](#step-2-register-an-oauth-client-for-the-mcp-server)) | No | Interactive end-users, k8s/multi-user deployments |
+| **Raw bearer passthrough** | HTTP | Sends `Authorization: Bearer <viya-jwt>` on every request | Validates the JWT against Viya's JWKS and uses it upstream as-is | ✅ Required (or token issued elsewhere) | No | Automation/CI that already holds a Viya token; co-exists with PKCE on the same `/mcp` endpoint when `ALLOW_RAW_BEARER=true` |
+| **`sas-viya` CLI cache** | stdio | Runs `sas-viya auth loginCode` once | Reads access token from `~/.sas/credentials.json` on each tool call | ❌ Not needed (uses built-in `sas.cli` client) | ✅ `sas-viya` CLI | Operators who already use the SAS Viya CLI |
+| **`sas-mcp-login` cache** | stdio | Runs `uv run sas-mcp-login` once | Reads access token from `~/.sas-mcp-server/credentials.json` on each tool call | ❌ Not needed (uses built-in `vscode` client) | ❌ None | Zero-prereq bootstrap; lowest friction on Viya 2022.11+ |
+| **Native device-code (fallback)** | stdio | None — server prints a URL and code on first tool call | RFC 8628 device-authorization flow against SAS Logon | ⚠️ Only if your registered client has the device-code grant type | ❌ None | Viya deployments that don't CSRF-protect `/SASLogon/oauth/device_authorization` |
+
+**Defaults and ordering**
+
+- **HTTP mode** always runs PKCE. The raw-bearer path is additive and opt-in via `ALLOW_RAW_BEARER=true`; when off, only PKCE clients can authenticate.
+- **stdio mode** tries the cache files in order: `sas-viya` CLI cache → `sas-mcp-login` cache → native device-code. The first hit wins.
+
+**Removed**
+
+- Password-grant stdio authentication (was: `VIYA_USERNAME` + `VIYA_PASSWORD`). Deprecated by OAuth 2.1 and incompatible with confidential OAuth clients. See [`stdio_server.py`](../src/sas_mcp_server/stdio_server.py) for details.
+
+---
+
 ### Viya Setup
 The SAS MCP Server runs locally and expects to communicate with a Viya instance.
 

--- a/examples/docker/setup.md
+++ b/examples/docker/setup.md
@@ -1,6 +1,25 @@
 ## Running with Docker
 This repo provides a Dockerfile that can be used to build a docker image for the MCP server. Much more handy for production scenarios, portability, reproducibility, etc.
 
+### Pulling the pre-built image
+Official multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry:
+
+```sh
+docker pull ghcr.io/sassoftware/sas-mcp-server:latest
+```
+
+Tag → image-version mapping:
+
+| Tag | Source | Notes |
+|---|---|---|
+| `latest` | most recent `v*` git tag | Stable, recommended for general use |
+| `<major>.<minor>.<patch>` (e.g. `0.1.0`) | matching `v*` git tag | Pin to a specific release |
+| `<major>.<minor>` (e.g. `0.1`) | latest patch of that minor line | Tracks patch updates |
+| `edge` | tip of `main` | Unreleased / pre-release; expect breakage |
+| `sha-<short>` (e.g. `sha-d3d89f4`) | specific commit | Pin to an exact build |
+
+Each published image carries a signed build provenance attestation (verifiable with `gh attestation verify`).
+
 ### Building
 Basic:
 ```sh

--- a/examples/docker/setup.md
+++ b/examples/docker/setup.md
@@ -13,8 +13,8 @@ Tag → image-version mapping:
 | Tag | Source | Notes |
 |---|---|---|
 | `latest` | most recent `v*` git tag | Stable, recommended for general use |
-| `<major>.<minor>.<patch>` (e.g. `0.1.0`) | matching `v*` git tag | Pin to a specific release |
-| `<major>.<minor>` (e.g. `0.1`) | latest patch of that minor line | Tracks patch updates |
+| `<major>.<minor>.<patch>` (e.g. `1.0.0`) | matching `v*` git tag | Pin to a specific release |
+| `<major>.<minor>` (e.g. `1.0`) | latest patch of that minor line | Tracks patch updates |
 | `edge` | tip of `main` | Unreleased / pre-release; expect breakage |
 | `sha-<short>` (e.g. `sha-d3d89f4`) | specific commit | Pin to an exact build |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [project.scripts]
 app = "sas_mcp_server.main:main"
 app-stdio = "sas_mcp_server.stdio_server:main"
+sas-mcp-login = "sas_mcp_server.auth_login:main"
 
 [build-system]
 requires = ["uv_build>=0.8.22,<0.9.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sas-mcp-server"
-version = "0.1.0"
+version = "1.0.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [{name = "SAS Institute Inc."}]

--- a/src/sas_mcp_server/auth_login.py
+++ b/src/sas_mcp_server/auth_login.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Zero-prerequisite OAuth 2.0 login helper for SAS Viya stdio mode.
+
+Runs the OAuth 2.0 Authorization Code + PKCE flow against the built-in
+``vscode`` client shipped with SAS Viya 2022.11+. No admin client
+registration and no external CLI install are required, which makes this
+the lowest-friction bootstrap when the operator cannot use the ``sas-viya``
+CLI path.
+
+The flow is interactive: a browser opens to the SAS Logon page, the user
+signs in, and SAS Logon displays the authorization code on a results
+page. The user pastes the code back into the terminal; the helper
+exchanges it for an access token and writes the result to
+``~/.sas-mcp-server/credentials.json`` in the same shape as
+``~/.sas/credentials.json`` so the stdio server picks it up
+automatically.
+
+Usage:
+
+  uv run sas-mcp-login
+      Prints the SAS Logon URL, opens it in a browser, then prompts for the
+      authorization code (interactive terminal).
+
+  uv run sas-mcp-login --code <CODE>
+      Two-step variant for non-interactive contexts (e.g., shells without a
+      TTY). The first invocation (no --code) persists PKCE state to
+      ``~/.sas-mcp-server/login-state.json`` and prints instructions; the
+      second invocation completes the exchange.
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import secrets
+import string
+import sys
+import webbrowser
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlencode
+
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DEFAULT_HELPER_CLIENT_ID = "vscode"
+CACHE_PATH = Path.home() / ".sas-mcp-server" / "credentials.json"
+STATE_PATH = Path.home() / ".sas-mcp-server" / "login-state.json"
+
+
+def _generate_pkce() -> tuple[str, str]:
+    allowed = string.ascii_letters + string.digits + "-._~"
+    verifier = "".join(secrets.choice(allowed) for _ in range(128))
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return verifier, challenge
+
+
+def _authorize_url(
+    endpoint: str, client_id: str, challenge: str, redirect_uri: str | None
+) -> str:
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "code_challenge_method": "S256",
+        "code_challenge": challenge,
+        "state": secrets.token_urlsafe(16),
+    }
+    if redirect_uri:
+        params["redirect_uri"] = redirect_uri
+    return f"{endpoint.rstrip('/')}/SASLogon/oauth/authorize?{urlencode(params)}"
+
+
+def _exchange(
+    endpoint: str,
+    client_id: str,
+    code: str,
+    verifier: str,
+    redirect_uri: str | None,
+    verify_ssl: bool,
+) -> dict:
+    data = {
+        "client_id": client_id,
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": verifier,
+    }
+    if redirect_uri:
+        data["redirect_uri"] = redirect_uri
+    resp = httpx.post(
+        f"{endpoint.rstrip('/')}/SASLogon/oauth/token",
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        verify=verify_ssl,
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _write_state(payload: dict) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(payload))
+    try:
+        os.chmod(STATE_PATH, 0o600)
+    except OSError:
+        pass
+
+
+def _read_state() -> dict | None:
+    if not STATE_PATH.exists():
+        return None
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _clear_state() -> None:
+    try:
+        STATE_PATH.unlink()
+    except OSError:
+        pass
+
+
+def _write_cache(tokens: dict) -> Path:
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    expires_in = int(tokens.get("expires_in", 0))
+    expiry = (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).isoformat()
+    payload = {
+        "Default": {
+            "access-token": tokens["access_token"],
+            "refresh-token": tokens.get("refresh_token", ""),
+            "expiry": expiry,
+        }
+    }
+    CACHE_PATH.write_text(json.dumps(payload, indent=2))
+    try:
+        os.chmod(CACHE_PATH, 0o600)
+    except OSError:
+        pass
+    return CACHE_PATH
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="SAS Viya zero-prereq OAuth login helper for sas-mcp-server stdio mode.",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.getenv("VIYA_ENDPOINT", ""),
+        help="SAS Viya endpoint (default: VIYA_ENDPOINT from environment)",
+    )
+    parser.add_argument(
+        "--client-id",
+        default=os.getenv("AUTH_HELPER_CLIENT_ID", DEFAULT_HELPER_CLIENT_ID),
+        help="OAuth client_id to use (default: 'vscode' — built-in on Viya 2022.11+)",
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        default="",
+        help=(
+            "OAuth redirect URI. Default is empty, which omits the parameter "
+            "entirely; SAS Logon then shows the authorization code on a results "
+            "page for the user to copy. Pass a value only if your client has a "
+            "registered redirect URI."
+        ),
+    )
+    parser.add_argument(
+        "--code",
+        default="",
+        help=(
+            "Authorization code returned by SAS Logon. Pass this in a second "
+            "invocation after the first one has opened the browser. Without "
+            "--code, the helper falls back to an interactive prompt if stdin "
+            "is a terminal, or saves the PKCE state to "
+            f"{STATE_PATH} and exits otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Print the authorization URL without opening a browser",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Skip SSL certificate verification",
+    )
+    args = parser.parse_args()
+
+    if not args.endpoint:
+        parser.error(
+            "VIYA_ENDPOINT is not set in the environment and --endpoint was not given"
+        )
+
+    env_ssl = os.getenv("SSL_VERIFY", "true").lower() not in ("false", "0", "no")
+    verify_ssl = False if args.insecure else env_ssl
+
+    # Phase 2: --code was given. Load saved state, exchange, write cache.
+    if args.code:
+        state = _read_state()
+        if not state:
+            print(
+                f"No saved login state at {STATE_PATH}. Run `sas-mcp-login` "
+                "first to get the authorization URL, then re-run with --code.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            tokens = _exchange(
+                state["endpoint"],
+                state["client_id"],
+                args.code,
+                state["verifier"],
+                state.get("redirect_uri") or None,
+                verify_ssl,
+            )
+        except httpx.HTTPStatusError as exc:
+            print(f"\nToken exchange failed: {exc}", file=sys.stderr)
+            if exc.response is not None:
+                print(f"Response body: {exc.response.text[:500]}", file=sys.stderr)
+            return 1
+        path = _write_cache(tokens)
+        _clear_state()
+        print(f"Token cached at: {path}")
+        print(
+            "Stdio mode (`uv run app-stdio` or the container's `app-stdio` "
+            "command) will read this file automatically. Re-run "
+            "`sas-mcp-login` when the token expires."
+        )
+        return 0
+
+    # Phase 1: no --code. Generate PKCE, print URL, persist verifier, and either
+    # prompt interactively (terminal) or exit with instructions (non-tty).
+    redirect_uri = args.redirect_uri or None
+    verifier, challenge = _generate_pkce()
+    auth_url = _authorize_url(args.endpoint, args.client_id, challenge, redirect_uri)
+    _write_state({
+        "endpoint": args.endpoint,
+        "client_id": args.client_id,
+        "redirect_uri": redirect_uri or "",
+        "verifier": verifier,
+    })
+
+    print(f"Endpoint:    {args.endpoint}")
+    print(f"Client ID:   {args.client_id}")
+    print(f"Redirect:    {redirect_uri or '(none — SAS Logon will show the code on a page)'}")
+    print(f"SSL verify:  {verify_ssl}")
+    print()
+    print("Step 1 — open this URL in a browser and sign in:")
+    print()
+    print(f"  {auth_url}")
+    print()
+    if not args.no_browser:
+        webbrowser.open(auth_url)
+
+    if redirect_uri:
+        instruction = (
+            f"Step 2 — after signing in, the browser is redirected to "
+            f"{redirect_uri}?code=...\n"
+            "         Copy the value of the 'code' query parameter."
+        )
+    else:
+        instruction = (
+            "Step 2 — after signing in, SAS Logon displays the authorization "
+            "code on the results page.\n         Copy the code."
+        )
+    print(instruction)
+    print()
+
+    if not sys.stdin.isatty():
+        # Non-interactive: persist state, tell the user how to finish.
+        print(
+            "Stdin is not a terminal, so this helper cannot prompt. Once you "
+            "have the code, run:\n"
+            f"\n    uv run sas-mcp-login --code <CODE>\n\n"
+            f"PKCE state has been saved to {STATE_PATH}."
+        )
+        return 0
+
+    try:
+        code = input("Authorization code: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print("\nAborted.")
+        return 1
+    if not code:
+        print("No code provided.", file=sys.stderr)
+        return 1
+
+    try:
+        tokens = _exchange(
+            args.endpoint,
+            args.client_id,
+            code,
+            verifier,
+            redirect_uri,
+            verify_ssl,
+        )
+    except httpx.HTTPStatusError as exc:
+        print(f"\nToken exchange failed: {exc}", file=sys.stderr)
+        if exc.response is not None:
+            print(f"Response body: {exc.response.text[:500]}", file=sys.stderr)
+        return 1
+
+    path = _write_cache(tokens)
+    _clear_state()
+    print()
+    print(f"Token cached at: {path}")
+    print(
+        "Stdio mode (`uv run app-stdio` or the container's `app-stdio` command) "
+        "will read this file automatically. Re-run `sas-mcp-login` when the "
+        "token expires."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -1,16 +1,50 @@
 # Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import ssl
 
 from dotenv import load_dotenv
 from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
+from mcp.server.auth.provider import AccessToken
 
 load_dotenv()
 
 SSL_VERIFY = os.getenv("SSL_VERIFY", "true").lower() not in ("false", "0", "no")
+ALLOW_RAW_BEARER = os.getenv("ALLOW_RAW_BEARER", "false").lower() in ("true", "1", "yes")
+
+_logger = logging.getLogger(__name__)
+
+
+class PermissiveOAuthProxy(OAuthProxy):
+    """OAuthProxy that optionally accepts raw upstream JWTs.
+
+    When ``ALLOW_RAW_BEARER`` is set, a bearer token that fails the standard
+    MCP JWT swap (because it isn't a proxy-issued JWT) falls through to the
+    configured ``token_verifier``. If the verifier accepts it (i.e. the
+    token is a valid Viya JWT signed by the upstream JWKS), the request
+    proceeds with the raw token used directly as the upstream credential.
+
+    This lets PKCE clients and pre-authenticated programmatic clients hit
+    the same MCP endpoint without conflict — the additive path only kicks
+    in after the standard swap has already failed.
+    """
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        validated = await super().load_access_token(token)
+        if validated is not None:
+            return validated
+        if not ALLOW_RAW_BEARER:
+            return None
+        raw = await self._token_validator.verify_token(token)
+        if raw is not None:
+            _logger.info(
+                "Accepted raw bearer token (ALLOW_RAW_BEARER=true); "
+                "bypassing MCP JWT swap"
+            )
+        return raw
 
 if not SSL_VERIFY:
     # Disable SSL verification for self-signed Viya certificates
@@ -61,7 +95,7 @@ JWKS_URI = f"{VIYA_ENDPOINT}/SASLogon/token_keys"
 
 token_verifier = JWTVerifier(jwks_uri=JWKS_URI, audience=[])
 
-viya_auth = OAuthProxy(
+viya_auth = PermissiveOAuthProxy(
     upstream_authorization_endpoint=AUTHORIZATION_ENDPOINT,
     upstream_token_endpoint=TOKEN_ENDPOINT,
     upstream_client_id=CLIENT_ID,

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -3,71 +3,173 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Stdio MCP Server for SAS Viya.
-Authenticates directly to Viya using password grant, allowing MCP clients
-to start the server on demand without a pre-running HTTP server.
+
+Authenticates via OAuth 2.0 Device Authorization Grant (RFC 8628). Two paths
+are supported, tried in order:
+
+  1. Token cached by the SAS Viya CLI's ``sas-viya auth loginCode`` command.
+     Default location: ``~/.sas/credentials.json`` (override the parent dir
+     with the ``SAS_CLI_CONFIG`` env var). This path is the recommended one
+     because SAS Logon Manager typically CSRF-protects the device endpoint,
+     so the CLI's browser-driven flow is the path of least resistance.
+
+  2. Native device-code flow against ``/SASLogon/oauth/device_authorization``.
+     Used only when no cached credentials exist. Works on Viya instances
+     whose admins have not enabled CSRF protection on the device endpoint
+     and whose OAuth client is registered with the device-code grant type.
+
+Password grant has been removed: it requires a password in plaintext on disk,
+OAuth 2.1 deprecates it, and it does not work for confidential OAuth clients
+(SAS Logon rejects empty client secrets with ``invalid_client``).
 """
 
+import json
 import os
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
 import httpx
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import FastMCPError
-from .config import VIYA_ENDPOINT, CLIENT_ID, SSL_VERIFY
-from .viya_utils import logger
-from .tools import register_tools
+
+from .config import CLIENT_ID, SSL_VERIFY, VIYA_ENDPOINT
 from .prompts import register_prompts
+from .tools import register_tools
+from .viya_utils import logger
 
 load_dotenv()
 
-VIYA_USERNAME = os.getenv("VIYA_USERNAME", "")
-VIYA_PASSWORD = os.getenv("VIYA_PASSWORD", "")
+SAS_CLI_CONFIG = os.getenv("SAS_CLI_CONFIG", "")
+DEVICE_AUTH_URL = f"{VIYA_ENDPOINT}/SASLogon/oauth/device_authorization"
+TOKEN_URL = f"{VIYA_ENDPOINT}/SASLogon/oauth/token"
+DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
 
 
 class AuthenticationError(FastMCPError):
-    def __init__(self, message):
+    def __init__(self, message: str):
         super().__init__(message)
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"AuthenticationError: {self.message}"
 
 
-def _get_viya_token() -> str:
-    """Authenticate to Viya using password grant and return an access token."""
-    if not VIYA_USERNAME or not VIYA_PASSWORD:
-        raise AuthenticationError(
-            "VIYA_USERNAME and VIYA_PASSWORD must be set in .env for stdio mode"
-        )
-    resp = httpx.post(
-        f"{VIYA_ENDPOINT}/SASLogon/oauth/token",
+def _credentials_path() -> Path:
+    """Location of the access token cached by ``sas-viya auth loginCode``."""
+    base = Path(SAS_CLI_CONFIG) if SAS_CLI_CONFIG else Path.home()
+    return base / ".sas" / "credentials.json"
+
+
+def _read_sas_cli_token() -> str | None:
+    """Return the access token cached by the SAS Viya CLI, or ``None``."""
+    path = _credentials_path()
+    if not path.exists():
+        return None
+    try:
+        creds = json.loads(path.read_text())
+        token = creds["Default"]["access-token"]
+    except (KeyError, json.JSONDecodeError, OSError) as exc:
+        logger.warning(f"Could not read sas-viya credentials at {path}: {exc}")
+        return None
+    logger.info(f"Loaded access token from {path}")
+    return token
+
+
+def _native_device_code_token() -> str:
+    """Run RFC 8628 device flow directly against SAS Logon."""
+    init = httpx.post(
+        DEVICE_AUTH_URL,
         auth=(CLIENT_ID, ""),
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        data={
-            "grant_type": "password",
-            "username": VIYA_USERNAME,
-            "password": VIYA_PASSWORD,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
         },
+        data={"client_id": CLIENT_ID, "scope": "openid"},
         verify=SSL_VERIFY,
+        timeout=15.0,
     )
-    resp.raise_for_status()
-    return resp.json()["access_token"]
+    if init.status_code == 403 and "CSRF" in init.text:
+        raise AuthenticationError(
+            "Viya rejected the device-authorization request (CSRF protection "
+            "on /SASLogon/oauth/device_authorization). Install the sas-viya "
+            "CLI, run `sas-viya auth loginCode`, and re-launch this server; "
+            f"the cached token at {_credentials_path()} will be used."
+        )
+    init.raise_for_status()
+    flow = init.json()
+
+    verification_uri = flow.get("verification_uri_complete") or flow["verification_uri"]
+    user_code = flow["user_code"]
+    expires_in = int(flow.get("expires_in", 1800))
+    interval = max(int(flow.get("interval", 5)), 5)
+
+    msg = (
+        f"\n[sas-mcp-server] To authenticate, open:\n  {verification_uri}\n"
+        f"and enter code: {user_code}\n"
+    )
+    logger.info(msg)
+    print(msg, file=sys.stderr, flush=True)
+    try:
+        webbrowser.open(verification_uri, new=2)
+    except Exception:
+        pass
+
+    deadline = time.time() + expires_in
+    while time.time() < deadline:
+        time.sleep(interval)
+        poll = httpx.post(
+            TOKEN_URL,
+            auth=(CLIENT_ID, ""),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": DEVICE_GRANT,
+                "device_code": flow["device_code"],
+                "client_id": CLIENT_ID,
+            },
+            verify=SSL_VERIFY,
+            timeout=15.0,
+        )
+        if poll.status_code == 200:
+            return poll.json()["access_token"]
+        try:
+            err = poll.json().get("error")
+        except Exception:
+            err = None
+        if err == "authorization_pending":
+            continue
+        if err == "slow_down":
+            interval += 5
+            continue
+        raise AuthenticationError(
+            f"Device-code authentication failed: {err or poll.text[:200]}"
+        )
+    raise AuthenticationError("Device-code authentication timed out")
 
 
-# Token getter for stdio mode: acquires token via password grant
+def _get_viya_token() -> str:
+    token = _read_sas_cli_token()
+    if token:
+        return token
+    logger.info(
+        "No cached sas-viya CLI credentials; attempting native device-code flow"
+    )
+    return _native_device_code_token()
+
+
 async def _stdio_get_token(ctx: Context) -> str:
     return _get_viya_token()
 
 
-# Initialize the FastMCP server (no auth — stdio clients handle auth differently)
 logger.info(f"Connecting to SAS Viya at {VIYA_ENDPOINT}")
 mcp = FastMCP("SAS Viya Execution MCP Server")
-
-# Register all tools and prompts
 register_tools(mcp, _stdio_get_token)
 register_prompts(mcp)
 
 
-def main():
+def main() -> None:
     """Run the MCP server in stdio mode."""
     mcp.run(transport="stdio")
 

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -4,16 +4,20 @@
 """
 Stdio MCP Server for SAS Viya.
 
-Authenticates via OAuth 2.0 Device Authorization Grant (RFC 8628). Two paths
-are supported, tried in order:
+Authenticates via OAuth 2.0. Three paths are tried in order; the first one
+that yields a token wins:
 
   1. Token cached by the SAS Viya CLI's ``sas-viya auth loginCode`` command.
      Default location: ``~/.sas/credentials.json`` (override the parent dir
-     with the ``SAS_CLI_CONFIG`` env var). This path is the recommended one
-     because SAS Logon Manager typically CSRF-protects the device endpoint,
-     so the CLI's browser-driven flow is the path of least resistance.
+     with the ``SAS_CLI_CONFIG`` env var).
 
-  2. Native device-code flow against ``/SASLogon/oauth/device_authorization``.
+  2. Token cached by this project's own zero-prereq login helper
+     (``uv run sas-mcp-login``). Default location:
+     ``~/.sas-mcp-server/credentials.json``. The helper runs Authorization
+     Code + PKCE against the built-in ``vscode`` OAuth client and writes
+     the token in the same shape as the SAS Viya CLI cache.
+
+  3. Native device-code flow against ``/SASLogon/oauth/device_authorization``.
      Used only when no cached credentials exist. Works on Viya instances
      whose admins have not enabled CSRF protection on the device endpoint
      and whose OAuth client is registered with the device-code grant type.
@@ -57,22 +61,26 @@ class AuthenticationError(FastMCPError):
         return f"AuthenticationError: {self.message}"
 
 
-def _credentials_path() -> Path:
+def _sas_cli_credentials_path() -> Path:
     """Location of the access token cached by ``sas-viya auth loginCode``."""
     base = Path(SAS_CLI_CONFIG) if SAS_CLI_CONFIG else Path.home()
     return base / ".sas" / "credentials.json"
 
 
-def _read_sas_cli_token() -> str | None:
-    """Return the access token cached by the SAS Viya CLI, or ``None``."""
-    path = _credentials_path()
+def _helper_credentials_path() -> Path:
+    """Location of the access token cached by ``sas-mcp-login``."""
+    return Path.home() / ".sas-mcp-server" / "credentials.json"
+
+
+def _read_cached_token(path: Path) -> str | None:
+    """Return the ``Default.access-token`` value from *path*, or ``None``."""
     if not path.exists():
         return None
     try:
         creds = json.loads(path.read_text())
         token = creds["Default"]["access-token"]
     except (KeyError, json.JSONDecodeError, OSError) as exc:
-        logger.warning(f"Could not read sas-viya credentials at {path}: {exc}")
+        logger.warning(f"Could not read credentials at {path}: {exc}")
         return None
     logger.info(f"Loaded access token from {path}")
     return token
@@ -94,9 +102,10 @@ def _native_device_code_token() -> str:
     if init.status_code == 403 and "CSRF" in init.text:
         raise AuthenticationError(
             "Viya rejected the device-authorization request (CSRF protection "
-            "on /SASLogon/oauth/device_authorization). Install the sas-viya "
-            "CLI, run `sas-viya auth loginCode`, and re-launch this server; "
-            f"the cached token at {_credentials_path()} will be used."
+            "on /SASLogon/oauth/device_authorization). Run either "
+            "`sas-viya auth loginCode` (writes ~/.sas/credentials.json) or "
+            "`uv run sas-mcp-login` (writes ~/.sas-mcp-server/credentials.json) "
+            "and re-launch this server."
         )
     init.raise_for_status()
     flow = init.json()
@@ -150,11 +159,13 @@ def _native_device_code_token() -> str:
 
 
 def _get_viya_token() -> str:
-    token = _read_sas_cli_token()
-    if token:
-        return token
+    for path in (_sas_cli_credentials_path(), _helper_credentials_path()):
+        token = _read_cached_token(path)
+        if token:
+            return token
     logger.info(
-        "No cached sas-viya CLI credentials; attempting native device-code flow"
+        "No cached credentials found at ~/.sas or ~/.sas-mcp-server; "
+        "attempting native device-code flow"
     )
     return _native_device_code_token()
 

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -30,8 +30,9 @@ def register_tools(mcp, get_token):
         The server instance to register tools on.
     get_token : callable
         ``async def get_token(ctx: Context) -> str`` — returns a Viya access
-        token.  HTTP mode pulls it from context state; stdio mode acquires it
-        via password grant.
+        token.  HTTP mode pulls it from context state; stdio mode reads a
+        token cached by ``sas-viya auth loginCode`` or runs an RFC 8628
+        device-code flow.
     """
 
     # ------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "sas-mcp-server"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Closes #1 by adding a multi-arch (`linux/amd64`, `linux/arm64`) GHCR publishing workflow that meets the SAS OSPO container-publishing guidelines (maintainer + four OCI labels on the runtime stage, signed build provenance, SBOM attestations). The image will land at `ghcr.io/sassoftware/sas-mcp-server` on the first tagged release.

While verifying the resulting image worked end-to-end against a real Viya instance, the existing stdio auth surface turned out to be broken for confidential OAuth clients (the common case for custom Viya client registrations) — the `auth=(CLIENT_ID, "")` call returns `invalid_client`. The remaining commits address that:

- **Replace password-grant stdio auth with a chain of OAuth 2.0 paths**, tried in order: `sas-viya auth loginCode` cache → built-in `sas-mcp-login` helper cache → native RFC 8628 device code. Password grant was deprecated by OAuth 2.1 and didn't work for confidential clients.
- **Add `sas-mcp-login`** as a zero-prereq bootstrap helper using the built-in `vscode` Viya OAuth client (Viya 2022.11+). Operators who can't install the `sas-viya` CLI and don't have admin rights to register a custom OAuth client can now use stdio mode anyway.
- **Add `ALLOW_RAW_BEARER`** as an additive HTTP-mode flag — when enabled, the server accepts raw upstream Viya JWTs in `Authorization: Bearer` alongside the existing OAuth2 PKCE flow. Useful for automation/CI clients that already hold a Viya token. PKCE clients are unaffected.

Each commit is small, scoped, and reviewable on its own. Bumps version to **1.0.0** in `pyproject.toml` and `CHANGELOG.md` — that's a deliberate marker for the auth-model overhaul and the first published container image. Happy to bump down to `0.2.0` if maintainers prefer.

## Commits

| Hash | Scope |
|---|---|
| `730a7c2` | ci: publish container image to GHCR — closes #1 |
| `702109b` | fix(stdio): replace password grant with OAuth 2.0 device-code flow |
| `35dc5e5` | feat(auth): zero-prereq `sas-mcp-login` helper for stdio mode |
| `f05f8e1` | feat(auth): accept raw upstream bearer tokens via `ALLOW_RAW_BEARER` |
| `321f9cd` | docs: unified auth-modes overview + CHANGELOG entries |
| `7ef803e` | docs: troubleshooting entries for auth modes; cut 1.0.0 release |
| `07ac992` | chore(deps): sync uv.lock to package version 1.0.0 |

## What this PR does NOT change

- Existing HTTP/OAuth2 PKCE flow is unchanged when `ALLOW_RAW_BEARER` is unset (default).
- `VIYA_USERNAME` / `VIYA_PASSWORD` remain in `.env.sample` because the integration test suite uses them. They're no longer read by the running stdio server.
- No tag is cut — the workflow waits for a maintainer-pushed `v1.0.0` tag to publish `:latest` and the semver tags. Until then, merging to `main` only publishes `:edge` + `:sha-<short>`.

## Test plan — all validated against a live Viya instance

- [x] **GHCR workflow** — Dockerfile + workflow YAML reviewed; the action versions match GitHub's documented patterns. The image with the new OCI labels was built locally with podman and confirmed to carry all four labels (`maintainer`, `image.source`, `image.description`, `image.licenses`) on the runner stage.
- [x] **HTTP mode + OAuth2 PKCE** in the locally-built container — full browser flow, 26 tools registered, `list_cas_servers` / `list_caslibs` / `execute_sas_code` succeeded.
- [x] **Stdio mode + `sas-viya` CLI cache** — token loaded from mounted `~/.sas/credentials.json`, real Viya calls succeeded.
- [x] **Stdio mode + `sas-mcp-login` cache** — helper completed PKCE flow with the built-in `vscode` client, wrote `~/.sas-mcp-server/credentials.json`, container stdio mode then loaded and used the token.
- [x] **HTTP mode + raw bearer passthrough** — `ALLOW_RAW_BEARER=true` accepts arbitrary Viya-signed JWTs (verified with both an `sas-mcp-login`-issued token and an externally-issued token for the `sas.launcher` client). With `ALLOW_RAW_BEARER=false`, the same call returns 401 — confirming the flag is the gate.
- [x] **PR-time Dockerfile build check** — `docker-build.yml` is path-filtered to Dockerfile-relevant changes; will run on this PR.

## Pre-flight for maintainers

For first-time publish on `sassoftware/sas-mcp-server`:

1. **Workflow permissions** — `Settings → Actions → General → Workflow permissions` set to *Read and write permissions*. The workflow declares `permissions: { contents: read, packages: write, id-token: write, attestations: write }` but org-level settings can still restrict it.
2. **Package visibility** — GHCR makes new packages **private** on first push. After the first merge to `main`, flip visibility to **public** at `https://github.com/orgs/sassoftware/packages/container/sas-mcp-server/settings`. The `org.opencontainers.image.source` label is in place so repo permissions inherit cleanly.
3. **Cutting `v1.0.0`** — once the package is public, push a `v1.0.0` git tag to publish `:latest`, `:1.0.0`, `:1.0`, `:1` with provenance + SBOM. Or use `workflow_dispatch` from the Actions tab for an ad-hoc publish.

## Follow-ups (intentionally out of scope)

- Docker Hub mirror (issue #1 mentions it as an alternative; OSPO doc only covers GHCR).
- cosign signing on top of the existing build-provenance attestation.
- Make uvicorn auto-reload opt-in via env var. Attempted earlier in this branch and reverted — the change exposed a separate environment-specific issue (VS Code integrated terminal signaling the foreground process) that's better handled in its own PR after the root cause is understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)