### PR TITLE
feat!: code-quality overhaul, CI gate, full test coverage, and tool fixes (1.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI (lint, type-check, unit tests)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
+      - name: Type check (pyright)
+        run: uv run pyright src
+
+      - name: Unit tests
+        env:
+          VIYA_ENDPOINT: https://ci.invalid.example.com
+        run: uv run python -m pytest -m "not integration"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,73 @@
+name: Integration tests (live SAS Viya)
+
+# Runs the @pytest.mark.integration suite against a REAL SAS Viya instance and
+# publishes the results onto the pull request — as a Check, a sticky PR comment,
+# and a downloadable artifact — WITHOUT committing any result files to the repo.
+#
+# Requirements (configure once in repo settings):
+#   Secrets:  VIYA_ENDPOINT, VIYA_USERNAME, VIYA_PASSWORD   (TEST_CLIENT_ID optional)
+#   Variables (optional): INTEGRATION_RUNNER (e.g. a self-hosted runner label with
+#                         network access to Viya — GitHub-hosted runners usually
+#                         cannot reach an internal Viya), SSL_VERIFY ("false" for
+#                         self-signed certs).
+#
+# Triggers: manual (workflow_dispatch) or by adding the "run-integration" label
+# to a PR. It is intentionally NOT part of the default PR gate (ci.yml), which
+# stays fast and hermetic.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  integration:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-integration'
+    runs-on: ${{ vars.INTEGRATION_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Run integration tests
+        env:
+          VIYA_ENDPOINT: ${{ secrets.VIYA_ENDPOINT }}
+          VIYA_USERNAME: ${{ secrets.VIYA_USERNAME }}
+          VIYA_PASSWORD: ${{ secrets.VIYA_PASSWORD }}
+          TEST_CLIENT_ID: ${{ secrets.TEST_CLIENT_ID }}
+          SSL_VERIFY: ${{ vars.SSL_VERIFY || 'true' }}
+        run: |
+          mkdir -p reports
+          uv run python -m pytest -m integration --no-cov \
+            --junitxml=reports/integration.xml
+
+      - name: Upload JUnit results artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          path: reports/integration.xml
+          if-no-files-found: error
+
+      - name: Publish results to the PR (check + sticky comment)
+        if: ${{ !cancelled() }}
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: reports/integration.xml
+          check_name: Integration tests (live SAS Viya)
+          comment_mode: always

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,16 @@ build/
 venv/
 ENV/
 
-# Linter
+# Linter / type checker / coverage
 .ruff_cache/
+.pyright/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Test result reports (published to PRs as CI artifacts, never committed)
+reports/
 
 # Security - tokens and credentials
 .token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [1.1.0] - 2026-05-31
+
+### Changed — BREAKING
+- **`execute_sas_code` now returns a structured object instead of a 4-element array.** The tool returns a JSON object `{"snippet_id", "state", "log", "listing"}` (all strings) so MCP clients can address fields by name and the declared return type matches reality. Callers that parsed the previous positional `[snippet_id, state, log, listing]` array must switch to keyed access.
+- **`create_ml_project` arguments changed.** The single `data_table_uri` argument is replaced by `caslib_name` + `table_name` (plus optional `server_id`, default `cas-shared-default`); the tool now builds the data-table URI itself and pre-checks that the table is loaded in global scope, returning an actionable error when it isn't (instead of an opaque `mlPipelineAutomation` failure later).
+
+### Fixed
+- **`promote_table_to_memory` no longer always returns 404 (issue #10).** It previously wrapped a `casManagement` call that only acts on an already-in-memory table, so the common "load a table via `execute_sas_code`, then promote it in a later call" flow failed — the session-scoped table was already gone. It now loads the table from its caslib **source** and promotes it to global scope via the `updateTableState` API, and is idempotent (a no-op when the table is already loaded in global scope).
+
+### Added
+- **`list_source_tables` tool** — lists source tables not yet loaded into CAS memory (`state=unloaded`), so callers can discover what `promote_table_to_memory` can load. Brings the tool count to 27.
+- **Code-quality tooling and a CI gate.** `[tool.ruff]` and `[tool.pyright]` config in `pyproject.toml`; `pytest-cov` with a 90% coverage floor; a new `.github/workflows/ci.yml` runs ruff → pyright → unit tests on every PR and on `main` (previously CI only built Docker images — tests and lint were never gated). `run_tests.sh` now runs the ruff + pyright gates before pytest (skip with `--no-lint`).
+- **`src/sas_mcp_server/viya_client.py`** — generic Viya REST helpers (`get_json`, `get_paged_items`, `post_json`, `delete_resource`, `make_client`) plus the shared `logger`, extracted from `viya_utils.py` with public names.
+- **`src/sas_mcp_server/exceptions.py`** — shared `AuthenticationError` (previously defined identically in `mcp_server.py` and `stdio_server.py`) and a `ConfigError`.
+- **`src/sas_mcp_server/env.py`** — side-effect-free `env_bool` helper used by both `config.py` and `auth_login.py`, removing duplicated `SSL_VERIFY`/`ALLOW_RAW_BEARER` parsing.
+- **Tests for previously uncovered modules** — `tests/test_auth_login.py`, `tests/test_stdio_server.py`, `tests/test_env.py`, `tests/test_config_oauth.py`, real HTTP auth-middleware/health-route tests in `tests/test_mcp_server.py`, and tool error-path tests. Package coverage rose from ~58% to ~95%.
+- **Comprehensive live integration coverage** — every one of the 26 tools and 8 prompt templates is now exercised against a real SAS Viya, with `test_every_tool_has_integration_coverage` / `test_every_prompt_has_integration_coverage` guards that fail if a registered tool/prompt is ever added without an integration test. Added `cancel_job` and `run_ml_project` workflows and per-prompt rendering through the live-connected server.
+- **`.github/workflows/integration.yml`** — opt-in job (manual `workflow_dispatch` or the `run-integration` PR label) that runs the integration suite against Viya using repo secrets and publishes results onto the PR as a Check, a sticky comment, and a JUnit artifact — **without committing any result files** (`reports/` is git-ignored).
+- Full type annotations across the package, including parameterized return types on every tool.
+
+### Changed
+- All 26 tools now share a single `viya_session` async context manager for the log + token + client preamble that was previously copy-pasted into each tool.
+- `viya_utils.py` is now compute session/job orchestration only; `run_one_snippet` returns the structured dict described above.
+- `config.py` raises `ConfigError` (not a bare `Exception`) when `VIYA_ENDPOINT` is unset; logging is now lazy `%`-style throughout.
+
+### Removed
+- Dead helpers in `viya_utils.py` reachable only from tests: `_put_data`, `_get_text`, `_get_paged_lines`, `fetch_full_job_log`, `fetch_full_job_listing`, `fetch_full_session_log`.
+
 ## [1.0.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ The server validates the token against Viya's JWKS and uses it upstream as-is, b
 - **list_cas_servers**: List available CAS servers
 - **list_caslibs**: List CAS libraries on a server
 - **list_castables**: List tables in a CAS library
+- **list_source_tables**: List source tables not yet loaded into memory (candidates for promotion)
 - **get_castable_info**: Get table metadata (row count, columns, size)
 - **get_castable_columns**: Get column names, types, labels, formats
 - **get_castable_data**: Fetch sample rows from a CAS table
 
 #### Data Operations & Files
 - **upload_data**: Upload CSV data into a CAS table
-- **promote_table_to_memory**: Promote a table to global scope in CAS
+- **promote_table_to_memory**: Load a source table into memory at global scope (idempotent)
 - **list_files**: List files in the Viya Files Service
 - **upload_file**: Upload a file to Viya Files Service
 - **download_file**: Download file content
@@ -155,7 +156,7 @@ The server validates the token against Viya's JWKS and uses it upstream as-is, b
 
 #### Model Management & Scoring
 - **list_ml_projects**: List AutoML projects
-- **create_ml_project**: Create a new AutoML project
+- **create_ml_project**: Create a new AutoML project from a loaded, global-scope CAS table (caslib + table + optional CAS server)
 - **run_ml_project**: Run pipeline automation
 - **list_registered_models**: List models in repository
 - **list_models_and_decisions**: List published MAS modules
@@ -281,17 +282,50 @@ Integration tests call every tool against a live Viya environment. They require 
 ./run_tests.sh --integration-only
 ```
 
+Every one of the 27 tools and 8 prompt templates has an integration test, enforced by the
+`test_every_tool_has_integration_coverage` / `test_every_prompt_has_integration_coverage`
+guards — adding a new tool or prompt without integration coverage fails the suite. The
+resource-dependent tests discover real targets on the instance: `score_data` scores the most
+recently modified MAS module (discovering a real step and its inputs), and `run_ml_project`
+re-runs the most recently modified `completed` ML project. They `skip` only if the instance
+has no such resource at all.
+
+**In CI:** the `.github/workflows/integration.yml` workflow runs this suite on demand
+(manual dispatch, or by adding the `run-integration` label to a PR) using repository
+secrets, and publishes the results back to the PR as a status check, a sticky comment, and
+a downloadable JUnit artifact. Result files are written to `reports/` (git-ignored) and are
+never committed.
+
+**Locally (attach results to a PR yourself):** run with `--report` to write the JUnit XML
+and a Markdown summary into `reports/` (git-ignored), then post them to a PR with the GitHub
+CLI — no commit, no CI required:
+
+```sh
+./run_tests.sh --integration-only --report
+gh pr comment <PR> --body-file reports/integration-summary.md   # summary table as a comment
+gh gist create reports/integration.xml                          # full XML as a linkable gist
+```
+
+> GitHub has no API/CLI to attach a binary file to a PR (drag-and-drop upload is browser-only),
+> so the summary is posted as a comment and the raw XML is shared via a gist link or pasted in a
+> collapsed `<details>` block. To produce the canonical Actions *artifact* from your machine
+> instead, trigger the workflow remotely: `gh workflow run integration.yml`.
+
 ### Test Structure
 
 | File | Description |
 |---|---|
-| `tests/test_tool_payloads.py` | Payload assertions for all 26 tools — verifies URL paths, JSON body structure, query params, and headers |
+| `tests/test_tool_payloads.py` | Payload assertions for all 27 tools (URL paths, JSON body, query params, headers) plus error-path coverage |
 | `tests/test_integration.py` | End-to-end workflow tests against a real Viya instance |
-| `tests/test_tools.py` | Unit tests for HTTP helper functions (`_get_json`, `_post_json`, etc.) |
-| `tests/test_viya_utils.py` | Unit tests for Viya compute session and job utilities |
-| `tests/test_mcp_server.py` | Unit tests for MCP server and auth middleware |
-| `tests/test_prompts.py` | Unit tests for prompt template rendering |
+| `tests/test_tools.py` | Unit tests for the generic Viya REST helpers in `viya_client` (`get_json`, `post_json`, `make_client`, …) |
+| `tests/test_viya_utils.py` | Unit tests for Viya compute session and job orchestration |
+| `tests/test_mcp_server.py` | Unit tests for the HTTP auth middleware, health route, and token getter |
 | `tests/test_config.py` | Unit tests for configuration loading |
+| `tests/test_config_oauth.py` | Unit tests for `PermissiveOAuthProxy` raw-bearer handling |
+| `tests/test_auth_login.py` | Unit tests for the `sas-mcp-login` OAuth/PKCE helper |
+| `tests/test_stdio_server.py` | Unit tests for stdio token resolution and the device-code flow |
+| `tests/test_env.py` | Unit tests for the `env_bool` helper |
+| `tests/test_prompts.py` | Unit tests for prompt template rendering |
 
 ## Contributing
 Maintainers are accepting patches and contributions to this project. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details about submitting contributions to this project.

--- a/examples/register_mcp_client.py
+++ b/examples/register_mcp_client.py
@@ -2,10 +2,11 @@
 """Register (or re-register) the sas-mcp OAuth client on a SAS Viya instance."""
 
 import getpass
+import os
 import ssl
+
 import httpx
 from dotenv import load_dotenv
-import os
 
 load_dotenv()
 
@@ -75,8 +76,8 @@ def register_client(base_url: str, token: str, client_id: str, redirect_uri: str
     resp.raise_for_status()
     print(f"Client '{client_id}' registered successfully.")
     print(f"  Redirect URI: {redirect_uri}")
-    print(f"  Scopes: openid")
-    print(f"  Grant types: authorization_code, refresh_token")
+    print("  Scopes: openid")
+    print("  Grant types: authorization_code, refresh_token")
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sas-mcp-server"
-version = "1.0.0"
-description = "Add your description here"
+version = "1.1.0"
+description = "An MCP server for executing SAS code and querying Compute, CAS, and model APIs on SAS Viya via OAuth 2.0."
 readme = "README.md"
 authors = [{name = "SAS Institute Inc."}]
 requires-python = ">=3.12"
@@ -24,7 +24,33 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "pyright>=1.1.409",
     "pytest>=9.0.0",
     "pytest-asyncio>=0.24.0",
+    "pytest-cov>=7.1.0",
     "ruff>=0.14.4",
 ]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+# E/F: pyflakes + pycodestyle, I: isort, B: bugbear, UP: pyupgrade,
+# G: logging-format, TRY: tryceratops, SIM: flake8-simplify.
+select = ["E", "F", "I", "B", "UP", "G", "TRY", "SIM"]
+ignore = [
+    "TRY003",  # long messages in exceptions are fine for this CLI/server
+    "TRY300",  # "move to else block" — noisy, low value here
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests legitimately use broad excepts and don't need logging-format hygiene.
+"tests/**" = ["G004", "B017", "TRY003"]
+
+[tool.pyright]
+include = ["src"]
+pythonVersion = "3.12"
+typeCheckingMode = "basic"
+reportMissingTypeStubs = false

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,11 +10,14 @@ python_functions = test_*
 testpaths = tests
 
 # Output options
-addopts = 
+addopts =
     -v
     --strict-markers
     --tb=short
     --disable-warnings
+    --cov=src/sas_mcp_server
+    --cov-report=term-missing
+    --cov-fail-under=90
 
 # Markers
 markers =

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 
 INTEGRATION=false
 INTEGRATION_ONLY=false
+NO_LINT=false
+REPORT=false
 ENDPOINT=""
 USERNAME=""
 PASSWORD=""
@@ -22,15 +24,20 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --integration)       INTEGRATION=true; shift ;;
         --integration-only)  INTEGRATION=true; INTEGRATION_ONLY=true; shift ;;
+        --no-lint)           NO_LINT=true; shift ;;
+        --report)            REPORT=true; shift ;;
         --endpoint)          ENDPOINT="$2"; shift 2 ;;
         --username)          USERNAME="$2"; shift 2 ;;
         --password)          PASSWORD="$2"; shift 2 ;;
         -h|--help)
-            echo "Usage: $0 [--integration] [--integration-only] [--endpoint URL] [--username USER] [--password PASS]"
+            echo "Usage: $0 [--integration] [--integration-only] [--no-lint] [--report] [--endpoint URL] [--username USER] [--password PASS]"
             echo ""
-            echo "  (no flags)          Run unit tests only"
-            echo "  --integration       Run unit + integration tests"
+            echo "  (no flags)          Run lint + type check + unit tests"
+            echo "  --integration       Run lint + type check + unit + integration tests"
             echo "  --integration-only  Run integration tests only"
+            echo "  --no-lint           Skip the ruff + pyright gates"
+            echo "  --report            Write reports/integration.xml + reports/integration-summary.md"
+            echo "                      (git-ignored) — for attaching results to a PR locally"
             echo "  --endpoint URL      SAS Viya endpoint (overrides VIYA_ENDPOINT / .env)"
             echo "  --username USER     Viya username   (overrides VIYA_USERNAME / .env)"
             echo "  --password PASS     Viya password   (overrides VIYA_PASSWORD / .env)"
@@ -46,13 +53,38 @@ done
 [[ -n "$USERNAME" ]] && export VIYA_USERNAME="$USERNAME"
 [[ -n "$PASSWORD" ]] && export VIYA_PASSWORD="$PASSWORD"
 
+# Optional JUnit report (written to git-ignored reports/). The coverage floor in
+# pytest.ini applies to the full unit suite, so integration-only runs disable it.
+REPORT_ARG=""
+if $REPORT; then
+    mkdir -p reports
+    REPORT_ARG="--junitxml=reports/integration.xml"
+fi
+
+# Lint + type-check gates (skip with --no-lint or for integration-only runs)
+if ! $NO_LINT && ! $INTEGRATION_ONLY; then
+    echo "=== Linting (ruff) ==="
+    uv run ruff check .
+    echo "=== Type checking (pyright) ==="
+    uv run pyright src
+fi
+
 if $INTEGRATION_ONLY; then
     echo "=== Running integration tests ==="
-    uv run python -m pytest -m integration -v "$@"
+    uv run python -m pytest -m integration --no-cov -v $REPORT_ARG "$@"
 elif $INTEGRATION; then
     echo "=== Running all tests (unit + integration) ==="
-    uv run python -m pytest -v "$@"
+    uv run python -m pytest -v $REPORT_ARG "$@"
 else
     echo "=== Running unit tests ==="
     uv run python -m pytest -m "not integration" -v "$@"
+fi
+
+if $REPORT; then
+    uv run python scripts/junit_to_summary.py reports/integration.xml reports/integration-summary.md >/dev/null
+    echo ""
+    echo "Wrote reports/integration.xml and reports/integration-summary.md (git-ignored)."
+    echo "Attach results to a PR without committing, e.g.:"
+    echo "  gh pr comment <PR> --body-file reports/integration-summary.md   # summary as a comment"
+    echo "  gh gist create reports/integration.xml                          # full XML as a linkable gist"
 fi

--- a/scripts/junit_to_summary.py
+++ b/scripts/junit_to_summary.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Render a JUnit XML file as a Markdown summary table.
+
+Usage:
+    python scripts/junit_to_summary.py <junit.xml> [output.md]
+
+Writes the Markdown to *output.md* if given, and always prints it to stdout.
+Used by ``run_tests.sh --report`` to produce a human-readable artifact that can
+be posted to a pull request (e.g. ``gh pr comment <PR> --body-file ...``)
+without committing anything to the repository.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+
+
+def render(xml_path: str) -> str:
+    root = ET.parse(xml_path).getroot()
+    suite = root.find("testsuite") if root.tag == "testsuites" else root
+
+    rows: list[tuple[str, str, str, str]] = []
+    passed = 0
+    for tc in suite.findall("testcase"):
+        name = tc.get("name", "?")
+        elapsed = f"{float(tc.get('time', 0) or 0):.1f}s"
+        failure, error, skipped = (
+            tc.find("failure"),
+            tc.find("error"),
+            tc.find("skipped"),
+        )
+        if failure is not None:
+            status, note = "FAIL", (failure.get("message") or "")[:90]
+        elif error is not None:
+            status, note = "ERROR", (error.get("message") or "")[:90]
+        elif skipped is not None:
+            status, note = "SKIP", (skipped.get("message") or "")[:90]
+        else:
+            status, note, passed = "PASS", "", passed + 1
+        rows.append((name, status, elapsed, note))
+
+    total = suite.get("tests", str(len(rows)))
+    lines = [
+        "## Integration test results - live SAS Viya",
+        "",
+        f"**{total} tests | {passed} passed | {suite.get('skipped', 0)} skipped | "
+        f"{suite.get('failures', 0)} failed | {suite.get('errors', 0)} errors | "
+        f"{float(suite.get('time', 0) or 0):.0f}s**",
+        "",
+        "| Test | Result | Time | Note |",
+        "|---|---|---|---|",
+    ]
+    lines += [f"| `{n}` | {s} | {t} | {note} |" for n, s, t, note in rows]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    md = render(sys.argv[1])
+    if len(sys.argv) >= 3:
+        with open(sys.argv[2], "w", encoding="utf-8") as fh:
+            fh.write(md)
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sas_mcp_server/auth_login.py
+++ b/src/sas_mcp_server/auth_login.py
@@ -33,6 +33,7 @@ Usage:
 
 import argparse
 import base64
+import contextlib
 import hashlib
 import json
 import os
@@ -40,12 +41,14 @@ import secrets
 import string
 import sys
 import webbrowser
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlencode
 
 import httpx
 from dotenv import load_dotenv
+
+from .env import env_bool
 
 load_dotenv()
 
@@ -110,10 +113,8 @@ def _exchange(
 def _write_state(payload: dict) -> None:
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(json.dumps(payload))
-    try:
+    with contextlib.suppress(OSError):
         os.chmod(STATE_PATH, 0o600)
-    except OSError:
-        pass
 
 
 def _read_state() -> dict | None:
@@ -126,16 +127,14 @@ def _read_state() -> dict | None:
 
 
 def _clear_state() -> None:
-    try:
+    with contextlib.suppress(OSError):
         STATE_PATH.unlink()
-    except OSError:
-        pass
 
 
 def _write_cache(tokens: dict) -> Path:
     CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
     expires_in = int(tokens.get("expires_in", 0))
-    expiry = (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).isoformat()
+    expiry = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
     payload = {
         "Default": {
             "access-token": tokens["access_token"],
@@ -144,10 +143,8 @@ def _write_cache(tokens: dict) -> Path:
         }
     }
     CACHE_PATH.write_text(json.dumps(payload, indent=2))
-    try:
+    with contextlib.suppress(OSError):
         os.chmod(CACHE_PATH, 0o600)
-    except OSError:
-        pass
     return CACHE_PATH
 
 
@@ -203,8 +200,7 @@ def main() -> int:
             "VIYA_ENDPOINT is not set in the environment and --endpoint was not given"
         )
 
-    env_ssl = os.getenv("SSL_VERIFY", "true").lower() not in ("false", "0", "no")
-    verify_ssl = False if args.insecure else env_ssl
+    verify_ssl = False if args.insecure else env_bool("SSL_VERIFY", True)
 
     # Phase 2: --code was given. Load saved state, exchange, write cache.
     if args.code:

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -10,10 +10,13 @@ from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from mcp.server.auth.provider import AccessToken
 
+from .env import env_bool
+from .exceptions import ConfigError
+
 load_dotenv()
 
-SSL_VERIFY = os.getenv("SSL_VERIFY", "true").lower() not in ("false", "0", "no")
-ALLOW_RAW_BEARER = os.getenv("ALLOW_RAW_BEARER", "false").lower() in ("true", "1", "yes")
+SSL_VERIFY = env_bool("SSL_VERIFY", True)
+ALLOW_RAW_BEARER = env_bool("ALLOW_RAW_BEARER", False)
 
 _logger = logging.getLogger(__name__)
 
@@ -84,7 +87,7 @@ CONTEXT_NAME = os.getenv("COMPUTE_CONTEXT_NAME", "SAS Job Execution compute cont
 MCP_BASE_URL = os.getenv("MCP_BASE_URL", f"http://localhost:{HOST_PORT}")
 
 if not VIYA_ENDPOINT:
-    raise Exception(
+    raise ConfigError(
         "VIYA_ENDPOINT is not set. Please set it in the environment variables."
     )
 

--- a/src/sas_mcp_server/env.py
+++ b/src/sas_mcp_server/env.py
@@ -1,0 +1,31 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Side-effect-free environment-variable helpers shared across modules.
+
+This module deliberately performs no I/O and imports nothing from the rest of
+the package, so it is safe to import from the lightweight ``auth_login`` CLI
+without triggering the server configuration in :mod:`sas_mcp_server.config`.
+"""
+
+import os
+
+_TRUE = {"true", "1", "yes", "on"}
+_FALSE = {"false", "0", "no", "off"}
+
+
+def env_bool(name: str, default: bool) -> bool:
+    """Parse a boolean-ish environment variable.
+
+    Recognises ``true/1/yes/on`` and ``false/0/no/off`` (case-insensitive).
+    Returns *default* when the variable is unset or holds an unrecognised value.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    val = raw.strip().lower()
+    if val in _TRUE:
+        return True
+    if val in _FALSE:
+        return False
+    return default

--- a/src/sas_mcp_server/exceptions.py
+++ b/src/sas_mcp_server/exceptions.py
@@ -1,0 +1,21 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared exception types for the SAS MCP server."""
+
+from fastmcp.exceptions import FastMCPError
+
+
+class AuthenticationError(FastMCPError):
+    """Raised when a request cannot be authenticated against SAS Viya."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"AuthenticationError: {self.message}"
+
+
+class ConfigError(Exception):
+    """Raised when required server configuration is missing or invalid."""

--- a/src/sas_mcp_server/main.py
+++ b/src/sas_mcp_server/main.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import uvicorn
+
 from .config import HOST_PORT
 
 
-def main():
+def main() -> None:
     uvicorn.run(
         "sas_mcp_server.mcp_server:app", host="0.0.0.0", port=HOST_PORT, reload=True
     )

--- a/src/sas_mcp_server/mcp_server.py
+++ b/src/sas_mcp_server/mcp_server.py
@@ -6,65 +6,59 @@ Starter MCP Server for SAS Viya, utilizing the SAS Viya OAuth flow for authentic
 Handles session management, job submission, and result retrieval using httpx.
 """
 
-# Auth handling and API access with Viya
-from .config import viya_auth
+from typing import Any
+
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
-from fastmcp.exceptions import FastMCPError
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.server.middleware import Middleware, MiddlewareContext
+from starlette.requests import Request
 from starlette.responses import JSONResponse
-from .viya_utils import logger
-from .tools import register_tools
+
+from .config import VIYA_ENDPOINT, viya_auth
+from .exceptions import AuthenticationError
 from .prompts import register_prompts
+from .tools import register_tools
+from .viya_client import logger
 
 # Load environment variables before accessing them
 load_dotenv()
 
 
-class AuthenticationError(FastMCPError):
-    def __init__(self, message):
-        super().__init__(message)
-        self.message = message
-
-    def __str__(self):
-        return f"AuthenticationError: {self.message}"
-
-
 class AuthMiddleware(Middleware):
-    async def on_call_tool(self, ctx: MiddlewareContext, call_next):
+    async def on_call_tool(self, ctx: MiddlewareContext, call_next: Any) -> Any:
         request = get_http_request()
         bearer_token = request.headers.get("Authorization")
-        if bearer_token:
-            parts = bearer_token.split()
-            jwt = (
-                parts[1]
-                if len(parts) > 1 and parts[0].lower() == "bearer"
-                else bearer_token
-            )
-            logger.info("Client auth header found, Swapping for upstream token")
-            viya_access_info = await viya_auth.load_access_token(jwt)
-            if viya_access_info:
-                logger.info("Viya access info retrieved successfully!")
-                viya_access_token = viya_access_info.token
-                await ctx.fastmcp_context.set_state("access_token", viya_access_token)
-            else:
-                logger.error("Could not retrieve upstream access token!")
-        else:
+        if not bearer_token:
             logger.error("No auth header found. Cannot proceed")
             raise AuthenticationError("No auth header found. Cannot proceed")
+
+        parts = bearer_token.split()
+        jwt = (
+            parts[1]
+            if len(parts) > 1 and parts[0].lower() == "bearer"
+            else bearer_token
+        )
+        logger.info("Client auth header found, Swapping for upstream token")
+        viya_access_info = await viya_auth.load_access_token(jwt)
+        if viya_access_info:
+            logger.info("Viya access info retrieved successfully!")
+            fastmcp_ctx = ctx.fastmcp_context
+            if fastmcp_ctx is not None:
+                await fastmcp_ctx.set_state("access_token", viya_access_info.token)
+        else:
+            logger.error("Could not retrieve upstream access token!")
         return await call_next(ctx)
 
 
 # Initialize the FastMCP server
-from .config import VIYA_ENDPOINT
-logger.info(f"Connecting to SAS Viya at {VIYA_ENDPOINT}")
+logger.info("Connecting to SAS Viya at %s", VIYA_ENDPOINT)
 mcp = FastMCP("SAS Viya Execution MCP Server", auth=viya_auth)
 mcp.add_middleware(AuthMiddleware())
 
 
 @mcp.custom_route("/health", methods=["GET"])
-async def health_check(request):
+async def health_check(request: Request) -> JSONResponse:
     logger.info("Performing health check . . .")
     return JSONResponse({"status": "healthy", "service": "sas-viya-execution-mcp"})
 

--- a/src/sas_mcp_server/prompts.py
+++ b/src/sas_mcp_server/prompts.py
@@ -6,15 +6,15 @@ Prompt templates for the SAS MCP server.
 Registered via ``register_prompts(mcp)`` on the FastMCP instance.
 """
 
-from typing import Optional
+from fastmcp import FastMCP
 from fastmcp.prompts import Message
 
 
-def register_prompts(mcp):
+def register_prompts(mcp: FastMCP) -> None:
     """Register all prompt templates on *mcp*."""
 
     @mcp.prompt()
-    def debug_sas_log(log_text: str, severity_filter: Optional[str] = None) -> list[Message]:
+    def debug_sas_log(log_text: str, severity_filter: str | None = None) -> list[Message]:
         """Analyze a SAS log for errors, warnings, and notes with root-cause explanations and suggested fixes."""
         filter_instruction = ""
         if severity_filter:
@@ -27,7 +27,7 @@ def register_prompts(mcp):
 
     @mcp.prompt()
     def explore_dataset(library: str, dataset: str,
-                        focus_vars: Optional[str] = None) -> list[Message]:
+                        focus_vars: str | None = None) -> list[Message]:
         """Generate comprehensive SAS data-profiling code (CONTENTS, MEANS, FREQ, UNIVARIATE)."""
         vars_instruction = ""
         if focus_vars:
@@ -41,8 +41,8 @@ def register_prompts(mcp):
 
     @mcp.prompt()
     def data_quality_check(library: str, dataset: str,
-                           key_variables: Optional[str] = None,
-                           business_rules: Optional[str] = None) -> list[Message]:
+                           key_variables: str | None = None,
+                           business_rules: str | None = None) -> list[Message]:
         """Generate SAS code for a data quality assessment (completeness, uniqueness, validity)."""
         extras = ""
         if key_variables:
@@ -71,7 +71,7 @@ def register_prompts(mcp):
 
     @mcp.prompt()
     def optimize_sas_code(sas_code: str,
-                          optimization_focus: Optional[str] = None) -> list[Message]:
+                          optimization_focus: str | None = None) -> list[Message]:
         """Review and optimize SAS code for performance, readability, or both."""
         focus = optimization_focus or "performance and readability"
         return [Message(role="user", content=(
@@ -86,7 +86,7 @@ def register_prompts(mcp):
 
     @mcp.prompt()
     def explain_sas_code(sas_code: str,
-                         audience_level: Optional[str] = None) -> list[Message]:
+                         audience_level: str | None = None) -> list[Message]:
         """Provide a block-by-block explanation of SAS code, tailored to skill level."""
         level = audience_level or "intermediate"
         return [Message(role="user", content=(
@@ -101,7 +101,7 @@ def register_prompts(mcp):
 
     @mcp.prompt()
     def sas_macro_builder(macro_name: str, purpose: str,
-                          parameters: Optional[str] = None) -> list[Message]:
+                          parameters: str | None = None) -> list[Message]:
         """Build a production-quality reusable SAS macro."""
         params_instruction = ""
         if parameters:
@@ -119,8 +119,8 @@ def register_prompts(mcp):
 
     @mcp.prompt()
     def generate_report(dataset: str,
-                        report_type: Optional[str] = None,
-                        output_format: Optional[str] = None) -> list[Message]:
+                        report_type: str | None = None,
+                        output_format: str | None = None) -> list[Message]:
         """Generate SAS ODS/PROC REPORT code for formatted output."""
         rtype = report_type or "summary"
         fmt = output_format or "HTML"

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -27,6 +27,7 @@ OAuth 2.1 deprecates it, and it does not work for confidential OAuth clients
 (SAS Logon rejects empty client secrets with ``invalid_client``).
 """
 
+import contextlib
 import json
 import os
 import sys
@@ -37,12 +38,12 @@ from pathlib import Path
 import httpx
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
-from fastmcp.exceptions import FastMCPError
 
 from .config import CLIENT_ID, SSL_VERIFY, VIYA_ENDPOINT
+from .exceptions import AuthenticationError
 from .prompts import register_prompts
 from .tools import register_tools
-from .viya_utils import logger
+from .viya_client import logger
 
 load_dotenv()
 
@@ -50,15 +51,6 @@ SAS_CLI_CONFIG = os.getenv("SAS_CLI_CONFIG", "")
 DEVICE_AUTH_URL = f"{VIYA_ENDPOINT}/SASLogon/oauth/device_authorization"
 TOKEN_URL = f"{VIYA_ENDPOINT}/SASLogon/oauth/token"
 DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
-
-
-class AuthenticationError(FastMCPError):
-    def __init__(self, message: str):
-        super().__init__(message)
-        self.message = message
-
-    def __str__(self) -> str:
-        return f"AuthenticationError: {self.message}"
 
 
 def _sas_cli_credentials_path() -> Path:
@@ -80,9 +72,9 @@ def _read_cached_token(path: Path) -> str | None:
         creds = json.loads(path.read_text())
         token = creds["Default"]["access-token"]
     except (KeyError, json.JSONDecodeError, OSError) as exc:
-        logger.warning(f"Could not read credentials at {path}: {exc}")
+        logger.warning("Could not read credentials at %s: %s", path, exc)
         return None
-    logger.info(f"Loaded access token from {path}")
+    logger.info("Loaded access token from %s", path)
     return token
 
 
@@ -121,10 +113,8 @@ def _native_device_code_token() -> str:
     )
     logger.info(msg)
     print(msg, file=sys.stderr, flush=True)
-    try:
+    with contextlib.suppress(Exception):
         webbrowser.open(verification_uri, new=2)
-    except Exception:
-        pass
 
     deadline = time.time() + expires_in
     while time.time() < deadline:
@@ -174,7 +164,7 @@ async def _stdio_get_token(ctx: Context) -> str:
     return _get_viya_token()
 
 
-logger.info(f"Connecting to SAS Viya at {VIYA_ENDPOINT}")
+logger.info("Connecting to SAS Viya at %s", VIYA_ENDPOINT)
 mcp = FastMCP("SAS Viya Execution MCP Server")
 register_tools(mcp, _stdio_get_token)
 register_prompts(mcp)

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -6,22 +6,29 @@ Shared tool registration for both HTTP and stdio MCP servers.
 All tools are registered via ``register_tools(mcp, get_token)``.
 """
 
-from typing import Optional
-import httpx as _httpx
-from fastmcp import Context
-from fastmcp.tools import ToolResult
-from .viya_utils import (
-    _get_json,
-    _get_paged_items,
-    _post_json,
-    _delete_resource,
-    _make_client,
-    run_one_snippet,
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+from fastmcp import Context, FastMCP
+
+from .config import CONTEXT_NAME, VIYA_ENDPOINT
+from .viya_client import (
+    delete_resource,
+    get_json,
+    get_paged_items,
     logger,
+    make_client,
+    post_json,
 )
+from .viya_utils import run_one_snippet
 
 
-def register_tools(mcp, get_token):
+def register_tools(
+    mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]
+) -> None:
     """Register all tools on *mcp*.
 
     Parameters
@@ -35,12 +42,24 @@ def register_tools(mcp, get_token):
         device-code flow.
     """
 
+    @asynccontextmanager
+    async def viya_session(name: str, ctx: Context) -> AsyncIterator[httpx.AsyncClient]:
+        """Log tool usage, resolve a Viya token, and yield an authed client.
+
+        Collapses the per-tool preamble (log line + token fetch + client
+        construction) into one context manager shared by every tool.
+        """
+        logger.info("--- TOOL USED: %s ---", name)
+        token = await get_token(ctx)
+        async with make_client(token) as client:
+            yield client
+
     # ------------------------------------------------------------------
     # Original tool
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    async def execute_sas_code(sas_code: str, ctx: Context) -> ToolResult:
+    async def execute_sas_code(sas_code: str, ctx: Context) -> dict[str, str]:
         """
         Executes the provided SAS code in the Viya environment and returns information about the completed Job.
         This will create a job definition for the SAS code, execute it, and then retrieve the results.
@@ -49,52 +68,47 @@ def register_tools(mcp, get_token):
             sas_code (str): the SAS code snippet to be executed using the Viya Job Execution API Service
 
         Returns:
-            Structured output data containing detailed information about the executed sas code.
-            This includes a listing field and a log field. The listing output represents the intended output
-            of the SAS code when executed, if the code ran successfully. The log output represents information
-            about the execution of the sas code, such as if it ran successfully or not and whether or not there are
-            errors or issues with the execution.
-
+            A dictionary with four string fields describing the executed job:
+            ``snippet_id`` (the job's snippet identifier), ``state`` (the final
+            job state, e.g. ``completed``/``error``/``warning``), ``log`` (the
+            full SAS log — execution details, notes, and any errors/warnings),
+            and ``listing`` (the SAS listing output, i.e. the intended results
+            when the code ran successfully).
         """
         logger.info("--- TOOL USED: execute_sas_code ---")
         token = await get_token(ctx)
-        output = await run_one_snippet(sas_code, "1", token)
-        return output
+        return await run_one_snippet(sas_code, "1", token)
 
     # ------------------------------------------------------------------
     # Tier 1 — Data Discovery (CAS Management)
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    async def list_cas_servers(ctx: Context) -> list:
+    async def list_cas_servers(ctx: Context) -> list[dict[str, Any]]:
         """List available CAS servers on the Viya environment."""
-        logger.info("--- TOOL USED: list_cas_servers ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items("/casManagement/servers", client)
+        async with viya_session("list_cas_servers", ctx) as client:
+            items, _ = await get_paged_items("/casManagement/servers", client)
             return [{"name": s.get("name"), "id": s.get("id"),
                      "description": s.get("description", "")} for s in items]
 
     @mcp.tool()
     async def list_caslibs(server_id: str, ctx: Context,
-                           limit: int = 50) -> list:
+                           limit: int = 50) -> list[dict[str, Any]]:
         """List CAS libraries (caslibs) available on a CAS server.
 
         Args:
             server_id: CAS server name or ID (e.g. 'cas-shared-default').
             limit: Maximum number of caslibs to return (default 50).
         """
-        logger.info("--- TOOL USED: list_caslibs ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items(
+        async with viya_session("list_caslibs", ctx) as client:
+            items, _ = await get_paged_items(
                 f"/casManagement/servers/{server_id}/caslibs", client, limit=limit)
             return [{"name": c.get("name"), "type": c.get("type", ""),
                      "description": c.get("description", "")} for c in items]
 
     @mcp.tool()
     async def list_castables(server_id: str, caslib_name: str, ctx: Context,
-                             limit: int = 50) -> list:
+                             limit: int = 50) -> list[dict[str, Any]]:
         """List tables in a CAS library.
 
         Args:
@@ -102,10 +116,8 @@ def register_tools(mcp, get_token):
             caslib_name: Name of the caslib.
             limit: Maximum number of tables to return (default 50).
         """
-        logger.info("--- TOOL USED: list_castables ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items(
+        async with viya_session("list_castables", ctx) as client:
+            items, _ = await get_paged_items(
                 f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables",
                 client, limit=limit)
             return [{"name": t.get("name"),
@@ -113,8 +125,30 @@ def register_tools(mcp, get_token):
                      "columnCount": t.get("columnCount")} for t in items]
 
     @mcp.tool()
+    async def list_source_tables(server_id: str, caslib_name: str, ctx: Context,
+                                 limit: int = 50) -> list[dict[str, Any]]:
+        """List source tables that are NOT yet loaded into memory in a CAS library.
+
+        These are the candidates for ``promote_table_to_memory`` — tables that
+        exist on the caslib's data source but are not in CAS memory yet.
+
+        Args:
+            server_id: CAS server name or ID.
+            caslib_name: Name of the caslib.
+            limit: Maximum number of tables to return (default 50).
+        """
+        async with viya_session("list_source_tables", ctx) as client:
+            items, _ = await get_paged_items(
+                f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables",
+                client, limit=limit, extra_params={"state": "unloaded"})
+            return [{"name": t.get("name"),
+                     "sourceTableName": t.get("sourceTableName"),
+                     "scope": t.get("scope"),
+                     "state": t.get("state", "unloaded")} for t in items]
+
+    @mcp.tool()
     async def get_castable_info(server_id: str, caslib_name: str,
-                                table_name: str, ctx: Context) -> dict:
+                                table_name: str, ctx: Context) -> dict[str, Any]:
         """Get metadata for a CAS table (row count, column count, size, etc.).
 
         Args:
@@ -122,17 +156,15 @@ def register_tools(mcp, get_token):
             caslib_name: Name of the caslib.
             table_name: Name of the table.
         """
-        logger.info("--- TOOL USED: get_castable_info ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            return await _get_json(
+        async with viya_session("get_castable_info", ctx) as client:
+            return await get_json(
                 f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}",
                 client)
 
     @mcp.tool()
     async def get_castable_columns(server_id: str, caslib_name: str,
                                    table_name: str, ctx: Context,
-                                   limit: int = 200) -> list:
+                                   limit: int = 200) -> list[dict[str, Any]]:
         """Get column metadata for a CAS table (names, types, labels, formats).
 
         Args:
@@ -141,10 +173,8 @@ def register_tools(mcp, get_token):
             table_name: Name of the table.
             limit: Maximum columns to return (default 200).
         """
-        logger.info("--- TOOL USED: get_castable_columns ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items(
+        async with viya_session("get_castable_columns", ctx) as client:
+            items, _ = await get_paged_items(
                 f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}/columns",
                 client, limit=limit)
             return [{"name": c.get("name"), "type": c.get("type"),
@@ -155,7 +185,7 @@ def register_tools(mcp, get_token):
     @mcp.tool()
     async def get_castable_data(server_id: str, caslib_name: str,
                                 table_name: str, ctx: Context,
-                                limit: int = 100, start: int = 0) -> dict:
+                                limit: int = 100, start: int = 0) -> dict[str, Any]:
         """Fetch rows from a CAS table with column names.
 
         Args:
@@ -165,13 +195,10 @@ def register_tools(mcp, get_token):
             limit: Maximum rows to return (default 100).
             start: Row offset (default 0).
         """
-        logger.info("--- TOOL USED: get_castable_data ---")
-        token = await get_token(ctx)
-        from .viya_utils import VIYA_ENDPOINT
         data_source_id = f"cas~fs~{server_id}~fs~{caslib_name}"
         table_id = f"cas~fs~{server_id}~fs~{caslib_name}~fs~{table_name}"
-        async with _make_client(token) as client:
-            columns = []
+        async with viya_session("get_castable_data", ctx) as client:
+            columns: list[dict[str, Any]] = []
             col_start = 0
             col_limit = 100
             while True:
@@ -202,7 +229,7 @@ def register_tools(mcp, get_token):
             rows = []
             for item in row_data.get("items", []):
                 cells = item.get("cells", [])
-                rows.append(dict(zip(col_names, cells)))
+                rows.append(dict(zip(col_names, cells, strict=False)))
 
             return {
                 "columns": col_names,
@@ -218,7 +245,7 @@ def register_tools(mcp, get_token):
 
     @mcp.tool()
     async def upload_data(server_id: str, caslib_name: str, table_name: str,
-                          csv_data: str, ctx: Context) -> dict:
+                          csv_data: str, ctx: Context) -> dict[str, Any]:
         """Upload CSV data into a CAS table.
 
         Args:
@@ -227,10 +254,7 @@ def register_tools(mcp, get_token):
             table_name: Name for the new table.
             csv_data: CSV-formatted data string (including header row).
         """
-        logger.info("--- TOOL USED: upload_data ---")
-        token = await get_token(ctx)
-        from .viya_utils import VIYA_ENDPOINT
-        async with _make_client(token) as client:
+        async with viya_session("upload_data", ctx) as client:
             resp = await client.post(
                 f"{VIYA_ENDPOINT}/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables",
                 data={
@@ -245,7 +269,10 @@ def register_tools(mcp, get_token):
                     "status": "table_already_exists",
                     "table_name": table_name,
                     "caslib": caslib_name,
-                    "message": f"Table '{table_name}' already exists in caslib '{caslib_name}'. Drop or rename before re-uploading.",
+                    "message": (
+                        f"Table '{table_name}' already exists in caslib "
+                        f"'{caslib_name}'. Drop or rename before re-uploading."
+                    ),
                 }
             resp.raise_for_status()
             body = resp.json()
@@ -260,48 +287,80 @@ def register_tools(mcp, get_token):
 
     @mcp.tool()
     async def promote_table_to_memory(server_id: str, caslib_name: str,
-                                      table_name: str, ctx: Context) -> dict:
-        """Promote a CAS table to global scope (makes it visible to all sessions).
+                                      table_name: str, ctx: Context) -> dict[str, Any]:
+        """Load a source table into CAS memory at global scope (visible to all sessions).
+
+        Loads the table from its caslib data source and promotes it to global
+        scope via the casManagement ``updateTableState`` API. Idempotent: if the
+        table is already loaded in global scope it is left untouched. Use
+        ``list_source_tables`` to discover unloaded tables that can be promoted.
 
         Args:
             server_id: CAS server name or ID.
             caslib_name: Caslib containing the table.
-            table_name: Table to promote.
+            table_name: Table to load and promote.
         """
-        logger.info("--- TOOL USED: promote_table_to_memory ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
+        table_path = (
+            f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}"
+        )
+        async with viya_session("promote_table_to_memory", ctx) as client:
+            # Idempotency: skip if the table is already loaded in global scope.
             try:
-                return await _post_json(
-                    f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}",
-                    client, body={"scope": "global"})
-            except _httpx.HTTPStatusError as e:
-                if e.response.status_code == 409:
-                    return {"status": "already_promoted", "table": f"{caslib_name}.{table_name}"}
+                info = await get_json(table_path, client)
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    return {
+                        "status": "not_found",
+                        "table": f"{caslib_name}.{table_name}",
+                        "message": (
+                            f"No table '{table_name}' in caslib '{caslib_name}'. "
+                            "Use list_source_tables to find loadable source tables."
+                        ),
+                    }
                 raise
+            if info.get("state") == "loaded" and info.get("scope") == "global":
+                return {
+                    "status": "already_global",
+                    "table": f"{caslib_name}.{table_name}",
+                    "state": "loaded",
+                    "scope": "global",
+                }
+
+            # Load from source and promote to global scope. The updateTableState
+            # endpoint responds with text/plain (the new state), not JSON.
+            resp = await client.put(
+                f"{VIYA_ENDPOINT}{table_path}/state",
+                params={"value": "loaded", "scope": "global"},
+                headers={"Accept": "*/*"},
+            )
+            resp.raise_for_status()
+            return {
+                "status": "promoted",
+                "table": f"{caslib_name}.{table_name}",
+                "state": resp.text.strip() or "loaded",
+                "scope": "global",
+            }
 
     @mcp.tool()
     async def list_files(ctx: Context, limit: int = 50,
-                         filter_name: Optional[str] = None) -> list:
+                         filter_name: str | None = None) -> list[dict[str, Any]]:
         """List files in the Viya Files Service.
 
         Args:
             limit: Maximum files to return (default 50).
             filter_name: Optional name filter (substring match).
         """
-        logger.info("--- TOOL USED: list_files ---")
-        token = await get_token(ctx)
         filters = f"contains(name,'{filter_name}')" if filter_name else None
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items("/files/files", client,
-                                              limit=limit, filters=filters)
+        async with viya_session("list_files", ctx) as client:
+            items, _ = await get_paged_items("/files/files", client,
+                                             limit=limit, filters=filters)
             return [{"id": f.get("id"), "name": f.get("name"),
                      "contentType": f.get("contentType", ""),
                      "size": f.get("size")} for f in items]
 
     @mcp.tool()
     async def upload_file(file_name: str, content: str, ctx: Context,
-                          content_type: str = "text/plain") -> dict:
+                          content_type: str = "text/plain") -> dict[str, Any]:
         """Upload a file to the Viya Files Service.
 
         Args:
@@ -309,10 +368,7 @@ def register_tools(mcp, get_token):
             content: File content as a string.
             content_type: MIME type (default 'text/plain').
         """
-        logger.info("--- TOOL USED: upload_file ---")
-        token = await get_token(ctx)
-        from .viya_utils import VIYA_ENDPOINT
-        async with _make_client(token) as client:
+        async with viya_session("upload_file", ctx) as client:
             resp = await client.post(
                 f"{VIYA_ENDPOINT}/files/files",
                 content=content.encode("utf-8"),
@@ -329,10 +385,7 @@ def register_tools(mcp, get_token):
         Args:
             file_id: ID of the file to download.
         """
-        logger.info("--- TOOL USED: download_file ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            from .viya_utils import VIYA_ENDPOINT
+        async with viya_session("download_file", ctx) as client:
             resp = await client.get(f"{VIYA_ENDPOINT}/files/files/{file_id}/content")
             resp.raise_for_status()
             return resp.text
@@ -343,39 +396,35 @@ def register_tools(mcp, get_token):
 
     @mcp.tool()
     async def list_reports(ctx: Context, limit: int = 50,
-                           filter_name: Optional[str] = None) -> list:
+                           filter_name: str | None = None) -> list[dict[str, Any]]:
         """List Visual Analytics reports.
 
         Args:
             limit: Maximum reports to return (default 50).
             filter_name: Optional name filter (substring match).
         """
-        logger.info("--- TOOL USED: list_reports ---")
-        token = await get_token(ctx)
         filters = f"contains(name,'{filter_name}')" if filter_name else None
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items("/reports/reports", client,
-                                              limit=limit, filters=filters)
+        async with viya_session("list_reports", ctx) as client:
+            items, _ = await get_paged_items("/reports/reports", client,
+                                             limit=limit, filters=filters)
             return [{"id": r.get("id"), "name": r.get("name"),
                      "description": r.get("description", ""),
                      "createdBy": r.get("createdBy", "")} for r in items]
 
     @mcp.tool()
-    async def get_report(report_id: str, ctx: Context) -> dict:
+    async def get_report(report_id: str, ctx: Context) -> dict[str, Any]:
         """Get a Visual Analytics report's metadata and definition.
 
         Args:
             report_id: ID of the report.
         """
-        logger.info("--- TOOL USED: get_report ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            return await _get_json(f"/reports/reports/{report_id}", client)
+        async with viya_session("get_report", ctx) as client:
+            return await get_json(f"/reports/reports/{report_id}", client)
 
     @mcp.tool()
     async def get_report_image(report_id: str, ctx: Context,
                                image_type: str = "png",
-                               section_index: int = 0) -> dict:
+                               section_index: int = 0) -> dict[str, Any]:
         """Render a Visual Analytics report section as an image.
 
         Args:
@@ -383,11 +432,7 @@ def register_tools(mcp, get_token):
             image_type: Image format — 'png' or 'svg' (default 'png').
             section_index: Report section/page index (default 0).
         """
-        logger.info("--- TOOL USED: get_report_image ---")
-        token = await get_token(ctx)
-        import json as _json
-        from .viya_utils import VIYA_ENDPOINT
-        async with _make_client(token) as client:
+        async with viya_session("get_report_image", ctx) as client:
             body = {
                 "reportUri": f"/reports/reports/{report_id}",
                 "layoutType": "thumbnail",
@@ -398,7 +443,7 @@ def register_tools(mcp, get_token):
             }
             resp = await client.post(
                 f"{VIYA_ENDPOINT}/reportImages/jobs",
-                content=_json.dumps(body).encode(),
+                content=json.dumps(body).encode(),
                 headers={
                     "Content-Type": "application/vnd.sas.report.images.job.request+json",
                     "Accept": "application/vnd.sas.report.images.job+json",
@@ -413,16 +458,13 @@ def register_tools(mcp, get_token):
 
     @mcp.tool()
     async def submit_batch_job(sas_code: str, ctx: Context,
-                               job_name: Optional[str] = None) -> dict:
+                               job_name: str | None = None) -> dict[str, Any]:
         """Submit a SAS job for asynchronous execution via the Job Execution service.
 
         Args:
             sas_code: SAS code to execute.
             job_name: Optional descriptive name for the job.
         """
-        logger.info("--- TOOL USED: submit_batch_job ---")
-        token = await get_token(ctx)
-        from .viya_utils import CONTEXT_NAME
         body = {
             "name": job_name or "mcp-batch-job",
             "jobDefinition": {
@@ -433,33 +475,29 @@ def register_tools(mcp, get_token):
                 "_contextName": CONTEXT_NAME,
             },
         }
-        async with _make_client(token) as client:
-            return await _post_json("/jobExecution/jobs", client, body=body)
+        async with viya_session("submit_batch_job", ctx) as client:
+            return await post_json("/jobExecution/jobs", client, body=body)
 
     @mcp.tool()
-    async def get_job_status(job_id: str, ctx: Context) -> dict:
+    async def get_job_status(job_id: str, ctx: Context) -> dict[str, Any]:
         """Check the status of a submitted job.
 
         Args:
             job_id: ID of the job.
         """
-        logger.info("--- TOOL USED: get_job_status ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            return await _get_json(f"/jobExecution/jobs/{job_id}", client)
+        async with viya_session("get_job_status", ctx) as client:
+            return await get_json(f"/jobExecution/jobs/{job_id}", client)
 
     @mcp.tool()
-    async def list_jobs(ctx: Context, limit: int = 20) -> list:
+    async def list_jobs(ctx: Context, limit: int = 20) -> list[dict[str, Any]]:
         """List recent jobs from the Job Execution service.
 
         Args:
             limit: Maximum jobs to return (default 20).
         """
-        logger.info("--- TOOL USED: list_jobs ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items("/jobExecution/jobs", client,
-                                              limit=limit)
+        async with viya_session("list_jobs", ctx) as client:
+            items, _ = await get_paged_items("/jobExecution/jobs", client,
+                                             limit=limit)
             return [{"id": j.get("id"), "name": j.get("name", ""),
                      "state": j.get("state", ""),
                      "creationTimeStamp": j.get("creationTimeStamp", "")} for j in items]
@@ -471,10 +509,8 @@ def register_tools(mcp, get_token):
         Args:
             job_id: ID of the job to cancel.
         """
-        logger.info("--- TOOL USED: cancel_job ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            await _delete_resource(f"/jobExecution/jobs/{job_id}", client)
+        async with viya_session("cancel_job", ctx) as client:
+            await delete_resource(f"/jobExecution/jobs/{job_id}", client)
             return f"Job {job_id} cancelled."
 
     @mcp.tool()
@@ -484,11 +520,8 @@ def register_tools(mcp, get_token):
         Args:
             job_id: ID of the job.
         """
-        logger.info("--- TOOL USED: get_job_log ---")
-        token = await get_token(ctx)
-        from .viya_utils import VIYA_ENDPOINT
-        async with _make_client(token) as client:
-            data = await _get_json(f"/jobExecution/jobs/{job_id}", client)
+        async with viya_session("get_job_log", ctx) as client:
+            data = await get_json(f"/jobExecution/jobs/{job_id}", client)
             results = data.get("results", {})
 
             log_uri = None
@@ -518,42 +551,53 @@ def register_tools(mcp, get_token):
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    async def list_ml_projects(ctx: Context, limit: int = 50) -> list:
+    async def list_ml_projects(ctx: Context, limit: int = 50) -> list[dict[str, Any]]:
         """List AutoML pipeline automation projects.
 
         Args:
             limit: Maximum projects to return (default 50).
         """
-        logger.info("--- TOOL USED: list_ml_projects ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items(
+        async with viya_session("list_ml_projects", ctx) as client:
+            items, _ = await get_paged_items(
                 "/mlPipelineAutomation/projects", client, limit=limit)
             return [{"id": p.get("id"), "name": p.get("name", ""),
                      "state": p.get("state", ""),
                      "description": p.get("description", "")} for p in items]
 
     @mcp.tool()
-    async def create_ml_project(project_name: str, data_table_uri: str,
+    async def create_ml_project(project_name: str, caslib_name: str, table_name: str,
                                 target_variable: str, ctx: Context,
+                                server_id: str = "cas-shared-default",
                                 description: str = "",
                                 prediction_type: str = "binary",
                                 target_event_level: str = "1",
-                                auto_run: bool = True) -> dict:
-        """Create a new AutoML pipeline automation project.
+                                auto_run: bool = True) -> dict[str, Any]:
+        """Create a new AutoML pipeline automation project from a CAS table.
+
+        The training table must already be loaded into CAS memory at **global**
+        scope. This tool verifies that first and returns an actionable error
+        otherwise (use ``promote_table_to_memory`` to load + promote a source
+        table, and ``list_source_tables`` to find one). The data-table URI is
+        built from ``server_id``/``caslib_name``/``table_name``.
 
         Args:
             project_name: Name for the project.
-            data_table_uri: URI of the training data table (e.g. '/dataTables/dataSources/cas~fs~cas-shared-default~fs~Public/tables/HMEQ').
+            caslib_name: Caslib containing the training table.
+            table_name: Name of the (loaded, global) training table.
             target_variable: Name of the target/response variable.
+            server_id: CAS server name or ID (default 'cas-shared-default').
             description: Optional project description.
             prediction_type: 'binary', 'interval', or 'nominal' (default 'binary').
             target_event_level: Target event level for binary/nominal classification (default '1').
             auto_run: Whether to automatically run pipelines after creation (default True).
         """
-        logger.info("--- TOOL USED: create_ml_project ---")
-        token = await get_token(ctx)
-        analytics_attrs = {
+        table_path = (
+            f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}"
+        )
+        data_table_uri = (
+            f"/dataTables/dataSources/cas~fs~{server_id}~fs~{caslib_name}/tables/{table_name}"
+        )
+        analytics_attrs: dict[str, Any] = {
             "targetVariable": target_variable,
             "targetLevel": prediction_type,
             "partitionEnabled": True,
@@ -574,22 +618,46 @@ def register_tools(mcp, get_token):
             },
             "analyticsProjectAttributes": analytics_attrs,
         }
-        async with _make_client(token) as client:
-            return await _post_json("/mlPipelineAutomation/projects", client, body=body)
+        async with viya_session("create_ml_project", ctx) as client:
+            # Pre-flight: the training table must be loaded in global scope, or
+            # mlPipelineAutomation fails opaquely later.
+            try:
+                info = await get_json(table_path, client)
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    return {
+                        "status": "table_not_found",
+                        "table": f"{caslib_name}.{table_name}",
+                        "message": (
+                            f"Table '{table_name}' not found in caslib '{caslib_name}' on "
+                            f"server '{server_id}'. Load and promote it with "
+                            "promote_table_to_memory (see list_source_tables)."
+                        ),
+                    }
+                raise
+            if not (info.get("state") == "loaded" and info.get("scope") == "global"):
+                return {
+                    "status": "table_not_global",
+                    "table": f"{caslib_name}.{table_name}",
+                    "state": info.get("state"),
+                    "scope": info.get("scope"),
+                    "message": (
+                        "The training table must be loaded in global scope before "
+                        "creating an ML project. Use promote_table_to_memory to load "
+                        "and promote it."
+                    ),
+                }
+            return await post_json("/mlPipelineAutomation/projects", client, body=body)
 
     @mcp.tool()
-    async def run_ml_project(project_id: str, ctx: Context) -> dict:
+    async def run_ml_project(project_id: str, ctx: Context) -> dict[str, Any]:
         """Run an AutoML pipeline automation project.
 
         Args:
             project_id: ID of the project to run.
         """
-        logger.info("--- TOOL USED: run_ml_project ---")
-        token = await get_token(ctx)
-        import json as _json
-        from .viya_utils import VIYA_ENDPOINT
         mlpa_type = "application/vnd.sas.analytics.ml.pipeline.automation.project+json"
-        async with _make_client(token) as client:
+        async with viya_session("run_ml_project", ctx) as client:
             get_resp = await client.get(
                 f"{VIYA_ENDPOINT}/mlPipelineAutomation/projects/{project_id}",
                 headers={"Accept": mlpa_type},
@@ -600,7 +668,7 @@ def register_tools(mcp, get_token):
             resp = await client.put(
                 f"{VIYA_ENDPOINT}/mlPipelineAutomation/projects/{project_id}",
                 params={"action": "retrainProject"},
-                content=_json.dumps(project_body).encode(),
+                content=json.dumps(project_body).encode(),
                 headers={
                     "Content-Type": mlpa_type,
                     "Accept": mlpa_type,
@@ -614,39 +682,35 @@ def register_tools(mcp, get_token):
             return resp.json()
 
     @mcp.tool()
-    async def list_registered_models(ctx: Context, limit: int = 50) -> list:
+    async def list_registered_models(ctx: Context, limit: int = 50) -> list[dict[str, Any]]:
         """List models in the Model Repository.
 
         Args:
             limit: Maximum models to return (default 50).
         """
-        logger.info("--- TOOL USED: list_registered_models ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items("/modelRepository/models", client,
-                                              limit=limit)
+        async with viya_session("list_registered_models", ctx) as client:
+            items, _ = await get_paged_items("/modelRepository/models", client,
+                                             limit=limit)
             return [{"id": m.get("id"), "name": m.get("name", ""),
                      "description": m.get("description", ""),
                      "modelVersionName": m.get("modelVersionName", "")} for m in items]
 
     @mcp.tool()
-    async def list_models_and_decisions(ctx: Context, limit: int = 50) -> list:
+    async def list_models_and_decisions(ctx: Context, limit: int = 50) -> list[dict[str, Any]]:
         """List published scoring models and decisions (MAS modules).
 
         Args:
             limit: Maximum modules to return (default 50).
         """
-        logger.info("--- TOOL USED: list_models_and_decisions ---")
-        token = await get_token(ctx)
-        async with _make_client(token) as client:
-            items, _ = await _get_paged_items("/microanalyticScore/modules", client,
-                                              limit=limit)
+        async with viya_session("list_models_and_decisions", ctx) as client:
+            items, _ = await get_paged_items("/microanalyticScore/modules", client,
+                                             limit=limit)
             return [{"id": m.get("id"), "name": m.get("name", ""),
                      "description": m.get("description", "")} for m in items]
 
     @mcp.tool()
     async def score_data(module_id: str, step_id: str, input_data: dict,
-                         ctx: Context) -> dict:
+                         ctx: Context) -> dict[str, Any]:
         """Score data against a published model or decision (MAS module).
 
         Args:
@@ -654,10 +718,8 @@ def register_tools(mcp, get_token):
             step_id: Step ID within the module (usually 'score' or 'execute').
             input_data: Dictionary of input variable name-value pairs.
         """
-        logger.info("--- TOOL USED: score_data ---")
-        token = await get_token(ctx)
         body = {"inputs": [{"name": k, "value": v} for k, v in input_data.items()]}
-        async with _make_client(token) as client:
-            return await _post_json(
+        async with viya_session("score_data", ctx) as client:
+            return await post_json(
                 f"/microanalyticScore/modules/{module_id}/steps/{step_id}", client,
                 body=body)

--- a/src/sas_mcp_server/viya_client.py
+++ b/src/sas_mcp_server/viya_client.py
@@ -1,0 +1,97 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic SAS Viya REST helpers.
+
+These functions wrap the common request shapes used by the MCP tools (GET a
+JSON document, GET a paginated collection, POST JSON, DELETE a resource) and
+build the authenticated :class:`httpx.AsyncClient`. They are the public,
+cross-module API of this package — ``tools.py`` and ``viya_utils.py`` both
+depend on them. The shared :data:`logger` lives here as the lowest-level module
+(above only :mod:`sas_mcp_server.config`) so every other module can import it
+without creating an import cycle.
+"""
+
+from typing import Any
+
+import httpx
+from fastmcp.utilities.logging import get_logger
+
+from .config import SSL_VERIFY, VIYA_ENDPOINT
+
+logger = get_logger(__name__)
+
+# Viya REST calls can be slow (compute session spin-up, large log fetches);
+# give them a generous client timeout.
+_CLIENT_TIMEOUT = 300.0
+
+JSONDict = dict[str, Any]
+
+
+async def get_json(
+    url: str,
+    client: httpx.AsyncClient,
+    params: dict[str, Any] | None = None,
+    accept: str = "application/json",
+) -> JSONDict:
+    """GET a JSON response from a Viya REST endpoint."""
+    full_url = f"{VIYA_ENDPOINT}{url}"
+    resp = await client.get(full_url, headers={"Accept": accept}, params=params or {})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def get_paged_items(
+    url: str,
+    client: httpx.AsyncClient,
+    limit: int = 20,
+    start: int = 0,
+    filters: str | None = None,
+    extra_params: dict[str, Any] | None = None,
+) -> tuple[list[JSONDict], int]:
+    """GET a paginated collection and return the items list plus total count."""
+    params: dict[str, Any] = {"start": start, "limit": limit}
+    if filters:
+        params["filter"] = filters
+    if extra_params:
+        params.update(extra_params)
+    data = await get_json(
+        url, client, params=params, accept="application/vnd.sas.collection+json"
+    )
+    return data.get("items", []), data.get("count", 0)
+
+
+async def post_json(
+    url: str,
+    client: httpx.AsyncClient,
+    body: Any | None = None,
+    params: dict[str, Any] | None = None,
+    accept: str = "application/json",
+) -> JSONDict:
+    """POST JSON to a Viya REST endpoint and return the response JSON."""
+    full_url = f"{VIYA_ENDPOINT}{url}"
+    resp = await client.post(
+        full_url,
+        json=body,
+        headers={"Content-Type": "application/json", "Accept": accept},
+        params=params or {},
+    )
+    resp.raise_for_status()
+    if resp.status_code == 204 or not resp.content:
+        return {}
+    return resp.json()
+
+
+async def delete_resource(url: str, client: httpx.AsyncClient) -> None:
+    """DELETE a Viya REST resource."""
+    full_url = f"{VIYA_ENDPOINT}{url}"
+    resp = await client.delete(full_url)
+    resp.raise_for_status()
+
+
+def make_client(token: str) -> httpx.AsyncClient:
+    """Create an :class:`httpx.AsyncClient` with auth headers for Viya API calls."""
+    if not token.startswith("Bearer "):
+        token = f"Bearer {token}"
+    headers = {"Authorization": token}
+    return httpx.AsyncClient(headers=headers, verify=SSL_VERIFY, timeout=_CLIENT_TIMEOUT)

--- a/src/sas_mcp_server/viya_utils.py
+++ b/src/sas_mcp_server/viya_utils.py
@@ -1,155 +1,25 @@
 # Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""SAS Viya compute session and job orchestration.
+
+These helpers drive the Compute service end to end: resolve a compute context,
+open a session, submit code, poll for completion, and tear the session down.
+``run_one_snippet`` is the public entry point used by the ``execute_sas_code``
+MCP tool. Generic REST helpers and the shared client/logger live in
+:mod:`sas_mcp_server.viya_client`.
+"""
+
 import asyncio
+
 import httpx
-from fastmcp.utilities.logging import get_logger
-from .config import VIYA_ENDPOINT, CONTEXT_NAME, SSL_VERIFY
 
-logger = get_logger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Generic API helpers (used by new tools)
-# ---------------------------------------------------------------------------
-
-async def _get_json(url, client, params=None, accept="application/json"):
-    """GET a JSON response from a Viya REST endpoint."""
-    full_url = f"{VIYA_ENDPOINT}{url}"
-    resp = await client.get(full_url, headers={"Accept": accept}, params=params or {})
-    resp.raise_for_status()
-    return resp.json()
+from .config import CONTEXT_NAME, VIYA_ENDPOINT
+from .viya_client import logger, make_client
 
 
-async def _get_paged_items(url, client, limit=20, start=0, filters=None, extra_params=None):
-    """GET a paginated collection and return the items list plus total count."""
-    params = {"start": start, "limit": limit}
-    if filters:
-        params["filter"] = filters
-    if extra_params:
-        params.update(extra_params)
-    data = await _get_json(url, client, params=params,
-                           accept="application/vnd.sas.collection+json")
-    return data.get("items", []), data.get("count", 0)
-
-
-async def _post_json(url, client, body=None, params=None, accept="application/json"):
-    """POST JSON to a Viya REST endpoint and return the response JSON."""
-    full_url = f"{VIYA_ENDPOINT}{url}"
-    resp = await client.post(full_url, json=body,
-                             headers={"Content-Type": "application/json",
-                                      "Accept": accept},
-                             params=params or {})
-    resp.raise_for_status()
-    if resp.status_code == 204 or not resp.content:
-        return {}
-    return resp.json()
-
-
-async def _put_data(url, client, data, content_type="text/csv", params=None):
-    """PUT raw data (e.g. CSV upload) to a Viya REST endpoint."""
-    full_url = f"{VIYA_ENDPOINT}{url}"
-    resp = await client.put(full_url, content=data,
-                            headers={"Content-Type": content_type},
-                            params=params or {})
-    resp.raise_for_status()
-    if resp.status_code == 204 or not resp.content:
-        return {}
-    return resp.json()
-
-
-async def _delete_resource(url, client):
-    """DELETE a Viya REST resource."""
-    full_url = f"{VIYA_ENDPOINT}{url}"
-    resp = await client.delete(full_url)
-    resp.raise_for_status()
-
-
-def _make_client(token):
-    """Create an httpx.AsyncClient with auth headers for Viya API calls."""
-    if not token.startswith("Bearer "):
-        token = f"Bearer {token}"
-    headers = {"Authorization": token}
-    return httpx.AsyncClient(headers=headers, verify=SSL_VERIFY, timeout=300.0)
-
-
-# ---------------------------------------------------------------------------
-# Original helpers (log/listing fetching)
-# ---------------------------------------------------------------------------
-
-async def _get_text(url, client, verify=True, extra_params=None):
-    # Try text/plain in one shot
-    full_url = f"{VIYA_ENDPOINT}{url}"
-    r = await client.get(
-        full_url, headers={"Accept": "text/plain"}, params=extra_params or {}
-    )
-    if r.status_code == 200 and r.headers.get("Content-Type", "").startswith(
-        "text/plain"
-    ):
-        return r.text
-    # Some deployments need an explicit query hint
-    r = await client.get(
-        full_url,
-        headers={"Accept": "text/plain"},
-        params={**(extra_params or {}), "type": "text"},
-    )
-    if r.status_code == 200 and r.headers.get("Content-Type", "").startswith(
-        "text/plain"
-    ):
-        return r.text
-    return None  # caller will fallback to paged JSON
-
-
-async def _get_paged_lines(url, client, page_limit=10000):
-    start = 0
-    lines = []
-    headers = {"Accept": "application/vnd.sas.collection+json"}
-    full_url = f"{VIYA_ENDPOINT}{url}"
-    while True:
-        resp = await client.get(
-            full_url, headers=headers, params={"start": start, "limit": page_limit}
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        items = data.get("items", [])
-        if not items:
-            break
-        # items can be dicts like {"line": "..."} or {"text": "..."} depending on endpoint
-        for it in items:
-            lines.append(it.get("line") or it.get("text") or "")
-        if len(items) < page_limit:
-            break
-        start += page_limit
-    return "\n".join(lines)
-
-
-async def fetch_full_job_log(client, session_id, job_id):
-    base = f"/compute/sessions/{session_id}/jobs/{job_id}"
-    # 1) Try whole job log as text
-    text = await _get_text(f"{base}/log", client)
-    if text is not None:
-        return text
-    # 2) Fallback to paged JSON
-    return await _get_paged_lines(f"{base}/log", client)
-
-
-async def fetch_full_job_listing(client, session_id, job_id):
-    base = f"/compute/sessions/{session_id}/jobs/{job_id}"
-    text = await _get_text(f"{base}/listing", client)
-    if text is not None:
-        return text
-    return await _get_paged_lines(f"{base}/listing", client)
-
-
-async def fetch_full_session_log(client, session_id):
-    # Entire session log (useful if you want everything the session produced)
-    text = await _get_text(f"/compute/sessions/{session_id}/log", client)
-    if text is not None:
-        return text
-    return await _get_paged_lines(f"/compute/sessions/{session_id}/log", client)
-
-
-async def get_context_id(client, context_name):
+async def get_context_id(client: httpx.AsyncClient, context_name: str) -> str:
+    """Return the id of the named compute context, raising if it is absent."""
     url = f"{VIYA_ENDPOINT}/compute/contexts?name={context_name}"
     resp = await client.get(url)
     coll = resp.json()
@@ -159,13 +29,17 @@ async def get_context_id(client, context_name):
     return items[0]["id"]
 
 
-async def create_session(client, context_id, name="py-parallel"):
+async def create_session(
+    client: httpx.AsyncClient, context_id: str, name: str = "py-parallel"
+) -> str:
+    """Create a compute session in *context_id* and return its id."""
     url = f"{VIYA_ENDPOINT}/compute/contexts/{context_id}/sessions"
     resp = await client.post(url, json={"name": name})
     return resp.json()["id"]
 
 
-async def submit_job(client, session_id, code):
+async def submit_job(client: httpx.AsyncClient, session_id: str, code: str) -> str:
+    """Submit *code* as a job in *session_id* and return the job id."""
     body = {"code": code.splitlines()}
     url = f"{VIYA_ENDPOINT}/compute/sessions/{session_id}/jobs"
     resp = await client.post(url, json=body)
@@ -173,7 +47,10 @@ async def submit_job(client, session_id, code):
     return job["id"]
 
 
-async def wait_job(client, session_id, job_id, poll=2):
+async def wait_job(
+    client: httpx.AsyncClient, session_id: str, job_id: str, poll: float = 2
+) -> tuple[str, str, str]:
+    """Poll *job_id* until it reaches a terminal state; return (state, log, listing)."""
     while True:
         state_url = f"{VIYA_ENDPOINT}/compute/sessions/{session_id}/jobs/{job_id}/state"
         resp = await client.get(state_url)
@@ -201,29 +78,41 @@ async def wait_job(client, session_id, job_id, poll=2):
         await asyncio.sleep(poll)
 
 
-async def run_one_snippet(snippet_data, snippet_id, token):
+async def run_one_snippet(
+    snippet_data: str, snippet_id: str, token: str
+) -> dict[str, str]:
+    """Execute one SAS snippet end to end and return its structured result.
+
+    Returns a dict with keys ``snippet_id``, ``state``, ``log`` and ``listing``.
+    The compute session is always torn down in a ``finally`` block.
+    """
     code = snippet_data
 
-    logger.info(f"Creating session with token (length: {len(token)})")
+    logger.info("Creating session with token (length: %d)", len(token))
 
-    async with _make_client(token) as client:
+    async with make_client(token) as client:
         ctx_id = await get_context_id(client, CONTEXT_NAME)
         sid = await create_session(client, ctx_id, name="py-parallel")
-        logger.info(f"Session created: {sid}")
+        logger.info("Session created: %s", sid)
         try:
             jid = await submit_job(client, sid, code)
-            logger.info(f"Job submitted: {jid}")
-            result = await wait_job(client, sid, jid)
-            logger.info(f"Job completed: {result[0]}")
-            return (snippet_id, *result)
-        except Exception as e:
-            logger.error(f"Error executing SAS job: {str(e)}")
-            raise e
+            logger.info("Job submitted: %s", jid)
+            state, log_text, listing_text = await wait_job(client, sid, jid)
+            logger.info("Job completed: %s", state)
+            return {
+                "snippet_id": snippet_id,
+                "state": state,
+                "log": log_text,
+                "listing": listing_text,
+            }
+        except Exception:
+            logger.exception("Error executing SAS job")
+            raise
         finally:
             try:
                 delete_url = f"{VIYA_ENDPOINT}/compute/sessions/{sid}"
                 await client.delete(delete_url)
-                logger.info(f"Session {sid} deleted successfully")
-            except Exception as e:
-                logger.error(f"Failed to delete session {sid}: {str(e)}")
-                raise e
+                logger.info("Session %s deleted successfully", sid)
+            except Exception:
+                logger.exception("Failed to delete session %s", sid)
+                raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,10 @@
 Pytest configuration and shared fixtures for SAS MCP Server tests.
 """
 import os
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
+import pytest
 from dotenv import load_dotenv
 
 # Load .env once, before any sas_mcp_server module is imported, so that
@@ -15,7 +16,7 @@ from dotenv import load_dotenv
 # developer's local environment rather than the bare OS env.
 load_dotenv()
 
-from fastmcp import FastMCP, Client
+from fastmcp import FastMCP  # noqa: E402  (must follow load_dotenv above)
 
 
 @pytest.fixture
@@ -161,7 +162,6 @@ def mcp_server_with_mock_client():
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
     paged_resp = _make_mock_response({"items": [], "count": 0})
-    json_resp = _make_mock_response({"id": "test-id"})
     post_resp = _make_mock_response({"id": "test-id"}, status_code=201)
     post_resp.content = b'{"id": "test-id"}'
     put_resp = _make_mock_response({"tableName": "test"}, status_code=201)
@@ -173,7 +173,7 @@ def mcp_server_with_mock_client():
     mock_client.put.return_value = put_resp
     mock_client.delete.return_value = delete_resp
 
-    with patch("sas_mcp_server.tools._make_client", return_value=mock_client):
+    with patch("sas_mcp_server.tools.make_client", return_value=mock_client):
         mcp = FastMCP("Payload Test Server")
 
         async def mock_get_token(ctx):
@@ -236,6 +236,8 @@ def integration_mcp_server(viya_token):
     async def real_get_token(ctx):
         return _token
 
+    from sas_mcp_server.prompts import register_prompts
     from sas_mcp_server.tools import register_tools
     register_tools(mcp, real_get_token)
+    register_prompts(mcp)
     return mcp

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -1,0 +1,246 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the zero-prereq OAuth login helper (auth_login.py).
+
+The helper is intentionally decoupled from config (it imports only env_bool),
+so it can be exercised without VIYA_ENDPOINT or any server configuration.
+"""
+import base64
+import hashlib
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from sas_mcp_server import auth_login
+
+# ---------------------------------------------------------------------------
+# _generate_pkce
+# ---------------------------------------------------------------------------
+
+
+def test_generate_pkce_verifier_and_challenge():
+    verifier, challenge = auth_login._generate_pkce()
+    assert len(verifier) == 128
+    allowed = set(__import__("string").ascii_letters + __import__("string").digits + "-._~")
+    assert set(verifier) <= allowed
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+    assert challenge == expected
+    assert "=" not in challenge
+
+
+def test_generate_pkce_is_random():
+    assert auth_login._generate_pkce()[0] != auth_login._generate_pkce()[0]
+
+
+# ---------------------------------------------------------------------------
+# _authorize_url
+# ---------------------------------------------------------------------------
+
+
+def test_authorize_url_without_redirect():
+    url = auth_login._authorize_url("https://viya.test/", "vscode", "CHAL", None)
+    assert url.startswith("https://viya.test/SASLogon/oauth/authorize?")
+    assert "client_id=vscode" in url
+    assert "response_type=code" in url
+    assert "code_challenge=CHAL" in url
+    assert "code_challenge_method=S256" in url
+    assert "redirect_uri" not in url
+
+
+def test_authorize_url_with_redirect():
+    url = auth_login._authorize_url("https://viya.test", "vscode", "CHAL",
+                                    "http://localhost/cb")
+    assert "redirect_uri=http" in url
+
+
+# ---------------------------------------------------------------------------
+# _exchange
+# ---------------------------------------------------------------------------
+
+
+def test_exchange_posts_expected_body():
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"access_token": "tok"})
+    with patch("sas_mcp_server.auth_login.httpx.post", return_value=resp) as mock_post:
+        out = auth_login._exchange("https://v/", "vscode", "code123", "ver", None, True)
+
+    assert out == {"access_token": "tok"}
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://v/SASLogon/oauth/token"
+    assert kwargs["data"]["grant_type"] == "authorization_code"
+    assert kwargs["data"]["code"] == "code123"
+    assert kwargs["data"]["code_verifier"] == "ver"
+    assert kwargs["data"]["client_id"] == "vscode"
+    assert "redirect_uri" not in kwargs["data"]
+    assert kwargs["verify"] is True
+
+
+def test_exchange_includes_redirect_uri():
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={})
+    with patch("sas_mcp_server.auth_login.httpx.post", return_value=resp) as mock_post:
+        auth_login._exchange("https://v", "vscode", "c", "v", "http://cb", False)
+    assert mock_post.call_args[1]["data"]["redirect_uri"] == "http://cb"
+
+
+# ---------------------------------------------------------------------------
+# state persistence
+# ---------------------------------------------------------------------------
+
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    p = tmp_path / "login-state.json"
+    monkeypatch.setattr(auth_login, "STATE_PATH", p)
+    assert auth_login._read_state() is None
+
+    auth_login._write_state({"verifier": "v", "endpoint": "e"})
+    assert p.exists()
+    assert auth_login._read_state() == {"verifier": "v", "endpoint": "e"}
+
+    auth_login._clear_state()
+    assert not p.exists()
+    assert auth_login._read_state() is None
+
+
+def test_read_state_malformed_returns_none(tmp_path, monkeypatch):
+    p = tmp_path / "login-state.json"
+    p.write_text("{not valid json")
+    monkeypatch.setattr(auth_login, "STATE_PATH", p)
+    assert auth_login._read_state() is None
+
+
+def test_clear_state_missing_is_silent(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth_login, "STATE_PATH", tmp_path / "absent.json")
+    auth_login._clear_state()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _write_cache
+# ---------------------------------------------------------------------------
+
+
+def test_write_cache_shape(tmp_path, monkeypatch):
+    p = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth_login, "CACHE_PATH", p)
+    out = auth_login._write_cache(
+        {"access_token": "AT", "refresh_token": "RT", "expires_in": 3600}
+    )
+    assert out == p
+    data = json.loads(p.read_text())
+    assert data["Default"]["access-token"] == "AT"
+    assert data["Default"]["refresh-token"] == "RT"
+    assert data["Default"]["expiry"]  # ISO timestamp present
+
+
+def test_write_cache_defaults_missing_refresh(tmp_path, monkeypatch):
+    p = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth_login, "CACHE_PATH", p)
+    auth_login._write_cache({"access_token": "AT"})
+    data = json.loads(p.read_text())
+    assert data["Default"]["refresh-token"] == ""
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_endpoint_errors(monkeypatch):
+    monkeypatch.delenv("VIYA_ENDPOINT", raising=False)
+    monkeypatch.setattr(sys, "argv", ["sas-mcp-login"])
+    with pytest.raises(SystemExit):
+        auth_login.main()
+
+
+def test_main_code_without_state_returns_1(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth_login, "STATE_PATH", tmp_path / "missing.json")
+    monkeypatch.setattr(
+        sys, "argv", ["sas-mcp-login", "--endpoint", "https://v", "--code", "X"]
+    )
+    assert auth_login.main() == 1
+
+
+def test_main_code_success(tmp_path, monkeypatch):
+    state_p = tmp_path / "state.json"
+    cache_p = tmp_path / "creds.json"
+    monkeypatch.setattr(auth_login, "STATE_PATH", state_p)
+    monkeypatch.setattr(auth_login, "CACHE_PATH", cache_p)
+    auth_login._write_state({
+        "endpoint": "https://v", "client_id": "vscode",
+        "redirect_uri": "", "verifier": "ver",
+    })
+    monkeypatch.setattr(
+        sys, "argv", ["sas-mcp-login", "--endpoint", "https://v", "--code", "CODE"]
+    )
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"access_token": "AT", "expires_in": 3600})
+    with patch("sas_mcp_server.auth_login.httpx.post", return_value=resp):
+        rc = auth_login.main()
+
+    assert rc == 0
+    assert cache_p.exists()
+    assert not state_p.exists()  # state cleared after success
+    assert json.loads(cache_p.read_text())["Default"]["access-token"] == "AT"
+
+
+def test_main_code_exchange_failure_returns_1(tmp_path, monkeypatch):
+    state_p = tmp_path / "state.json"
+    monkeypatch.setattr(auth_login, "STATE_PATH", state_p)
+    monkeypatch.setattr(auth_login, "CACHE_PATH", tmp_path / "creds.json")
+    auth_login._write_state({
+        "endpoint": "https://v", "client_id": "vscode",
+        "redirect_uri": "", "verifier": "ver",
+    })
+    monkeypatch.setattr(
+        sys, "argv", ["sas-mcp-login", "--endpoint", "https://v", "--code", "CODE"]
+    )
+    err = httpx.HTTPStatusError("bad", request=MagicMock(), response=MagicMock(text="nope"))
+    with patch("sas_mcp_server.auth_login.httpx.post", side_effect=err):
+        assert auth_login.main() == 1
+
+
+def test_main_phase1_non_tty_saves_state(tmp_path, monkeypatch):
+    state_p = tmp_path / "state.json"
+    monkeypatch.setattr(auth_login, "STATE_PATH", state_p)
+    monkeypatch.setattr(
+        sys, "argv", ["sas-mcp-login", "--endpoint", "https://v", "--no-browser"]
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    rc = auth_login.main()
+    assert rc == 0
+    saved = auth_login._read_state()
+    assert saved["endpoint"] == "https://v"
+    assert "verifier" in saved
+
+
+def test_main_phase1_interactive_exchanges(tmp_path, monkeypatch):
+    state_p = tmp_path / "state.json"
+    cache_p = tmp_path / "creds.json"
+    monkeypatch.setattr(auth_login, "STATE_PATH", state_p)
+    monkeypatch.setattr(auth_login, "CACHE_PATH", cache_p)
+    monkeypatch.setattr(
+        sys, "argv", ["sas-mcp-login", "--endpoint", "https://v", "--no-browser"]
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *_: "PASTED_CODE")
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"access_token": "AT", "expires_in": 60})
+    with patch("sas_mcp_server.auth_login.httpx.post", return_value=resp) as mock_post:
+        rc = auth_login.main()
+
+    assert rc == 0
+    assert mock_post.call_args[1]["data"]["code"] == "PASTED_CODE"
+    assert cache_p.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,9 @@ producing empty-message ``httpcore.ConnectError``s on real Viya calls.
 """
 import importlib
 import sys
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 
 def _reload_config():
@@ -57,11 +58,12 @@ def test_config_missing_viya_endpoint(monkeypatch):
     monkeypatch.delenv("VIYA_ENDPOINT", raising=False)
     monkeypatch.setenv("CLIENT_ID", "test-client")
     # Block module-level load_dotenv from reloading VIYA_ENDPOINT from .env.
-    with patch('dotenv.load_dotenv'):
-        with pytest.raises(Exception, match="VIYA_ENDPOINT is not set"):
-            _reload_config()
+    with patch('dotenv.load_dotenv'), pytest.raises(Exception, match="VIYA_ENDPOINT is not set"):
+        _reload_config()
     # Restore a valid module state for subsequent tests in the session, since
-    # the failed reload leaves the module in a partially-initialised state.
+    # the failed reload leaves the module in a partially-initialised state. Set
+    # the endpoint explicitly so the reload succeeds even in CI (no local .env).
+    monkeypatch.setenv("VIYA_ENDPOINT", "https://test.viya.com")
     _reload_config()
 
 

--- a/tests/test_config_oauth.py
+++ b/tests/test_config_oauth.py
@@ -1,0 +1,58 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for PermissiveOAuthProxy.load_access_token — the additive raw-bearer
+path gated by ALLOW_RAW_BEARER.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import sas_mcp_server.config as config
+
+
+@pytest.mark.asyncio
+async def test_standard_swap_succeeds_returns_validated():
+    """When the standard MCP JWT swap succeeds, its result is returned as-is."""
+    auth = config.viya_auth
+    validated = MagicMock()
+    with patch.object(config.OAuthProxy, "load_access_token",
+                      AsyncMock(return_value=validated)):
+        result = await auth.load_access_token("client-jwt")
+    assert result is validated
+
+
+@pytest.mark.asyncio
+async def test_raw_bearer_disabled_returns_none():
+    """Swap fails and ALLOW_RAW_BEARER is off -> None (no raw fallthrough)."""
+    auth = config.viya_auth
+    with patch.object(config.OAuthProxy, "load_access_token", AsyncMock(return_value=None)), \
+         patch.object(config, "ALLOW_RAW_BEARER", False):
+        result = await auth.load_access_token("raw-token")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_raw_bearer_enabled_accepts_valid_upstream_jwt():
+    """Swap fails, ALLOW_RAW_BEARER on, verifier accepts -> raw token returned."""
+    auth = config.viya_auth
+    raw = MagicMock()
+    with patch.object(config.OAuthProxy, "load_access_token", AsyncMock(return_value=None)), \
+         patch.object(config, "ALLOW_RAW_BEARER", True), \
+         patch.object(auth, "_token_validator") as mock_validator:
+        mock_validator.verify_token = AsyncMock(return_value=raw)
+        result = await auth.load_access_token("raw-token")
+    assert result is raw
+
+
+@pytest.mark.asyncio
+async def test_raw_bearer_enabled_rejects_invalid_token():
+    """Swap fails, ALLOW_RAW_BEARER on, verifier rejects -> None."""
+    auth = config.viya_auth
+    with patch.object(config.OAuthProxy, "load_access_token", AsyncMock(return_value=None)), \
+         patch.object(config, "ALLOW_RAW_BEARER", True), \
+         patch.object(auth, "_token_validator") as mock_validator:
+        mock_validator.verify_token = AsyncMock(return_value=None)
+        result = await auth.load_access_token("bad-token")
+    assert result is None

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,29 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the env_bool helper."""
+from sas_mcp_server.env import env_bool
+
+
+def test_env_bool_unset_returns_default(monkeypatch):
+    monkeypatch.delenv("X_FLAG", raising=False)
+    assert env_bool("X_FLAG", True) is True
+    assert env_bool("X_FLAG", False) is False
+
+
+def test_env_bool_truthy_values(monkeypatch):
+    for value in ("true", "1", "yes", "on", "TRUE", "On"):
+        monkeypatch.setenv("X_FLAG", value)
+        assert env_bool("X_FLAG", False) is True
+
+
+def test_env_bool_falsey_values(monkeypatch):
+    for value in ("false", "0", "no", "off", "FALSE"):
+        monkeypatch.setenv("X_FLAG", value)
+        assert env_bool("X_FLAG", True) is False
+
+
+def test_env_bool_unrecognized_returns_default(monkeypatch):
+    monkeypatch.setenv("X_FLAG", "maybe")
+    assert env_bool("X_FLAG", True) is True
+    assert env_bool("X_FLAG", False) is False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,8 +7,8 @@ Integration tests that call MCP tools against a real SAS Viya instance.
 Requires VIYA_ENDPOINT, VIYA_USERNAME, and VIYA_PASSWORD environment variables.
 Run with:  uv run python -m pytest -m integration
 """
-import json
 import time
+
 import pytest
 from fastmcp import Client
 
@@ -20,6 +20,29 @@ from fastmcp import Client
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
 
 _SUFFIX = str(int(time.time()))[-6:]
+
+
+async def _viya_get(token: str, path: str, params: dict | None = None) -> dict:
+    """Authenticated GET against the live Viya, used for resource discovery."""
+    from sas_mcp_server.config import VIYA_ENDPOINT
+    from sas_mcp_server.viya_client import make_client
+
+    async with make_client(token) as client:
+        resp = await client.get(
+            f"{VIYA_ENDPOINT}{path}",
+            params=params or {},
+            headers={"Accept": "application/json"},
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+def _dummy_input_value(var_type: str):
+    """A type-appropriate placeholder value for a MAS step input variable."""
+    if (var_type or "").lower() in ("decimal", "double", "float", "integer", "int", "bigint"):
+        return 0
+    return ""
 
 
 # -----------------------------------------------------------------------
@@ -171,15 +194,13 @@ run;
 proc print data=work.mcp_test;
 run;
 """
-        result = await client.call_tool("execute_sas_code", {
+        result = (await client.call_tool("execute_sas_code", {
             "sas_code": code
-        })
-        parsed = json.loads(result.content[0].text)
-        assert isinstance(parsed, list)
-        assert len(parsed) == 4
-        snippet_id, state, log, listing = parsed
-        assert state in ("completed", "warning")
-        assert "mcp_test" in log.lower() or "NOTE" in log
+        })).data
+        assert isinstance(result, dict)
+        assert set(result) >= {"snippet_id", "state", "log", "listing"}
+        assert result["state"] in ("completed", "warning")
+        assert "mcp_test" in result["log"].lower() or "NOTE" in result["log"]
 
 
 # -----------------------------------------------------------------------
@@ -275,7 +296,9 @@ async def test_ml_project_workflow(integration_mcp_server):
 
         project = (await client.call_tool("create_ml_project", {
             "project_name": f"MCP Integration Test {_SUFFIX}",
-            "data_table_uri": f"/dataTables/dataSources/cas~fs~{server_id}~fs~Public/tables/{table}",
+            "server_id": server_id,
+            "caslib_name": "Public",
+            "table_name": table,
             "target_variable": "target",
             "prediction_type": "binary",
             "target_event_level": "1",
@@ -295,8 +318,12 @@ async def test_ml_project_workflow(integration_mcp_server):
 # -----------------------------------------------------------------------
 
 
-async def test_scoring_workflow(integration_mcp_server):
-    """list_registered_models → list_models_and_decisions"""
+async def test_scoring_workflow(integration_mcp_server, viya_token):
+    """list_registered_models → list_models_and_decisions → score_data.
+
+    Scores against the most recently modified MAS module on the instance,
+    discovering a real step and its input variables rather than guessing.
+    """
     async with Client(integration_mcp_server) as client:
         models = (await client.call_tool("list_registered_models", {"limit": 5})).data
         assert isinstance(models, list)
@@ -304,16 +331,253 @@ async def test_scoring_workflow(integration_mcp_server):
         modules = (await client.call_tool("list_models_and_decisions", {"limit": 5})).data
         assert isinstance(modules, list)
 
-        if not modules:
-            pytest.skip("No MAS modules found — cannot test score_data")
+    # Identify the latest module directly (sorted by modified time, newest first).
+    listing = await _viya_get(
+        viya_token,
+        "/microanalyticScore/modules",
+        params={"sortBy": "modifiedTimeStamp:descending", "limit": 1},
+    )
+    items = listing.get("items", [])
+    if not items:
+        pytest.skip("No MAS modules found — cannot test score_data")
+    module_id = items[0]["id"]
 
-        module_id = modules[0]["id"]
+    # Discover a usable step (prefer 'score'/'execute') and its input variables.
+    steps = (await _viya_get(
+        viya_token, f"/microanalyticScore/modules/{module_id}/steps"
+    )).get("items", [])
+    if not steps:
+        pytest.skip(f"Module {module_id} exposes no steps")
+    step = next((s for s in steps if s.get("id") in ("score", "execute")), steps[0])
+    step_id = step["id"]
+    step_detail = await _viya_get(
+        viya_token, f"/microanalyticScore/modules/{module_id}/steps/{step_id}"
+    )
+    input_data = {
+        inp["name"]: _dummy_input_value(inp.get("type", ""))
+        for inp in step_detail.get("inputs", [])
+    }
+
+    async with Client(integration_mcp_server) as client:
         try:
             result = (await client.call_tool("score_data", {
                 "module_id": module_id,
-                "step_id": "score",
-                "input_data": {"x": 1},
+                "step_id": step_id,
+                "input_data": input_data,
             })).data
-            assert isinstance(result, dict)
-        except Exception:
-            pytest.skip(f"Module {module_id} does not have a 'score' step or expects different inputs")
+        except Exception as e:
+            pytest.skip(
+                f"Module {module_id} step '{step_id}' rejected placeholder inputs: {e}"
+            )
+        assert isinstance(result, dict)
+
+
+# -----------------------------------------------------------------------
+# Cancel Job Workflow
+# -----------------------------------------------------------------------
+
+
+async def test_cancel_job_workflow(integration_mcp_server):
+    """submit_batch_job → cancel_job"""
+    async with Client(integration_mcp_server) as client:
+        submit = (await client.call_tool("submit_batch_job", {
+            "sas_code": "data _null_; do i = 1 to 100000000; end; run;",
+            "job_name": f"mcp-cancel-test-{_SUFFIX}",
+        })).data
+        assert "id" in submit
+        job_id = submit["id"]
+
+        try:
+            result = (await client.call_tool("cancel_job", {"job_id": job_id})).data
+        except Exception as e:
+            pytest.skip(f"cancel_job rejected (job already terminal on this Viya): {e}")
+        assert isinstance(result, str)
+        assert job_id in result
+
+
+# -----------------------------------------------------------------------
+# Run ML Project Workflow
+# -----------------------------------------------------------------------
+
+
+async def test_run_ml_project_workflow(integration_mcp_server, viya_token):
+    """run_ml_project against an existing completed project.
+
+    A freshly-created project isn't immediately runnable, so this targets the
+    most recently modified project already in the ``completed`` state and
+    re-runs (retrains) it.
+    """
+    listing = await _viya_get(
+        viya_token,
+        "/mlPipelineAutomation/projects",
+        params={
+            "sortBy": "modifiedTimeStamp:descending",
+            "filter": "eq(state,'completed')",
+            "limit": 1,
+        },
+    )
+    items = listing.get("items", [])
+    if not items:
+        pytest.skip("No completed ML projects on this Viya to run")
+    project_id = items[0]["id"]
+
+    async with Client(integration_mcp_server) as client:
+        try:
+            result = (await client.call_tool("run_ml_project", {
+                "project_id": project_id
+            })).data
+        except Exception as e:
+            pytest.skip(f"run_ml_project could not start project {project_id}: {e}")
+        assert isinstance(result, dict)
+
+
+# -----------------------------------------------------------------------
+# Promote-from-source Workflow
+# -----------------------------------------------------------------------
+
+
+async def test_promote_from_source_workflow(integration_mcp_server, viya_token):
+    """list_source_tables → promote_table_to_memory (load from source to global) → unload.
+
+    Exercises the real fix for the promote_table_to_memory bug: discover an
+    unloaded source table and load+promote it via updateTableState. Restores the
+    caslib's state by unloading anything this test loaded.
+    """
+    async with Client(integration_mcp_server) as client:
+        server = (await client.call_tool("list_cas_servers", {})).data[0]["name"]
+
+        caslib, sources = None, []
+        for lib in ("SAMPLES", "Public"):
+            sources = (await client.call_tool("list_source_tables", {
+                "server_id": server, "caslib_name": lib, "limit": 25,
+            })).data
+            if sources:
+                caslib = lib
+                break
+        if not sources:
+            pytest.skip("No unloaded source tables available to promote")
+
+        # Try a few candidates so one quirky source table doesn't fail the run.
+        promoted = None
+        for cand in sources[:5]:
+            try:
+                result = (await client.call_tool("promote_table_to_memory", {
+                    "server_id": server, "caslib_name": caslib, "table_name": cand["name"],
+                })).data
+            except Exception:
+                continue
+            if result.get("scope") == "global" and result.get("status") in ("promoted", "already_global"):
+                promoted = (cand["name"], result)
+                break
+        if not promoted:
+            pytest.skip("Could not load any source table on this Viya")
+        table, result = promoted
+
+        info = (await client.call_tool("get_castable_info", {
+            "server_id": server, "caslib_name": caslib, "table_name": table,
+        })).data
+        assert info.get("state") == "loaded"
+        assert info.get("scope") == "global"
+
+    # Cleanup: if we loaded it, unload it again to restore prior caslib state.
+    if result["status"] == "promoted":
+        from sas_mcp_server.config import VIYA_ENDPOINT
+        from sas_mcp_server.viya_client import make_client
+        async with make_client(viya_token) as raw:
+            await raw.put(
+                f"{VIYA_ENDPOINT}/casManagement/servers/{server}/caslibs/{caslib}/tables/{table}/state",
+                params={"value": "unloaded"}, headers={"Accept": "*/*"},
+            )
+
+
+# -----------------------------------------------------------------------
+# Prompt templates — rendered through the live-connected server
+# -----------------------------------------------------------------------
+
+# Prompt templates are client-side text generation (they do not call Viya
+# APIs), but these render each one through the same MCP server instance wired
+# to the real Viya token, exercising registration + rendering end to end.
+PROMPT_RENDER_ARGS = {
+    "debug_sas_log": {"log_text": "ERROR: File WORK.X does not exist."},
+    "explore_dataset": {"library": "SASHELP", "dataset": "CLASS"},
+    "data_quality_check": {"library": "SASHELP", "dataset": "CLASS"},
+    "statistical_analysis": {
+        "analysis_type": "linear regression",
+        "response_variable": "Weight",
+        "predictors": "Height Age",
+        "dataset": "SASHELP.CLASS",
+    },
+    "optimize_sas_code": {"sas_code": "data a; set b; run;"},
+    "explain_sas_code": {"sas_code": "proc print data=sashelp.class; run;"},
+    "sas_macro_builder": {"macro_name": "loadcsv", "purpose": "Load a CSV into CAS"},
+    "generate_report": {"dataset": "SASHELP.CLASS"},
+}
+
+
+@pytest.mark.parametrize("prompt_name", sorted(PROMPT_RENDER_ARGS))
+async def test_prompt_renders_through_live_server(integration_mcp_server, prompt_name):
+    """Every prompt template renders to non-empty messages via the live server."""
+    async with Client(integration_mcp_server) as client:
+        result = await client.get_prompt(prompt_name, PROMPT_RENDER_ARGS[prompt_name])
+        assert result.messages, f"{prompt_name} produced no messages"
+        content = result.messages[0].content
+        text = getattr(content, "text", None) or str(content)
+        assert text and text.strip(), f"{prompt_name} rendered empty content"
+
+
+# -----------------------------------------------------------------------
+# Coverage guards — fail if a registered tool/prompt has no integration test
+# -----------------------------------------------------------------------
+
+# Maps every registered tool to the integration test that invokes it against
+# real Viya. The guard below fails if a tool is registered but unmapped, so a
+# new tool cannot ship without integration coverage.
+TOOL_COVERAGE = {
+    "execute_sas_code": "test_sas_code_execution",
+    "list_cas_servers": "test_cas_discovery_workflow",
+    "list_caslibs": "test_cas_discovery_workflow",
+    "list_castables": "test_cas_discovery_workflow",
+    "list_source_tables": "test_promote_from_source_workflow",
+    "get_castable_info": "test_cas_discovery_workflow",
+    "get_castable_columns": "test_cas_discovery_workflow",
+    "get_castable_data": "test_cas_discovery_workflow",
+    "upload_data": "test_data_upload_workflow",
+    "promote_table_to_memory": "test_promote_from_source_workflow",
+    "list_files": "test_file_service_workflow",
+    "upload_file": "test_file_service_workflow",
+    "download_file": "test_file_service_workflow",
+    "list_reports": "test_report_workflow",
+    "get_report": "test_report_workflow",
+    "get_report_image": "test_report_workflow",
+    "submit_batch_job": "test_batch_job_workflow",
+    "get_job_status": "test_batch_job_workflow",
+    "list_jobs": "test_batch_job_workflow",
+    "cancel_job": "test_cancel_job_workflow",
+    "get_job_log": "test_batch_job_workflow",
+    "list_ml_projects": "test_ml_project_workflow",
+    "create_ml_project": "test_ml_project_workflow",
+    "run_ml_project": "test_run_ml_project_workflow",
+    "list_registered_models": "test_scoring_workflow",
+    "list_models_and_decisions": "test_scoring_workflow",
+    "score_data": "test_scoring_workflow",
+}
+
+
+async def test_every_tool_has_integration_coverage(integration_mcp_server):
+    """Every tool registered on the live server is exercised by an integration test."""
+    async with Client(integration_mcp_server) as client:
+        registered = {t.name for t in await client.list_tools()}
+    missing = registered - set(TOOL_COVERAGE)
+    stale = set(TOOL_COVERAGE) - registered
+    assert not missing, f"Tools with no integration test: {sorted(missing)}"
+    assert not stale, f"Coverage entries for tools that no longer exist: {sorted(stale)}"
+
+
+async def test_every_prompt_has_integration_coverage(integration_mcp_server):
+    """Every prompt registered on the live server is rendered by an integration test."""
+    async with Client(integration_mcp_server) as client:
+        registered = {p.name for p in await client.list_prompts()}
+    missing = registered - set(PROMPT_RENDER_ARGS)
+    stale = set(PROMPT_RENDER_ARGS) - registered
+    assert not missing, f"Prompts with no integration test: {sorted(missing)}"
+    assert not stale, f"Render args for prompts that no longer exist: {sorted(stale)}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,89 +2,113 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for the MCP server and tools.
+Tests for the HTTP-mode MCP server: auth middleware, health route, the
+token getter, and the AuthenticationError type.
 """
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch
-from fastmcp import Context
+
+from sas_mcp_server import mcp_server
 from sas_mcp_server.mcp_server import AuthenticationError
 
 
-@pytest.mark.asyncio
-async def test_execute_sas_code_success(sample_sas_code, mock_access_token):
-    """Test successful SAS code execution through the tool."""
-    mock_context = MagicMock(spec=Context)
-    mock_context.get_state.return_value = mock_access_token
-
-    with patch('sas_mcp_server.tools.run_one_snippet') as mock_run:
-        mock_run.return_value = ("1", "completed", "Log output", "Listing output")
-
-        token = await mock_context.get_state("access_token")
-        output = await mock_run(sample_sas_code, "1", token)
-
-        mock_run.assert_called_once_with(sample_sas_code, "1", mock_access_token)
-        assert output == ("1", "completed", "Log output", "Listing output")
-
-
-@pytest.mark.asyncio
-async def test_execute_sas_code_no_token():
-    """Test that execute_sas_code raises error when no token is available."""
-    mock_context = MagicMock(spec=Context)
-    mock_context.get_state.return_value = None
-
-    token = await mock_context.get_state("access_token")
-    assert token is None
-
-
-@pytest.mark.asyncio
-async def test_execute_sas_code_propagates_errors(sample_sas_code, mock_access_token):
-    """Test that errors from run_one_snippet are propagated."""
-    mock_context = MagicMock(spec=Context)
-    mock_context.get_state.return_value = mock_access_token
-
-    with patch('sas_mcp_server.tools.run_one_snippet') as mock_run:
-        mock_run.side_effect = Exception("API Error")
-
-        token = await mock_context.get_state("access_token")
-        with pytest.raises(Exception, match="API Error"):
-            await mock_run(sample_sas_code, "1", token)
-
-
 def test_authentication_error():
-    """Test AuthenticationError exception."""
+    """AuthenticationError carries its message and renders a prefixed string."""
     error = AuthenticationError("Test error message")
-
     assert error.message == "Test error message"
     assert str(error) == "AuthenticationError: Test error message"
 
 
+# ---------------------------------------------------------------------------
+# _http_get_token
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_execute_sas_code_with_multiline_code(mock_access_token):
-    """Test execute_sas_code with multiline SAS code."""
-    multiline_code = """
-    data work.sample;
-        do i = 1 to 10;
-            x = i * 2;
-            output;
-        end;
-    run;
+async def test_http_get_token_present():
+    ctx = MagicMock()
+    ctx.get_state = AsyncMock(return_value="VIYATOK")
+    assert await mcp_server._http_get_token(ctx) == "VIYATOK"
 
-    proc means data=work.sample;
-        var x;
-    run;
-    """
 
-    mock_context = MagicMock(spec=Context)
-    mock_context.get_state.return_value = mock_access_token
+@pytest.mark.asyncio
+async def test_http_get_token_missing_raises():
+    ctx = MagicMock()
+    ctx.get_state = AsyncMock(return_value=None)
+    with pytest.raises(AuthenticationError):
+        await mcp_server._http_get_token(ctx)
 
-    with patch('sas_mcp_server.tools.run_one_snippet') as mock_run:
-        mock_run.return_value = ("1", "completed", "PROC MEANS output", "Statistics")
 
-        token = await mock_context.get_state("access_token")
-        result = await mock_run(multiline_code, "1", token)
+# ---------------------------------------------------------------------------
+# health_check
+# ---------------------------------------------------------------------------
 
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args[0]
-        assert call_args[0] == multiline_code
-        assert call_args[1] == "1"
-        assert call_args[2] == mock_access_token
+
+@pytest.mark.asyncio
+async def test_health_check_ok():
+    resp = await mcp_server.health_check(MagicMock())
+    assert resp.status_code == 200
+    body = json.loads(bytes(resp.body))
+    assert body["status"] == "healthy"
+    assert body["service"] == "sas-viya-execution-mcp"
+
+
+# ---------------------------------------------------------------------------
+# AuthMiddleware.on_call_tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_valid_bearer_sets_state():
+    mw = mcp_server.AuthMiddleware()
+    req = MagicMock()
+    req.headers.get.return_value = "Bearer CLIENTJWT"
+    info = MagicMock()
+    info.token = "VIYATOK"
+    ctx = MagicMock()
+    ctx.fastmcp_context.set_state = AsyncMock()
+    call_next = AsyncMock(return_value="RESULT")
+
+    with patch("sas_mcp_server.mcp_server.get_http_request", return_value=req), \
+         patch.object(mcp_server.viya_auth, "load_access_token",
+                      AsyncMock(return_value=info)) as mock_load:
+        result = await mw.on_call_tool(ctx, call_next)
+
+    assert result == "RESULT"
+    mock_load.assert_awaited_once_with("CLIENTJWT")
+    ctx.fastmcp_context.set_state.assert_awaited_once_with("access_token", "VIYATOK")
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_no_header_raises():
+    mw = mcp_server.AuthMiddleware()
+    req = MagicMock()
+    req.headers.get.return_value = None
+    call_next = AsyncMock()
+
+    with patch("sas_mcp_server.mcp_server.get_http_request", return_value=req), pytest.raises(AuthenticationError):
+        await mw.on_call_tool(MagicMock(), call_next)
+
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_swap_failure_does_not_set_state():
+    mw = mcp_server.AuthMiddleware()
+    req = MagicMock()
+    req.headers.get.return_value = "Bearer X"
+    ctx = MagicMock()
+    ctx.fastmcp_context.set_state = AsyncMock()
+    call_next = AsyncMock(return_value="R")
+
+    with patch("sas_mcp_server.mcp_server.get_http_request", return_value=req), \
+         patch.object(mcp_server.viya_auth, "load_access_token",
+                      AsyncMock(return_value=None)):
+        result = await mw.on_call_tool(ctx, call_next)
+
+    assert result == "R"
+    ctx.fastmcp_context.set_state.assert_not_awaited()
+    call_next.assert_awaited_once_with(ctx)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,6 +6,7 @@ Tests for prompt template rendering.
 """
 import pytest
 from fastmcp import FastMCP
+
 from sas_mcp_server.prompts import register_prompts
 
 

--- a/tests/test_stdio_server.py
+++ b/tests/test_stdio_server.py
@@ -1,0 +1,149 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for stdio-mode token resolution and the native device-code flow.
+"""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sas_mcp_server import stdio_server
+from sas_mcp_server.exceptions import AuthenticationError
+
+# ---------------------------------------------------------------------------
+# credentials-path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_sas_cli_credentials_path_default(monkeypatch):
+    monkeypatch.setattr(stdio_server, "SAS_CLI_CONFIG", "")
+    assert stdio_server._sas_cli_credentials_path() == Path.home() / ".sas" / "credentials.json"
+
+
+def test_sas_cli_credentials_path_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(stdio_server, "SAS_CLI_CONFIG", str(tmp_path))
+    assert stdio_server._sas_cli_credentials_path() == tmp_path / ".sas" / "credentials.json"
+
+
+def test_helper_credentials_path():
+    expected = Path.home() / ".sas-mcp-server" / "credentials.json"
+    assert stdio_server._helper_credentials_path() == expected
+
+
+# ---------------------------------------------------------------------------
+# _read_cached_token
+# ---------------------------------------------------------------------------
+
+
+def test_read_cached_token_valid(tmp_path):
+    p = tmp_path / "credentials.json"
+    p.write_text(json.dumps({"Default": {"access-token": "TOK"}}))
+    assert stdio_server._read_cached_token(p) == "TOK"
+
+
+def test_read_cached_token_missing_file(tmp_path):
+    assert stdio_server._read_cached_token(tmp_path / "nope.json") is None
+
+
+def test_read_cached_token_missing_key(tmp_path):
+    p = tmp_path / "credentials.json"
+    p.write_text(json.dumps({"something": "else"}))
+    assert stdio_server._read_cached_token(p) is None
+
+
+def test_read_cached_token_malformed(tmp_path):
+    p = tmp_path / "credentials.json"
+    p.write_text("{not json")
+    assert stdio_server._read_cached_token(p) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_viya_token fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_get_viya_token_from_cli_cache(tmp_path, monkeypatch):
+    p = tmp_path / "credentials.json"
+    p.write_text(json.dumps({"Default": {"access-token": "CLITOK"}}))
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: p)
+    monkeypatch.setattr(stdio_server, "_helper_credentials_path", lambda: tmp_path / "absent.json")
+    assert stdio_server._get_viya_token() == "CLITOK"
+
+
+def test_get_viya_token_from_helper_cache(tmp_path, monkeypatch):
+    helper = tmp_path / "helper.json"
+    helper.write_text(json.dumps({"Default": {"access-token": "HELPERTOK"}}))
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(stdio_server, "_helper_credentials_path", lambda: helper)
+    assert stdio_server._get_viya_token() == "HELPERTOK"
+
+
+def test_get_viya_token_falls_back_to_device(tmp_path, monkeypatch):
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: tmp_path / "a.json")
+    monkeypatch.setattr(stdio_server, "_helper_credentials_path", lambda: tmp_path / "b.json")
+    monkeypatch.setattr(stdio_server, "_native_device_code_token", lambda: "DEVTOK")
+    assert stdio_server._get_viya_token() == "DEVTOK"
+
+
+@pytest.mark.asyncio
+async def test_stdio_get_token_delegates(monkeypatch):
+    monkeypatch.setattr(stdio_server, "_get_viya_token", lambda: "TOK")
+    assert await stdio_server._stdio_get_token(None) == "TOK"
+
+
+# ---------------------------------------------------------------------------
+# _native_device_code_token (RFC 8628)
+# ---------------------------------------------------------------------------
+
+
+def _device_init(**overrides):
+    flow = {
+        "verification_uri": "https://v/device",
+        "user_code": "ABCD",
+        "device_code": "DEV",
+        "expires_in": 1800,
+        "interval": 5,
+    }
+    flow.update(overrides)
+    resp = MagicMock(status_code=200)
+    resp.json = MagicMock(return_value=flow)
+    return resp
+
+
+def test_native_device_code_success():
+    poll = MagicMock(status_code=200)
+    poll.json = MagicMock(return_value={"access_token": "DEVTOK"})
+    with patch("sas_mcp_server.stdio_server.httpx.post", side_effect=[_device_init(), poll]), \
+         patch("sas_mcp_server.stdio_server.time.sleep"), \
+         patch("sas_mcp_server.stdio_server.webbrowser.open"):
+        assert stdio_server._native_device_code_token() == "DEVTOK"
+
+
+def test_native_device_code_csrf_rejected():
+    init = MagicMock(status_code=403)
+    init.text = "CSRF protection is enabled"
+    with patch("sas_mcp_server.stdio_server.httpx.post", return_value=init), \
+         patch("sas_mcp_server.stdio_server.webbrowser.open"), pytest.raises(AuthenticationError, match="CSRF"):
+        stdio_server._native_device_code_token()
+
+
+def test_native_device_code_pending_then_success():
+    pending = MagicMock(status_code=400)
+    pending.json = MagicMock(return_value={"error": "authorization_pending"})
+    success = MagicMock(status_code=200)
+    success.json = MagicMock(return_value={"access_token": "TOK"})
+    with patch("sas_mcp_server.stdio_server.httpx.post",
+               side_effect=[_device_init(), pending, success]), \
+         patch("sas_mcp_server.stdio_server.time.sleep"), \
+         patch("sas_mcp_server.stdio_server.webbrowser.open"):
+        assert stdio_server._native_device_code_token() == "TOK"
+
+
+def test_native_device_code_timeout():
+    with patch("sas_mcp_server.stdio_server.httpx.post", return_value=_device_init(expires_in=0)), \
+         patch("sas_mcp_server.stdio_server.time.sleep"), \
+         patch("sas_mcp_server.stdio_server.webbrowser.open"), pytest.raises(AuthenticationError, match="timed out"):
+        stdio_server._native_device_code_token()

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -9,15 +9,16 @@ request that would be sent to Viya — URL path, method, body structure, query
 params, and headers.  These tests use a mock httpx client (no network calls).
 """
 import json
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from fastmcp import Client
-from conftest import _make_mock_response
+from unittest.mock import MagicMock, patch
 
+import httpx
+from fastmcp import Client
+
+from conftest import _make_mock_response
 
 EXPECTED_TOOLS = [
     "execute_sas_code",
-    "list_cas_servers", "list_caslibs", "list_castables",
+    "list_cas_servers", "list_caslibs", "list_castables", "list_source_tables",
     "get_castable_info", "get_castable_columns", "get_castable_data",
     "upload_data", "promote_table_to_memory",
     "list_files", "upload_file", "download_file",
@@ -52,14 +53,17 @@ async def test_tool_schemas(mcp_server_with_mock_client):
         create_ml = tool_map["create_ml_project"]
         props = create_ml.inputSchema["properties"]
         assert "project_name" in props
-        assert "data_table_uri" in props
+        assert "caslib_name" in props
+        assert "table_name" in props
+        assert "server_id" in props
         assert "target_variable" in props
         assert "prediction_type" in props
         assert "target_event_level" in props
         assert "auto_run" in props
         required = create_ml.inputSchema.get("required", [])
         assert "project_name" in required
-        assert "data_table_uri" in required
+        assert "caslib_name" in required
+        assert "table_name" in required
         assert "target_variable" in required
 
         score = tool_map["score_data"]
@@ -112,6 +116,20 @@ async def test_list_castables_request(mcp_server_with_mock_client):
     url = mock_client.get.call_args[0][0]
     assert "/casManagement/servers/cas1/caslibs/Public/tables" in url
     params = mock_client.get.call_args[1]["params"]
+    assert params["limit"] == 10
+
+
+async def test_list_source_tables_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        await client.call_tool("list_source_tables", {
+            "server_id": "cas1", "caslib_name": "Public", "limit": 10
+        })
+
+    url = mock_client.get.call_args[0][0]
+    assert "/casManagement/servers/cas1/caslibs/Public/tables" in url
+    params = mock_client.get.call_args[1]["params"]
+    assert params["state"] == "unloaded"
     assert params["limit"] == 10
 
 
@@ -226,16 +244,24 @@ async def test_upload_data_request(mcp_server_with_mock_client):
 
 
 async def test_promote_table_to_memory_request(mcp_server_with_mock_client):
+    """Unloaded table: idempotency GET, then PUT state=loaded&scope=global."""
     mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"name": "MY_TABLE", "state": "unloaded"})
+    put_state = _make_mock_response(status_code=200)
+    put_state.text = "loaded"
+    mock_client.put.return_value = put_state
     async with Client(mcp) as client:
-        await client.call_tool("promote_table_to_memory", {
+        result = await client.call_tool("promote_table_to_memory", {
             "server_id": "cas1", "caslib_name": "Public", "table_name": "MY_TABLE"
         })
 
-    url = mock_client.post.call_args[0][0]
-    assert "/casManagement/servers/cas1/caslibs/Public/tables/MY_TABLE" in url
-    body = mock_client.post.call_args[1]["json"]
-    assert body == {"scope": "global"}
+    get_url = mock_client.get.call_args[0][0]
+    assert "/casManagement/servers/cas1/caslibs/Public/tables/MY_TABLE" in get_url
+    put_url = mock_client.put.call_args[0][0]
+    assert put_url.endswith("/casManagement/servers/cas1/caslibs/Public/tables/MY_TABLE/state")
+    assert mock_client.put.call_args[1]["params"] == {"value": "loaded", "scope": "global"}
+    assert result.data["status"] == "promoted"
+    assert result.data["scope"] == "global"
 
 
 async def test_list_files_request(mcp_server_with_mock_client):
@@ -280,7 +306,7 @@ async def test_download_file_request(mcp_server_with_mock_client):
     mcp, mock_client = mcp_server_with_mock_client
     mock_client.get.return_value.text = "file content here"
     async with Client(mcp) as client:
-        result = await client.call_tool("download_file", {"file_id": "abc-123"})
+        await client.call_tool("download_file", {"file_id": "abc-123"})
 
     url = mock_client.get.call_args[0][0]
     assert "/files/files/abc-123/content" in url
@@ -429,7 +455,7 @@ async def test_get_job_log_request(mcp_server_with_mock_client):
     mock_client.get.side_effect = route_get
 
     async with Client(mcp) as client:
-        result = await client.call_tool("get_job_log", {"job_id": "job-789"})
+        await client.call_tool("get_job_log", {"job_id": "job-789"})
 
     mock_client.get.side_effect = None
     mock_client.get.return_value = original_get
@@ -460,10 +486,12 @@ async def test_list_ml_projects_request(mcp_server_with_mock_client):
 
 async def test_create_ml_project_binary_request(mcp_server_with_mock_client):
     mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "loaded", "scope": "global"})
     async with Client(mcp) as client:
         await client.call_tool("create_ml_project", {
             "project_name": "Fraud Detection",
-            "data_table_uri": "/dataTables/dataSources/cas~fs~cas-shared-default~fs~Public/tables/HMEQ",
+            "caslib_name": "Public",
+            "table_name": "HMEQ",
             "target_variable": "BAD",
             "description": "Binary classification project",
             "prediction_type": "binary",
@@ -499,10 +527,12 @@ async def test_create_ml_project_binary_request(mcp_server_with_mock_client):
 
 async def test_create_ml_project_interval_request(mcp_server_with_mock_client):
     mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "loaded", "scope": "global"})
     async with Client(mcp) as client:
         await client.call_tool("create_ml_project", {
             "project_name": "Price Prediction",
-            "data_table_uri": "/dataTables/dataSources/cas~fs~cas-shared-default~fs~Public/tables/CARS",
+            "caslib_name": "Public",
+            "table_name": "CARS",
             "target_variable": "MSRP",
             "prediction_type": "interval",
         })
@@ -516,10 +546,12 @@ async def test_create_ml_project_interval_request(mcp_server_with_mock_client):
 
 async def test_create_ml_project_nominal_request(mcp_server_with_mock_client):
     mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "loaded", "scope": "global"})
     async with Client(mcp) as client:
         await client.call_tool("create_ml_project", {
             "project_name": "Multi Class",
-            "data_table_uri": "/dataTables/dataSources/cas~fs~cas-shared-default~fs~Public/tables/IRIS",
+            "caslib_name": "Public",
+            "table_name": "IRIS",
             "target_variable": "Species",
             "prediction_type": "nominal",
             "target_event_level": "setosa",
@@ -534,16 +566,62 @@ async def test_create_ml_project_nominal_request(mcp_server_with_mock_client):
 
 async def test_create_ml_project_auto_run_false(mcp_server_with_mock_client):
     mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "loaded", "scope": "global"})
     async with Client(mcp) as client:
         await client.call_tool("create_ml_project", {
             "project_name": "No Auto Run",
-            "data_table_uri": "/dataTables/dataSources/x/tables/T",
+            "caslib_name": "Public",
+            "table_name": "T",
             "target_variable": "Y",
             "auto_run": False,
         })
 
     body = mock_client.post.call_args[1]["json"]
     assert body["settings"]["autoRun"] is False
+
+
+async def test_create_ml_project_default_server_in_uri(mcp_server_with_mock_client):
+    """server_id defaults to cas-shared-default and is woven into the data-table URI."""
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "loaded", "scope": "global"})
+    async with Client(mcp) as client:
+        await client.call_tool("create_ml_project", {
+            "project_name": "Defaults", "caslib_name": "Public",
+            "table_name": "HMEQ", "target_variable": "BAD",
+        })
+    body = mock_client.post.call_args[1]["json"]
+    assert body["dataTableUri"] == (
+        "/dataTables/dataSources/cas~fs~cas-shared-default~fs~Public/tables/HMEQ"
+    )
+
+
+async def test_create_ml_project_rejects_non_global_table(mcp_server_with_mock_client):
+    """Pre-flight: an unloaded/session-scoped table is rejected without a POST."""
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "unloaded", "scope": None})
+    async with Client(mcp) as client:
+        result = await client.call_tool("create_ml_project", {
+            "project_name": "Bad", "caslib_name": "Public",
+            "table_name": "NOT_LOADED", "target_variable": "Y",
+        })
+    assert result.data["status"] == "table_not_global"
+    mock_client.post.assert_not_called()
+
+
+async def test_create_ml_project_table_not_found(mcp_server_with_mock_client):
+    """Pre-flight: a missing table returns a not_found status, no POST."""
+    mcp, mock_client = mcp_server_with_mock_client
+    resp = _make_mock_response(status_code=404)
+    resp.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError(
+        "missing", request=MagicMock(), response=MagicMock(status_code=404)))
+    mock_client.get.return_value = resp
+    async with Client(mcp) as client:
+        result = await client.call_tool("create_ml_project", {
+            "project_name": "Bad", "caslib_name": "Public",
+            "table_name": "GHOST", "target_variable": "Y",
+        })
+    assert result.data["status"] == "table_not_found"
+    mock_client.post.assert_not_called()
 
 
 async def test_run_ml_project_request(mcp_server_with_mock_client):
@@ -612,10 +690,112 @@ async def test_score_data_request(mcp_server_with_mock_client):
 async def test_execute_sas_code_request(mcp_server_with_mock_client):
     mcp, _ = mcp_server_with_mock_client
     with patch("sas_mcp_server.tools.run_one_snippet") as mock_run:
-        mock_run.return_value = ("1", "completed", "LOG", "LISTING")
+        mock_run.return_value = {
+            "snippet_id": "1", "state": "completed", "log": "LOG", "listing": "LISTING",
+        }
         async with Client(mcp) as client:
             result = await client.call_tool("execute_sas_code", {
                 "sas_code": "data test; x=1; run;"
             })
 
         mock_run.assert_called_once_with("data test; x=1; run;", "1", "test-token")
+        assert result.data == {
+            "snippet_id": "1", "state": "completed", "log": "LOG", "listing": "LISTING",
+        }
+
+
+# -----------------------------------------------------------------------
+# Error / edge-path coverage
+# -----------------------------------------------------------------------
+
+
+async def test_upload_data_conflict_returns_structured_error(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.post.return_value = _make_mock_response(status_code=409)
+    async with Client(mcp) as client:
+        result = await client.call_tool("upload_data", {
+            "server_id": "cas1", "caslib_name": "Public",
+            "table_name": "MY_TABLE", "csv_data": "a,b\n1,2",
+        })
+    assert result.data["status"] == "table_already_exists"
+    assert result.data["table_name"] == "MY_TABLE"
+    assert result.data["caslib"] == "Public"
+
+
+async def test_promote_table_already_global_is_noop(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "loaded", "scope": "global"})
+    async with Client(mcp) as client:
+        result = await client.call_tool("promote_table_to_memory", {
+            "server_id": "cas1", "caslib_name": "Public", "table_name": "MY_TABLE",
+        })
+    assert result.data["status"] == "already_global"
+    assert result.data["table"] == "Public.MY_TABLE"
+    mock_client.put.assert_not_called()
+
+
+async def test_promote_table_not_found(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    resp = _make_mock_response(status_code=404)
+    resp.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError(
+        "missing", request=MagicMock(), response=MagicMock(status_code=404)))
+    mock_client.get.return_value = resp
+    async with Client(mcp) as client:
+        result = await client.call_tool("promote_table_to_memory", {
+            "server_id": "cas1", "caslib_name": "Public", "table_name": "GHOST",
+        })
+    assert result.data["status"] == "not_found"
+    mock_client.put.assert_not_called()
+
+
+async def test_get_job_log_no_log_uri_returns_state(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"state": "completed", "results": {}})
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_job_log", {"job_id": "j1"})
+    assert result.data == "No log available. Job state: completed"
+
+
+async def test_get_job_log_error_dict_returns_message(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({
+        "state": "failed", "results": {}, "error": {"message": "boom"},
+    })
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_job_log", {"job_id": "j1"})
+    assert result.data == "Job failed: boom"
+
+
+async def test_get_job_log_dot_log_fallback(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    job_resp = _make_mock_response({
+        "state": "completed", "results": {"run.log": "/files/files/LOGID"},
+    })
+    content_resp = _make_mock_response()
+    content_resp.text = "LOG CONTENT"
+    original_get = mock_client.get.return_value
+
+    def route_get(url, **kwargs):
+        if "/jobExecution/jobs/j1" in url and "/content" not in url:
+            return job_resp
+        if "/files/files/LOGID/content" in url:
+            return content_resp
+        return original_get
+
+    mock_client.get.side_effect = route_get
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_job_log", {"job_id": "j1"})
+    mock_client.get.side_effect = None
+    mock_client.get.return_value = original_get
+    assert result.data == "LOG CONTENT"
+
+
+async def test_run_ml_project_204_returns_running(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    get_resp = _make_mock_response({"id": "p1"})
+    get_resp.headers = {"etag": '"e"', "Content-Type": "application/json"}
+    mock_client.get.return_value = get_resp
+    mock_client.put.return_value = _make_mock_response(status_code=204)
+    async with Client(mcp) as client:
+        result = await client.call_tool("run_ml_project", {"project_id": "p1"})
+    assert result.data == {"status": "running", "projectId": "p1"}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,35 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for the new API wrapper functions in viya_utils and tool registration.
+Tests for the generic Viya REST helper functions in viya_client.
 """
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
-from sas_mcp_server.viya_utils import (
-    _get_json,
-    _get_paged_items,
-    _post_json,
-    _put_data,
-    _delete_resource,
-    _make_client,
+import pytest
+
+from sas_mcp_server.viya_client import (
+    delete_resource,
+    get_json,
+    get_paged_items,
+    make_client,
+    post_json,
 )
 
-
 # ---------------------------------------------------------------------------
-# _get_json
+# get_json
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_get_json_success(mock_httpx_client, mock_env_vars):
-    """Test _get_json returns parsed JSON."""
+    """Test get_json returns parsed JSON."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.json = MagicMock(return_value={"name": "cas-shared-default"})
     mock_httpx_client.get.return_value = mock_response
 
-    result = await _get_json("/casManagement/servers/cas1", mock_httpx_client)
+    result = await get_json("/casManagement/servers/cas1", mock_httpx_client)
 
     assert result == {"name": "cas-shared-default"}
     mock_httpx_client.get.assert_called_once()
@@ -38,13 +38,13 @@ async def test_get_json_success(mock_httpx_client, mock_env_vars):
 
 @pytest.mark.asyncio
 async def test_get_json_with_params(mock_httpx_client, mock_env_vars):
-    """Test _get_json passes query params."""
+    """Test get_json passes query params."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.json = MagicMock(return_value={"items": []})
     mock_httpx_client.get.return_value = mock_response
 
-    await _get_json("/test", mock_httpx_client, params={"limit": 10})
+    await get_json("/test", mock_httpx_client, params={"limit": 10})
 
     call_kwargs = mock_httpx_client.get.call_args
     assert call_kwargs[1]["params"] == {"limit": 10}
@@ -52,7 +52,7 @@ async def test_get_json_with_params(mock_httpx_client, mock_env_vars):
 
 @pytest.mark.asyncio
 async def test_get_json_raises_on_error(mock_httpx_client, mock_env_vars):
-    """Test _get_json propagates HTTP errors."""
+    """Test get_json propagates HTTP errors."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock(
         side_effect=httpx.HTTPStatusError("404", request=MagicMock(), response=MagicMock())
@@ -60,17 +60,17 @@ async def test_get_json_raises_on_error(mock_httpx_client, mock_env_vars):
     mock_httpx_client.get.return_value = mock_response
 
     with pytest.raises(httpx.HTTPStatusError):
-        await _get_json("/bad/path", mock_httpx_client)
+        await get_json("/bad/path", mock_httpx_client)
 
 
 # ---------------------------------------------------------------------------
-# _get_paged_items
+# get_paged_items
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_get_paged_items_success(mock_httpx_client, mock_env_vars):
-    """Test _get_paged_items returns items and count."""
+    """Test get_paged_items returns items and count."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.json = MagicMock(return_value={
@@ -79,8 +79,8 @@ async def test_get_paged_items_success(mock_httpx_client, mock_env_vars):
     })
     mock_httpx_client.get.return_value = mock_response
 
-    items, count = await _get_paged_items("/casManagement/servers/cas1/caslibs",
-                                          mock_httpx_client, limit=50)
+    items, count = await get_paged_items("/casManagement/servers/cas1/caslibs",
+                                         mock_httpx_client, limit=50)
 
     assert len(items) == 2
     assert count == 2
@@ -89,27 +89,27 @@ async def test_get_paged_items_success(mock_httpx_client, mock_env_vars):
 
 @pytest.mark.asyncio
 async def test_get_paged_items_with_filter(mock_httpx_client, mock_env_vars):
-    """Test _get_paged_items passes filter parameter."""
+    """Test get_paged_items passes filter parameter."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.json = MagicMock(return_value={"items": [], "count": 0})
     mock_httpx_client.get.return_value = mock_response
 
-    await _get_paged_items("/files/files", mock_httpx_client,
-                           filters="contains(name,'test')")
+    await get_paged_items("/files/files", mock_httpx_client,
+                          filters="contains(name,'test')")
 
     call_kwargs = mock_httpx_client.get.call_args[1]
     assert call_kwargs["params"]["filter"] == "contains(name,'test')"
 
 
 # ---------------------------------------------------------------------------
-# _post_json
+# post_json
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_post_json_success(mock_httpx_client, mock_env_vars):
-    """Test _post_json sends body and returns response."""
+    """Test post_json sends body and returns response."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.status_code = 201
@@ -117,8 +117,8 @@ async def test_post_json_success(mock_httpx_client, mock_env_vars):
     mock_response.json = MagicMock(return_value={"id": "new-project"})
     mock_httpx_client.post.return_value = mock_response
 
-    result = await _post_json("/mlPipelineAutomation/projects",
-                              mock_httpx_client, body={"name": "test"})
+    result = await post_json("/mlPipelineAutomation/projects",
+                             mock_httpx_client, body={"name": "test"})
 
     assert result == {"id": "new-project"}
     mock_httpx_client.post.assert_called_once()
@@ -126,75 +126,53 @@ async def test_post_json_success(mock_httpx_client, mock_env_vars):
 
 @pytest.mark.asyncio
 async def test_post_json_no_content(mock_httpx_client, mock_env_vars):
-    """Test _post_json handles 204 No Content."""
+    """Test post_json handles 204 No Content."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.status_code = 204
     mock_response.content = b""
     mock_httpx_client.post.return_value = mock_response
 
-    result = await _post_json("/some/action", mock_httpx_client)
+    result = await post_json("/some/action", mock_httpx_client)
 
     assert result == {}
 
 
 # ---------------------------------------------------------------------------
-# _put_data
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_put_data_success(mock_httpx_client, mock_env_vars):
-    """Test _put_data uploads raw data."""
-    mock_response = AsyncMock()
-    mock_response.raise_for_status = MagicMock()
-    mock_response.status_code = 201
-    mock_response.content = b'{"tableName": "test"}'
-    mock_response.json = MagicMock(return_value={"tableName": "test"})
-    mock_httpx_client.put.return_value = mock_response
-
-    result = await _put_data("/casManagement/servers/cas1/caslibs/Public/tables/test",
-                             mock_httpx_client, data=b"a,b\n1,2")
-
-    assert result == {"tableName": "test"}
-    mock_httpx_client.put.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# _delete_resource
+# delete_resource
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_delete_resource_success(mock_httpx_client, mock_env_vars):
-    """Test _delete_resource sends DELETE request."""
+    """Test delete_resource sends DELETE request."""
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
     mock_httpx_client.delete.return_value = mock_response
 
-    await _delete_resource("/jobExecution/jobs/job123", mock_httpx_client)
+    await delete_resource("/jobExecution/jobs/job123", mock_httpx_client)
 
     mock_httpx_client.delete.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# _make_client
+# make_client
 # ---------------------------------------------------------------------------
 
 
 def test_make_client_adds_bearer_prefix(mock_env_vars):
-    """Test _make_client adds Bearer prefix when missing."""
-    with patch('sas_mcp_server.viya_utils.httpx.AsyncClient') as mock_cls:
+    """Test make_client adds Bearer prefix when missing."""
+    with patch('sas_mcp_server.viya_client.httpx.AsyncClient') as mock_cls:
         mock_cls.return_value = MagicMock()
-        _make_client("my-token")
+        make_client("my-token")
         call_kwargs = mock_cls.call_args[1]
         assert call_kwargs["headers"]["Authorization"] == "Bearer my-token"
 
 
 def test_make_client_preserves_bearer_prefix(mock_env_vars):
-    """Test _make_client does not double-prefix Bearer."""
-    with patch('sas_mcp_server.viya_utils.httpx.AsyncClient') as mock_cls:
+    """Test make_client does not double-prefix Bearer."""
+    with patch('sas_mcp_server.viya_client.httpx.AsyncClient') as mock_cls:
         mock_cls.return_value = MagicMock()
-        _make_client("Bearer my-token")
+        make_client("Bearer my-token")
         call_kwargs = mock_cls.call_args[1]
         assert call_kwargs["headers"]["Authorization"] == "Bearer my-token"

--- a/tests/test_viya_utils.py
+++ b/tests/test_viya_utils.py
@@ -2,22 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for viya_utils module.
+Tests for viya_utils module (compute session/job orchestration).
 """
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-import httpx
+
+import pytest
+
 from sas_mcp_server.viya_utils import (
-    get_context_id,
     create_session,
+    get_context_id,
+    run_one_snippet,
     submit_job,
     wait_job,
-    run_one_snippet,
-    fetch_full_job_log,
-    fetch_full_job_listing,
-    fetch_full_session_log,
-    _get_text,
-    _get_paged_lines
 )
 
 
@@ -27,9 +23,9 @@ async def test_get_context_id_success(mock_httpx_client, mock_context_response, 
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value=mock_context_response)
     mock_httpx_client.get.return_value = mock_response
-    
+
     context_id = await get_context_id(mock_httpx_client, "Test Context")
-    
+
     assert context_id == "test-context-id"
     mock_httpx_client.get.assert_called_once()
 
@@ -40,7 +36,7 @@ async def test_get_context_id_not_found(mock_httpx_client, mock_env_vars):
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value={"items": []})
     mock_httpx_client.get.return_value = mock_response
-    
+
     with pytest.raises(RuntimeError, match="Compute context not found"):
         await get_context_id(mock_httpx_client, "NonExistent Context")
 
@@ -51,9 +47,9 @@ async def test_create_session(mock_httpx_client, mock_session_response, mock_env
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value=mock_session_response)
     mock_httpx_client.post.return_value = mock_response
-    
+
     session_id = await create_session(mock_httpx_client, "test-context-id", "test-session")
-    
+
     assert session_id == "test-session-id"
     mock_httpx_client.post.assert_called_once()
     call_args = mock_httpx_client.post.call_args
@@ -66,9 +62,9 @@ async def test_submit_job(mock_httpx_client, mock_job_response, sample_sas_code,
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value=mock_job_response)
     mock_httpx_client.post.return_value = mock_response
-    
+
     job_id = await submit_job(mock_httpx_client, "test-session-id", sample_sas_code)
-    
+
     assert job_id == "test-job-id"
     mock_httpx_client.post.assert_called_once()
     call_args = mock_httpx_client.post.call_args
@@ -82,24 +78,24 @@ async def test_wait_job_completed(mock_httpx_client, mock_job_log, mock_job_list
     # Mock state response
     mock_state_response = AsyncMock()
     mock_state_response.text = "completed"
-    
+
     # Mock log response
     mock_log_response = AsyncMock()
     mock_log_response.json = MagicMock(return_value=mock_job_log)
-    
+
     # Mock listing response
     mock_listing_response = AsyncMock()
     mock_listing_response.json = MagicMock(return_value=mock_job_listing)
-    
+
     # Set up the client to return different responses
     mock_httpx_client.get.side_effect = [
         mock_state_response,
         mock_log_response,
         mock_listing_response
     ]
-    
+
     state, log, listing = await wait_job(mock_httpx_client, "test-session-id", "test-job-id", poll=0.01)
-    
+
     assert state == "completed"
     assert "NOTE: DATA statement used" in log
     assert "Obs    x    y" in listing
@@ -110,157 +106,55 @@ async def test_wait_job_error_state(mock_httpx_client, mock_job_log, mock_job_li
     """Test waiting for job that ends in error state."""
     mock_state_response = AsyncMock()
     mock_state_response.text = "error"
-    
+
     mock_log_response = AsyncMock()
     mock_log_response.json = MagicMock(return_value={
         "items": [{"line": "ERROR: Something went wrong"}]
     })
-    
+
     mock_listing_response = AsyncMock()
     mock_listing_response.json = MagicMock(return_value={"items": []})
-    
+
     mock_httpx_client.get.side_effect = [
         mock_state_response,
         mock_log_response,
         mock_listing_response
     ]
-    
+
     state, log, listing = await wait_job(mock_httpx_client, "test-session-id", "test-job-id", poll=0.01)
-    
+
     assert state == "error"
     assert "ERROR: Something went wrong" in log
 
 
 @pytest.mark.asyncio
-async def test_get_text_success(mock_httpx_client):
-    """Test _get_text when text/plain is returned."""
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {"Content-Type": "text/plain"}
-    mock_response.text = "Sample text output"
-    mock_httpx_client.get.return_value = mock_response
-    
-    result = await _get_text("/test/endpoint", mock_httpx_client)
-    
-    assert result == "Sample text output"
-
-
-@pytest.mark.asyncio
-async def test_get_text_fallback(mock_httpx_client):
-    """Test _get_text fallback when first attempt fails."""
-    mock_response_1 = AsyncMock()
-    mock_response_1.status_code = 404
-    mock_response_1.headers = {}
-    
-    mock_response_2 = AsyncMock()
-    mock_response_2.status_code = 200
-    mock_response_2.headers = {"Content-Type": "text/plain"}
-    mock_response_2.text = "Sample text output"
-    
-    mock_httpx_client.get.side_effect = [mock_response_1, mock_response_2]
-    
-    result = await _get_text("/test/endpoint", mock_httpx_client)
-    
-    assert result == "Sample text output"
-    assert mock_httpx_client.get.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_get_text_failure(mock_httpx_client):
-    """Test _get_text when both attempts fail."""
-    mock_response = AsyncMock()
-    mock_response.status_code = 404
-    mock_response.headers = {}
-    
-    mock_httpx_client.get.return_value = mock_response
-    
-    result = await _get_text("/test/endpoint", mock_httpx_client)
-    
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_get_paged_lines(mock_httpx_client):
-    """Test _get_paged_lines pagination."""
-    # First page
-    mock_response_1 = AsyncMock()
-    mock_response_1.raise_for_status = MagicMock()
-    mock_response_1.json = MagicMock(return_value={
-        "items": [
-            {"line": "Line 1"},
-            {"line": "Line 2"}
-        ]
-    })
-    
-    # Second page (empty, ends pagination)
-    mock_response_2 = AsyncMock()
-    mock_response_2.raise_for_status = MagicMock()
-    mock_response_2.json = MagicMock(return_value={"items": []})
-    
-    mock_httpx_client.get.side_effect = [mock_response_1, mock_response_2]
-    
-    result = await _get_paged_lines("/test/endpoint", mock_httpx_client, page_limit=2)
-    
-    assert result == "Line 1\nLine 2"
-    assert mock_httpx_client.get.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_fetch_full_job_log(mock_httpx_client):
-    """Test fetching full job log."""
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {"Content-Type": "text/plain"}
-    mock_response.text = "Job log output"
-    mock_httpx_client.get.return_value = mock_response
-    
-    result = await fetch_full_job_log(mock_httpx_client, "session-id", "job-id")
-    
-    assert result == "Job log output"
-
-
-@pytest.mark.asyncio
-async def test_fetch_full_job_listing(mock_httpx_client):
-    """Test fetching full job listing."""
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {"Content-Type": "text/plain"}
-    mock_response.text = "Job listing output"
-    mock_httpx_client.get.return_value = mock_response
-    
-    result = await fetch_full_job_listing(mock_httpx_client, "session-id", "job-id")
-    
-    assert result == "Job listing output"
-
-
-@pytest.mark.asyncio
 async def test_run_one_snippet_success(sample_sas_code, mock_access_token, mock_env_vars):
-    """Test successful execution of a SAS code snippet."""
-    with patch('sas_mcp_server.viya_utils.httpx.AsyncClient') as mock_client_class:
+    """Test successful execution of a SAS code snippet returns a structured dict."""
+    with patch('sas_mcp_server.viya_client.httpx.AsyncClient') as mock_client_class:
         mock_client = AsyncMock()
         mock_client_class.return_value.__aenter__.return_value = mock_client
-        
+
         # Mock all the API calls
         mock_context_response = AsyncMock()
         mock_context_response.json = MagicMock(return_value={"items": [{"id": "ctx-id"}]})
-        
+
         mock_session_response = AsyncMock()
         mock_session_response.json = MagicMock(return_value={"id": "sess-id"})
-        
+
         mock_job_response = AsyncMock()
         mock_job_response.json = MagicMock(return_value={"id": "job-id"})
-        
+
         mock_state_response = AsyncMock()
         mock_state_response.text = "completed"
-        
+
         mock_log_response = AsyncMock()
         mock_log_response.json = MagicMock(return_value={"items": [{"line": "Log output"}]})
-        
+
         mock_listing_response = AsyncMock()
         mock_listing_response.json = MagicMock(return_value={"items": [{"line": "Listing output"}]})
-        
+
         mock_delete_response = AsyncMock()
-        
+
         mock_client.get.side_effect = [
             mock_context_response,
             mock_state_response,
@@ -269,45 +163,45 @@ async def test_run_one_snippet_success(sample_sas_code, mock_access_token, mock_
         ]
         mock_client.post.side_effect = [mock_session_response, mock_job_response]
         mock_client.delete.return_value = mock_delete_response
-        
+
         result = await run_one_snippet(sample_sas_code, "1", mock_access_token)
-        
-        assert result[0] == "1"  # snippet_id
-        assert result[1] == "completed"  # state
-        assert "Log output" in result[2]  # log
-        assert "Listing output" in result[3]  # listing
+
+        assert result["snippet_id"] == "1"
+        assert result["state"] == "completed"
+        assert "Log output" in result["log"]
+        assert "Listing output" in result["listing"]
 
 
 @pytest.mark.asyncio
 async def test_run_one_snippet_with_bearer_prefix(sample_sas_code, mock_env_vars):
     """Test that Bearer prefix is handled correctly."""
     token_with_bearer = "Bearer test-token"
-    
-    with patch('sas_mcp_server.viya_utils.httpx.AsyncClient') as mock_client_class:
+
+    with patch('sas_mcp_server.viya_client.httpx.AsyncClient') as mock_client_class:
         mock_client = AsyncMock()
         mock_client_class.return_value.__aenter__.return_value = mock_client
-        
+
         # Mock minimal responses for the test
         mock_context_response = AsyncMock()
         mock_context_response.json = MagicMock(return_value={"items": [{"id": "ctx-id"}]})
-        
+
         mock_session_response = AsyncMock()
         mock_session_response.json = MagicMock(return_value={"id": "sess-id"})
-        
+
         mock_job_response = AsyncMock()
         mock_job_response.json = MagicMock(return_value={"id": "job-id"})
-        
+
         mock_state_response = AsyncMock()
         mock_state_response.text = "completed"
-        
+
         mock_log_response = AsyncMock()
         mock_log_response.json = MagicMock(return_value={"items": []})
-        
+
         mock_listing_response = AsyncMock()
         mock_listing_response.json = MagicMock(return_value={"items": []})
-        
+
         mock_delete_response = AsyncMock()
-        
+
         mock_client.get.side_effect = [
             mock_context_response,
             mock_state_response,
@@ -316,10 +210,55 @@ async def test_run_one_snippet_with_bearer_prefix(sample_sas_code, mock_env_vars
         ]
         mock_client.post.side_effect = [mock_session_response, mock_job_response]
         mock_client.delete.return_value = mock_delete_response
-        
+
         result = await run_one_snippet(sample_sas_code, "1", token_with_bearer)
-        
+        assert result["state"] == "completed"
+
         # Verify the client was created with Bearer token
         call_kwargs = mock_client_class.call_args[1]
         assert "Authorization" in call_kwargs["headers"]
         assert call_kwargs["headers"]["Authorization"] == token_with_bearer
+
+
+@pytest.mark.asyncio
+async def test_wait_job_polls_until_terminal(mock_httpx_client, mock_env_vars):
+    """wait_job keeps polling while the state is non-terminal."""
+    running = AsyncMock()
+    running.text = "running"
+    completed = AsyncMock()
+    completed.text = "completed"
+    log_resp = AsyncMock()
+    log_resp.json = MagicMock(return_value={"items": [{"line": "L"}]})
+    listing_resp = AsyncMock()
+    listing_resp.json = MagicMock(return_value={"items": [{"line": "O"}]})
+    mock_httpx_client.get.side_effect = [running, completed, log_resp, listing_resp]
+
+    state, log, listing = await wait_job(mock_httpx_client, "s", "j", poll=0.001)
+
+    assert state == "completed"
+    assert "L" in log
+    assert "O" in listing
+
+
+@pytest.mark.asyncio
+async def test_run_one_snippet_propagates_error_and_cleans_up(
+    sample_sas_code, mock_access_token, mock_env_vars
+):
+    """On failure the error propagates and the compute session is still deleted."""
+    with patch('sas_mcp_server.viya_client.httpx.AsyncClient') as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        ctx_resp = AsyncMock()
+        ctx_resp.json = MagicMock(return_value={"items": [{"id": "ctx-id"}]})
+        sess_resp = AsyncMock()
+        sess_resp.json = MagicMock(return_value={"id": "sess-id"})
+
+        mock_client.get.side_effect = [ctx_resp]
+        mock_client.post.side_effect = [sess_resp, Exception("submit boom")]
+        mock_client.delete.return_value = AsyncMock()
+
+        with pytest.raises(Exception, match="submit boom"):
+            await run_one_snippet(sample_sas_code, "1", mock_access_token)
+
+        mock_client.delete.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,90 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -648,6 +732,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -880,6 +973,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -906,6 +1012,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1161,7 +1281,7 @@ wheels = [
 
 [[package]]
 name = "sas-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1173,8 +1293,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -1189,8 +1311,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.14.4" },
 ]
 


### PR DESCRIPTION
## Summary

Comprehensive code-quality overhaul of `sas-mcp-server` (**1.1.0**), plus fixes for two
reported tool bugs. Rebased onto current `main`, so this diff is **only** the code-quality
work (the GHCR/auth work from #12 is already in `main`).

### Tooling & CI
- `ruff` + `pyright` config and `pytest-cov` (90% floor).
- New `ci.yml` gates **ruff → pyright → unit tests** on every PR — previously CI only built
  Docker images, so tests and lint were never enforced.
- Opt-in `integration.yml` runs the live-Viya suite and publishes results to the PR (status
  check + sticky comment + JUnit artifact) without committing anything.

### Refactor
- New `viya_client` (public REST helpers), `exceptions`, and `env` modules; dead code removed
  from `viya_utils`.
- Full type annotations; the repeated per-tool preamble collapsed into a `viya_session`
  context manager; lazy `%`-style logging.

### Tests
- Unit coverage **~58% → ~95%**; new suites for the OAuth login helper, stdio token
  resolution, HTTP auth middleware, config OAuth, and `env`; tautological tests rewritten.
- Live integration suite now covers **all 27 tools + 8 prompt templates**, enforced by
  `test_every_tool_has_integration_coverage` / `test_every_prompt_has_integration_coverage`.

### Fixes
- **`promote_table_to_memory` (#10):** was always 404 for the load-then-promote flow (the
  session-scoped table is gone by the next call). Now loads a source table and promotes it to
  global scope via the `updateTableState` API, **idempotently** (no-op if already
  loaded+global). Adds a **`list_source_tables`** tool to discover unloaded source tables.
- **`create_ml_project`:** takes `server_id` (default `cas-shared-default`) / `caslib_name` /
  `table_name` instead of a hand-built `data_table_uri`, and pre-checks that the table is
  loaded in global scope — returning an actionable error instead of an opaque
  `mlPipelineAutomation` failure.

### ⚠️ Breaking changes
- `execute_sas_code` now returns `{snippet_id, state, log, listing}` instead of a 4-element
  array.
- `create_ml_project` replaces `data_table_uri` with `server_id`/`caslib_name`/`table_name`.

### Verification
- `ruff` ✓, `pyright` ✓ (0 errors), **127 unit tests** (94.6% coverage).
- **21/21 integration tests** against a live SAS Viya — every tool and prompt exercised.

<details><summary>Integration results (live SAS Viya, 21/21)</summary>

| Test | Result |
|---|---|
| test_cas_discovery_workflow | PASS |
| test_data_upload_workflow | PASS |
| test_file_service_workflow | PASS |
| test_sas_code_execution | PASS |
| test_batch_job_workflow | PASS |
| test_report_workflow | PASS |
| test_ml_project_workflow | PASS |
| test_scoring_workflow | PASS |
| test_cancel_job_workflow | PASS |
| test_run_ml_project_workflow | PASS |
| test_promote_from_source_workflow | PASS |
| test_prompt_renders_through_live_server (×8 prompts) | PASS |
| test_every_tool_has_integration_coverage | PASS |
| test_every_prompt_has_integration_coverage | PASS |

</details>

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
