### PR TITLE
feat(catalog): SAS Information Catalog tools (search, profiling, discovery)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ reports/
 .DS_Store
 Thumbs.db
 
+# Reference material (API specs, course samples, scratch scripts) — kept local, not tracked
+docs/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
 target-version = "py312"
 line-length = 120
 src = ["src", "tests"]
+# Reference material (API specs, course samples, scratch scripts) is not project
+# source and should not be linted.
+extend-exclude = ["docs"]
 
 [tool.ruff.lint]
 # E/F: pyflakes + pycodestyle, I: isort, B: bugbear, UP: pyupgrade,

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -1002,20 +1002,23 @@ def register_tools(
                 params={"q": query, "indices": indices, "start": start, "limit": limit},
                 accept=search_collection_type,
             )
-            items = [
-                {
-                    "id": it.get("id"),
-                    "type": it.get("type"),
-                    "typeLabel": it.get("typeLabel", ""),
-                    "label": it.get("label", ""),
-                    "name": it.get("name", ""),
-                    "description": it.get("description", ""),
-                    "score": it.get("score"),
-                    "resource_uri": resource_uri_of(it),
-                    "attributes": it.get("attributes", {}),
-                }
-                for it in data.get("items", [])
-            ]
+            raw_items = data.get("items", [])
+            items = return_items(
+                raw_items,
+                [
+                    "id",
+                    "type",
+                    "typeLabel",
+                    "label",
+                    "name",
+                    "description",
+                    "score",
+                    "attributes",
+                ],
+            )
+            # resource_uri is derived from the item's links, not a flat field.
+            for out, src in zip(items, raw_items, strict=True):
+                out["resource_uri"] = resource_uri_of(src)
             return {
                 "count": data.get("count", len(items)),
                 "start": data.get("start", start),
@@ -1055,14 +1058,9 @@ def register_tools(
                 client,
                 params={"q": query, "start": 0, "limit": limit},
             )
-            facets = [
-                {
-                    "name": f.get("name"),
-                    "type": f.get("type", ""),
-                    "indices": f.get("indices", []),
-                }
-                for f in data.get("items", [])
-            ]
+            facets = return_items(
+                data.get("items", []), ["name", "type", "indices"]
+            )
             return {"facets": facets}
 
     @mcp.tool()

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -927,3 +927,528 @@ def register_tools(
             "compute_context": context_name,
             "deleted_session": sid,
         }
+
+    # ------------------------------------------------------------------
+    # Tier 7 — Information Catalog (metadata discovery & profiling)
+    # ------------------------------------------------------------------
+
+    catalog = "/catalog"
+    search_collection_type = "application/vnd.sas.metadata.search.collection+json"
+    # The adhoc job's status lives only in the full representation; the summary
+    # (application/json) omits it.
+    adhoc_media = "application/vnd.sas.metadata.bot.adhoc+json"
+    profile_levels = ("dataDictionary", "dataDictionaryAndProfile", "detailedMetrics")
+
+    def resource_uri_of(item: dict[str, Any]) -> str:
+        """Pull the source-asset URI (rel='resource') from a catalog item's links."""
+        for link in item.get("links", []) or []:
+            if link.get("rel") == "resource":
+                return link.get("href", "") or link.get("uri", "")
+        return ""
+
+    async def instance_for_resource_uri(
+        client: httpx.AsyncClient, resource_uri: str
+    ) -> dict[str, Any] | None:
+        """Resolve the catalog instance for a source-asset URI, or None if absent.
+
+        Filters ``/catalog/instances`` by ``resourceId`` — the reliable way to
+        locate the instance that profiling writes its results onto, rather than
+        assuming the instance id equals a search hit's id.
+        """
+        data = await get_json(
+            f"{catalog}/instances",
+            client,
+            params={"filter": f'eq(resourceId,"{resource_uri}")'},
+        )
+        items = data.get("items", []) or []
+        return items[0] if items else None
+
+    @mcp.tool()
+    async def catalog_search(
+        query: str,
+        ctx: Context,
+        indices: str = "catalog",
+        limit: int = 20,
+        start: int = 0,
+    ) -> dict[str, Any]:
+        """Search the SAS Information Catalog for assets (tables, columns, reports, ...).
+
+        The catalog is a metadata index across the whole Viya environment, so this
+        finds assets without needing to know their server/library first. Each hit
+        includes the asset's ``resource_uri`` — the URI you can hand to the matching
+        tool (e.g. get_report, get_castable_data) to act on the live asset — and an
+        ``attributes`` map with whatever metadata the catalog holds for it (commonly
+        ``library``, ``rowCount``, ``columnCount``, ``completenessPercent``,
+        ``reviewStatus``, ``informationPrivacy``, and ``analysisTimeStamp``).
+
+        The ``query`` uses the SAS catalog search grammar:
+          * Free text matches names, with wildcards ``*`` (0+ chars) and ``?`` (1 char): ``cust*``.
+          * Facets constrain fields, e.g. ``AssetType:Report``, ``Name:sales``,
+            ``Library.name:PUBLIC``, ``Column.informationPrivacy:Sensitive``.
+          * Ranges ``DateModified:[2024-01-01 TO 2024-12-31]`` and ``+`` to require a term.
+            Combine freely: ``AssetType:"CAS Table" +Name:cust*``.
+        Use ``catalog_search_helper`` to discover valid facet names and values.
+
+        Args:
+            query: The catalog search query (see grammar above). Use ``*`` to match all names.
+            indices: Comma-separated index name(s) to search (default 'catalog').
+            limit: Maximum hits to return (default 20).
+            start: Offset of the first hit (default 0).
+        """
+        async with viya_session("catalog_search", ctx) as client:
+            data = await get_json(
+                f"{catalog}/search",
+                client,
+                params={"q": query, "indices": indices, "start": start, "limit": limit},
+                accept=search_collection_type,
+            )
+            items = [
+                {
+                    "id": it.get("id"),
+                    "type": it.get("type"),
+                    "typeLabel": it.get("typeLabel", ""),
+                    "label": it.get("label", ""),
+                    "name": it.get("name", ""),
+                    "description": it.get("description", ""),
+                    "score": it.get("score"),
+                    "resource_uri": resource_uri_of(it),
+                    "attributes": it.get("attributes", {}),
+                }
+                for it in data.get("items", [])
+            ]
+            return {
+                "count": data.get("count", len(items)),
+                "start": data.get("start", start),
+                "limit": data.get("limit", limit),
+                "items": items,
+            }
+
+    @mcp.tool()
+    async def catalog_search_helper(
+        ctx: Context, facet: str | None = None, query: str = "", limit: int = 50
+    ) -> dict[str, Any]:
+        """Discover how to search the catalog: list facets, or values for one facet.
+
+        Call with no ``facet`` to list the available facets — the fields you can
+        constrain in a ``catalog_search`` query. Call with a ``facet`` name to get the
+        suggested/valid values for that facet (e.g. the asset types or review
+        statuses that actually exist). Use the results to build precise
+        ``catalog_search`` queries.
+
+        Args:
+            facet: Facet name to get suggested values for (e.g. 'AssetType'). If
+                omitted, returns the list of available facets instead.
+            query: Optional filter — when listing facets, matches facet names; when
+                listing values, matches value prefixes.
+            limit: Maximum entries to return (default 50).
+        """
+        async with viya_session("catalog_search_helper", ctx) as client:
+            if facet:
+                data = await get_json(
+                    f"{catalog}/search/suggestions",
+                    client,
+                    params={"facet": facet, "q": query, "limit": limit},
+                )
+                return {"facet": facet, "values": data.get("items", [])}
+            data = await get_json(
+                f"{catalog}/search/facets",
+                client,
+                params={"q": query, "start": 0, "limit": limit},
+            )
+            facets = [
+                {
+                    "name": f.get("name"),
+                    "type": f.get("type", ""),
+                    "indices": f.get("indices", []),
+                }
+                for f in data.get("items", [])
+            ]
+            return {"facets": facets}
+
+    @mcp.tool()
+    async def catalog_find_instance(
+        resource_uri: str, ctx: Context
+    ) -> dict[str, Any]:
+        """Resolve the catalog instance for a source-asset URI.
+
+        ``catalog_search`` finds assets by free text and facets, but the
+        profiling and download tools key off a catalog *instance id*. When you
+        already hold a resource URI — the ``resource_uri`` from a search hit, or
+        a CAS table path — this looks the instance up directly by ``resourceId``
+        (the same filter the profiling workflow uses) and returns its id plus
+        the key profile attributes. Use it to tell at a glance whether the asset
+        has been profiled (``analysisTimeStamp``) and what semantic metadata it
+        carries (``informationPrivacy``, ``nlpTerms``, ``nlpTags``,
+        ``mostImportantFields``) before calling ``catalog_download_table_profile``.
+
+        Args:
+            resource_uri: Source URI of the asset (e.g.
+                '/dataTables/dataSources/cas~fs~.../tables/MYTABLE').
+        """
+        async with viya_session("catalog_find_instance", ctx) as client:
+            inst = await instance_for_resource_uri(client, resource_uri)
+            if inst is None:
+                return {
+                    "status": "not_found",
+                    "resource_uri": resource_uri,
+                    "message": (
+                        "No catalog instance indexes that URI yet. Confirm the URI "
+                        "with catalog_search, or run a discovery agent "
+                        "(catalog_run_agent) to populate it."
+                    ),
+                }
+            attrs = inst.get("attributes", {}) or {}
+            return {
+                "status": "ok",
+                "instance_id": inst.get("id"),
+                "name": inst.get("name", ""),
+                "type": inst.get("type", ""),
+                "resource_uri": inst.get("resourceId", resource_uri),
+                "profiled": bool(attrs.get("analysisTimeStamp")),
+                "attributes": attrs,
+            }
+
+    @mcp.tool()
+    async def catalog_list_agents(
+        ctx: Context, limit: int = 50, start: int = 0, filter_name: str | None = None
+    ) -> list[dict[str, Any]]:
+        """List SAS Information Catalog discovery agents.
+
+        Agents crawl a data source (server/library) to discover assets and collect
+        their metadata into the catalog. Use ``catalog_run_agent`` to start one and
+        ``catalog_get_agent_history`` to see what a run produced.
+
+        Args:
+            limit: Maximum agents to return (default 50).
+            start: Offset of the first agent (default 0).
+            filter_name: Optional name filter (substring match).
+        """
+        params: dict[str, Any] = {"start": start, "limit": limit}
+        if filter_name:
+            params["filter"] = f"contains(name,'{filter_name}')"
+        async with viya_session("catalog_list_agents", ctx) as client:
+            data = await get_json(f"{catalog}/bots", client, params=params)
+            return return_items(
+                data.get("items", []),
+                ["id", "name", "description", "agentType", "provider"],
+            )
+
+    @mcp.tool()
+    async def catalog_run_agent(agent_id: str, ctx: Context) -> dict[str, str]:
+        """Start a catalog discovery agent run (asynchronous).
+
+        Triggers the agent to crawl its data source and populate/refresh catalog
+        metadata. The run is asynchronous — results are applied to the catalog in
+        the background; poll ``catalog_get_agent_history`` to track completion.
+        Note: the Catalog API can only *start* an agent, not stop one already running.
+
+        Args:
+            agent_id: ID of the agent to run (see catalog_list_agents).
+        """
+        async with viya_session("catalog_run_agent", ctx) as client:
+            resp = await client.put(
+                f"{VIYA_ENDPOINT}{catalog}/bots/{agent_id}/state",
+                params={"value": "running"},
+                headers={"Accept": "text/plain"},
+            )
+            resp.raise_for_status()
+            return {
+                "status": resp.text.strip() or "running",
+                "agent_id": agent_id,
+                "message": (
+                    "Agent started; metadata is applied to the catalog asynchronously. "
+                    "Poll catalog_get_agent_history for completion."
+                ),
+            }
+
+    @mcp.tool()
+    async def catalog_get_agent_history(
+        agent_id: str, ctx: Context, limit: int = 20, start: int = 0
+    ) -> list[dict[str, Any]]:
+        """Get the execution history of a catalog agent's runs.
+
+        Each record reports a run's status and how much metadata it populated
+        (tables enumerated/added/updated/removed), so you can confirm a run started
+        by ``catalog_run_agent`` finished and what it changed.
+
+        Args:
+            agent_id: ID of the agent (see catalog_list_agents).
+            limit: Maximum run records to return (default 20).
+            start: Offset of the first record (default 0).
+        """
+        async with viya_session("catalog_get_agent_history", ctx) as client:
+            data = await get_json(
+                f"{catalog}/bots/{agent_id}/history",
+                client,
+                params={"start": start, "limit": limit},
+            )
+            return return_items(
+                data.get("items", []),
+                [
+                    "id",
+                    "status",
+                    "creationTimeStamp",
+                    "endTimeStamp",
+                    "nEnumerated",
+                    "nAdded",
+                    "nUpdated",
+                    "nRemoved",
+                ],
+            )
+
+    @mcp.tool()
+    async def catalog_run_adhoc_analysis(
+        resource_uri: str,
+        name: str,
+        ctx: Context,
+        resource_type: str = "",
+        description: str = "",
+        provider: str = "TABLE-BOT",
+        identify_language: bool = True,
+        analyze_sentiment: bool = True,
+        get_nlp_semantic_id: bool = True,
+    ) -> dict[str, Any]:
+        """Submit an ad-hoc analysis (profiling) job for a table in the catalog.
+
+        Profiles the table — computing the data dictionary, column statistics, and
+        data-quality metrics that ``catalog_download_table_profile`` returns. The job
+        runs asynchronously and may take a while; poll ``catalog_get_adhoc_analysis``
+        with the returned job id until the profile is ready.
+
+        The three NLP job parameters are enabled by default — they drive the
+        semantic enrichment that populates an asset's ``informationPrivacy``,
+        ``nlpTerms``, ``nlpTags``, and ``mostImportantFields`` (the privacy and
+        keyword signals the catalog is most useful for). Leave them on unless you
+        only need a plain column profile and want the job to finish faster.
+
+        Args:
+            resource_uri: Source URI of the table to analyze (the ``resource_uri`` from
+                a catalog_search hit, e.g. '/dataTables/dataSources/cas~fs~.../tables/MYTABLE').
+            name: A name for the analysis job.
+            resource_type: Catalog entity type of the resource. Defaults to
+                'CASMEMTable' when the URI is a CAS table (contains 'cas~fs~');
+                pass it explicitly for other asset types.
+            description: Optional description for the job.
+            provider: Job provider (default 'TABLE-BOT').
+            identify_language: Detect each text column's language (default True).
+            analyze_sentiment: Score sentiment on text columns (default True).
+            get_nlp_semantic_id: Derive semantic types / privacy classification
+                (informationPrivacy, nlpTerms, nlpTags) (default True).
+        """
+        rtype = resource_type or (
+            "CASMEMTable" if "cas~fs~" in resource_uri else ""
+        )
+        if not rtype:
+            return {
+                "status": "missing_resource_type",
+                "resource_uri": resource_uri,
+                "message": (
+                    "Could not infer resource_type from the URI. Pass resource_type "
+                    "explicitly (e.g. 'CASMEMTable' for a CAS table)."
+                ),
+            }
+        job_parameters: dict[str, str] = {}
+        if identify_language:
+            job_parameters["identifyLanguage"] = "1"
+        if analyze_sentiment:
+            job_parameters["analyzeSentiment"] = "1"
+        if get_nlp_semantic_id:
+            job_parameters["getNLPSemanticID"] = "1"
+        body = {
+            "provider": provider,
+            "name": name,
+            "description": description,
+            "resources": [{"uri": resource_uri, "type": rtype}],
+            "jobParameters": job_parameters,
+        }
+        async with viya_session("catalog_run_adhoc_analysis", ctx) as client:
+            job = await post_json(
+                f"{catalog}/bots/adhocAnalysisJobs",
+                client,
+                body=body,
+                accept=adhoc_media,
+            )
+            return {
+                "id": job.get("id"),
+                "status": job.get("status", ""),
+                "name": job.get("name", name),
+                "message": (
+                    "Analysis submitted. Poll catalog_get_adhoc_analysis until status "
+                    "is 'completed', then catalog_download_table_profile."
+                ),
+            }
+
+    @mcp.tool()
+    async def catalog_get_adhoc_analysis(job_id: str, ctx: Context) -> dict[str, Any]:
+        """Get the status of an ad-hoc analysis job, and whether its profile is ready.
+
+        The job reaching a terminal ``status`` is *not* sufficient: the profile
+        attributes are written onto the asset a little later, so a download fired
+        the instant the job completes can come back empty. To close that gap, when
+        the job carries a resource this also resolves the target catalog instance
+        and reports ``profile_ready`` (the asset's ``analysisTimeStamp`` is
+        populated — the same gate ``catalog_download_table_profile`` uses) and
+        ``information_privacy`` (non-empty once the NLP semantic enrichment has
+        landed). Poll until ``profile_ready`` is true, then download.
+
+        Args:
+            job_id: The analysis job id returned by catalog_run_adhoc_analysis.
+        """
+        async with viya_session("catalog_get_adhoc_analysis", ctx) as client:
+            try:
+                job = await get_json(
+                    f"{catalog}/bots/adhocAnalysisJobs/{job_id}",
+                    client,
+                    accept=adhoc_media,
+                )
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    # Adhoc jobs can be purged once terminal — report it as such
+                    # rather than raising, so polling loops can stop cleanly.
+                    return {
+                        "id": job_id,
+                        "status": "not_found",
+                        "message": (
+                            "No such analysis job — it may have finished and been "
+                            "purged, or the id is wrong."
+                        ),
+                    }
+                raise
+            resources = job.get("resources", []) or []
+            resource_uri = ""
+            if resources:
+                resource_uri = resources[0].get("uri", "") or resources[0].get(
+                    "resourceId", ""
+                )
+            # Cross-check the asset itself: the job can be terminal while the
+            # profile is still being written onto the instance.
+            instance_id = ""
+            profile_ready = False
+            information_privacy = ""
+            if resource_uri:
+                inst = await instance_for_resource_uri(client, resource_uri)
+                if inst:
+                    instance_id = inst.get("id", "")
+                    inst_attrs = inst.get("attributes", {}) or {}
+                    profile_ready = bool(inst_attrs.get("analysisTimeStamp"))
+                    information_privacy = inst_attrs.get("informationPrivacy", "") or ""
+            return {
+                "id": job.get("id", job_id),
+                "status": job.get("status", ""),
+                "name": job.get("name", ""),
+                "creationTimeStamp": job.get("creationTimeStamp", ""),
+                "endTimeStamp": job.get("endTimeStamp", ""),
+                "resources": resources,
+                "instance_id": instance_id,
+                "profile_ready": profile_ready,
+                "information_privacy": information_privacy,
+                "message": (
+                    f"Profile ready — download with catalog_download_table_profile "
+                    f"(instance_id='{instance_id}')."
+                    if profile_ready
+                    else "Profile not written to the asset yet — poll again before "
+                    "downloading."
+                ),
+            }
+
+    @mcp.tool()
+    async def catalog_download_table_profile(
+        ctx: Context,
+        instance_id: str = "",
+        resource_uri: str = "",
+        level: str = "dataDictionaryAndProfile",
+    ) -> dict[str, Any]:
+        """Download a catalog table's data dictionary and profile as CSV.
+
+        Returns the table's column metadata plus, by default, its profile (column
+        statistics and data-quality metrics). If the table has not been profiled yet,
+        this returns a recommendation to run ``catalog_run_adhoc_analysis`` (pre-filled
+        with the table's URI and type) instead of an empty profile.
+
+        Identify the table by either ``instance_id`` or ``resource_uri`` (give one).
+        Passing ``resource_uri`` lets you run search → profile → download without ever
+        handling an instance id: the asset is resolved by ``resourceId`` the same way
+        ``catalog_find_instance`` does. ``instance_id`` takes precedence if both are given.
+
+        Args:
+            instance_id: Catalog instance id of the table (the ``id`` from a catalog_search hit).
+            resource_uri: Source URI of the table (the ``resource_uri`` from a search hit,
+                e.g. '/dataTables/dataSources/cas~fs~.../tables/MYTABLE'). Used when
+                ``instance_id`` is omitted.
+            level: Detail level — 'dataDictionaryAndProfile' (default; columns + profile),
+                'detailedMetrics' (full per-column metrics), or 'dataDictionary'
+                (column metadata only).
+        """
+        if level not in profile_levels:
+            return {
+                "status": "invalid_level",
+                "message": f"level must be one of {', '.join(profile_levels)}.",
+            }
+        if not instance_id and not resource_uri:
+            return {
+                "status": "missing_identifier",
+                "message": "Pass either instance_id or resource_uri.",
+            }
+        async with viya_session("catalog_download_table_profile", ctx) as client:
+            # Resolve the instance first to identify the asset and whether it is profiled.
+            if instance_id:
+                try:
+                    inst = await get_json(
+                        f"{catalog}/instances/{instance_id}",
+                        client,
+                        accept="application/vnd.sas.metadata.instance.entity+json",
+                    )
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code == 404:
+                        return {
+                            "status": "not_found",
+                            "instance_id": instance_id,
+                            "message": (
+                                f"No catalog instance '{instance_id}'. "
+                                "Use catalog_search to find one."
+                            ),
+                        }
+                    raise
+            else:
+                inst = await instance_for_resource_uri(client, resource_uri)
+                if inst is None:
+                    return {
+                        "status": "not_found",
+                        "resource_uri": resource_uri,
+                        "message": (
+                            f"No catalog instance indexes '{resource_uri}'. "
+                            "Use catalog_search or catalog_find_instance to confirm it."
+                        ),
+                    }
+                instance_id = inst.get("id", "")
+            attrs = inst.get("attributes", {}) or {}
+            resource_uri = inst.get("resourceId", "") or resource_uri
+            resource_type = inst.get("type", "")
+            wants_profile = level in ("dataDictionaryAndProfile", "detailedMetrics")
+            if wants_profile and not attrs.get("analysisTimeStamp"):
+                return {
+                    "status": "not_profiled",
+                    "instance_id": instance_id,
+                    "resource_uri": resource_uri,
+                    "resource_type": resource_type,
+                    "message": (
+                        "This table has no profile yet. Run catalog_run_adhoc_analysis "
+                        f"with resource_uri='{resource_uri}' and "
+                        f"resource_type='{resource_type}', poll catalog_get_adhoc_analysis "
+                        "until completed, then retry."
+                    ),
+                }
+            resp = await client.get(
+                f"{VIYA_ENDPOINT}{catalog}/instances",
+                params={"level": level, "filter": f"eq(id,'{instance_id}')"},
+                headers={"Accept": "text/csv"},
+                follow_redirects=True,
+            )
+            resp.raise_for_status()
+            return {
+                "status": "ok",
+                "instance_id": instance_id,
+                "resource_uri": resource_uri,
+                "level": level,
+                "csv": resp.text,
+            }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -629,6 +629,194 @@ async def test_prompt_renders_through_live_server(integration_mcp_server, prompt
 
 
 # -----------------------------------------------------------------------
+# Information Catalog Workflows
+# -----------------------------------------------------------------------
+
+
+def _hmeq_public_hit(items: list) -> dict | None:
+    """Find an HMEQ-in-Public-CAS hit by its resource URI, if present."""
+    for h in items:
+        uri = (h.get("resource_uri") or "").rstrip("/")
+        if uri.endswith("/Public/tables/HMEQ"):
+            return h
+    return None
+
+
+async def test_catalog_agents_workflow(integration_mcp_server):
+    """catalog_list_agents → catalog_get_agent_history → run the 'Public' agent."""
+    async with Client(integration_mcp_server) as client:
+        try:
+            agents = (
+                await client.call_tool("catalog_list_agents", {"limit": 100})
+            ).data
+        except Exception as e:
+            pytest.skip(f"Information Catalog not available on this Viya: {e}")
+        assert isinstance(agents, list)
+
+        public_agent = next(
+            (a for a in agents if (a.get("name") or "").strip().lower() == "public"),
+            None,
+        )
+        if public_agent is None:
+            pytest.skip("No discovery agent named 'Public' on this Viya")
+        agent_id = public_agent["id"]
+
+        # Run history must be retrievable for the agent.
+        history = (
+            await client.call_tool(
+                "catalog_get_agent_history", {"agent_id": agent_id, "limit": 5}
+            )
+        ).data
+        assert isinstance(history, list)
+
+        # Trigger the Public agent. 409 means it is already running — also a success.
+        try:
+            run = (
+                await client.call_tool("catalog_run_agent", {"agent_id": agent_id})
+            ).data
+        except Exception as e:
+            if "409" in str(e):
+                pytest.skip("Public agent is already running")
+            raise
+        assert run["agent_id"] == agent_id
+        assert run["status"]
+
+
+async def test_catalog_table_profile_loop(integration_mcp_server):
+    """Full loop: find/load HMEQ → ad-hoc analyze → poll to completion → download profile.
+
+    Proves the run→retrieve→profile chain end to end: searches for HMEQ in the
+    Public CAS library, loads sampsio.hmeq if it is not already cataloged, runs an
+    ad-hoc analysis, waits for it to complete, then downloads the profile and
+    asserts it is now available (status 'ok').
+    """
+    import asyncio
+
+    hmeq_uri = "/dataTables/dataSources/cas~fs~cas-shared-default~fs~Public/tables/HMEQ"
+
+    async with Client(integration_mcp_server) as client:
+        # 1. Is HMEQ already in the catalog under Public?
+        try:
+            results = (
+                await client.call_tool(
+                    "catalog_search", {"query": "Name:HMEQ", "limit": 25}
+                )
+            ).data
+        except Exception as e:
+            pytest.skip(f"Information Catalog not available on this Viya: {e}")
+
+        # Exercise the search helper while we are here.
+        helper = (await client.call_tool("catalog_search_helper", {})).data
+        assert "facets" in helper
+
+        hit = _hmeq_public_hit(results["items"])
+
+        # 2. Not in the catalog → ensure HMEQ is loaded (promoted) in Public CAS.
+        # Idempotent: drop any existing copy first so a re-run never hits the
+        # "global-scope tables cannot be replaced" error.
+        if hit is None:
+            load_code = (
+                "cas mySess;\n"
+                "libname public cas casLib='Public';\n"
+                "proc casutil;\n"
+                "  droptable casdata='HMEQ' incaslib='Public' quiet;\n"
+                "  load data=sampsio.hmeq outcaslib='Public' casout='HMEQ' promote;\n"
+                "quit;\n"
+                "cas mySess terminate;\n"
+            )
+            load = (
+                await client.call_tool("execute_sas_code", {"sas_code": load_code})
+            ).data
+            assert load["state"] in ("completed", "warning"), load["log"]
+
+        resource_uri = hit["resource_uri"] if hit else hmeq_uri
+        resource_type = (hit.get("type") if hit else None) or "casTable"
+
+        # 3. Submit an ad-hoc analysis; submission must return a job id + status.
+        job = (
+            await client.call_tool(
+                "catalog_run_adhoc_analysis",
+                {
+                    "resource_uri": resource_uri,
+                    "resource_type": resource_type,
+                    "name": f"mcp-hmeq-adhoc-{_SUFFIX}",
+                },
+            )
+        ).data
+        job_id = job["id"]
+        assert job_id, job
+        assert job["status"], "a submitted job should report a status"
+
+        # 4. Monitor until the job reaches a terminal state — this proves the
+        # submit -> poll -> retrieve mechanism. Whether the analysis *succeeds*
+        # depends on the Viya analysis backend, so we assert the job is trackable
+        # to a terminal state, not that the backend can always profile.
+        # 'not_found' = the job was purged after finishing, also terminal.
+        # Cold profiling of a CAS table routinely runs past two minutes, so we
+        # poll up to 5 minutes (60 x 5s) — the same envelope David's reference
+        # script waits — rather than flaking on a job that is still 'running'.
+        terminal = {"completed", "failed", "error", "canceled", "not_found"}
+        status = str(job["status"]).lower()
+        for _ in range(60):
+            if status in terminal:
+                break
+            await asyncio.sleep(5)
+            status = str(
+                (
+                    await client.call_tool(
+                        "catalog_get_adhoc_analysis", {"job_id": job_id}
+                    )
+                ).data["status"]
+            ).lower()
+        assert status in terminal, f"ad-hoc job never reached a terminal state: {status!r}"
+
+        # 4b. Resolve the instance straight from the resource URI — the search ->
+        # profile bridge. Either the URI is indexed ('ok' with an instance id) or
+        # it is not yet ('not_found'); both are valid, so assert the shape.
+        found = (
+            await client.call_tool(
+                "catalog_find_instance", {"resource_uri": resource_uri}
+            )
+        ).data
+        assert found["status"] in ("ok", "not_found"), found
+        if found["status"] == "ok":
+            assert found["instance_id"], found
+
+        # 5. Exercise the download tool end to end. Walk candidate tables across
+        # asset types and download each until one returns a profile ('ok') — that
+        # proves the CSV download path against a genuinely profiled table. If no
+        # table on this instance is profiled, the 'not_profiled' recommendation
+        # is the valid outcome.
+        candidates: list = []
+        for facet in (
+            "AssetType:parquet",
+            "AssetType:cas",
+            "AssetType:inmemorytable",
+            "AssetType:sas",
+        ):
+            candidates += (
+                await client.call_tool("catalog_search", {"query": facet, "limit": 15})
+            ).data["items"]
+        if not any(c.get("id") for c in candidates):
+            pytest.skip("No table instances available to download a profile")
+
+        last = None
+        for cand in candidates:
+            if not cand.get("id"):
+                continue
+            last = (
+                await client.call_tool(
+                    "catalog_download_table_profile", {"instance_id": cand["id"]}
+                )
+            ).data
+            if last["status"] == "ok":
+                assert last.get("csv", "").strip(), "profiled table returned empty CSV"
+                break
+        assert last is not None
+        assert last["status"] in ("ok", "not_profiled"), last
+
+
+# -----------------------------------------------------------------------
 # Coverage guards — fail if a registered tool/prompt has no integration test
 # -----------------------------------------------------------------------
 
@@ -668,6 +856,15 @@ TOOL_COVERAGE = {
     "list_compute_tables": "test_compute_discovery_workflow",
     "list_compute_columns": "test_compute_discovery_workflow",
     "reset_compute_session": "test_compute_session_reuse_and_reset",
+    "catalog_search": "test_catalog_table_profile_loop",
+    "catalog_search_helper": "test_catalog_table_profile_loop",
+    "catalog_find_instance": "test_catalog_table_profile_loop",
+    "catalog_download_table_profile": "test_catalog_table_profile_loop",
+    "catalog_run_adhoc_analysis": "test_catalog_table_profile_loop",
+    "catalog_get_adhoc_analysis": "test_catalog_table_profile_loop",
+    "catalog_list_agents": "test_catalog_agents_workflow",
+    "catalog_run_agent": "test_catalog_agents_workflow",
+    "catalog_get_agent_history": "test_catalog_agents_workflow",
 }
 
 

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -50,6 +50,15 @@ EXPECTED_TOOLS = [
     "list_compute_tables",
     "list_compute_columns",
     "reset_compute_session",
+    "catalog_search",
+    "catalog_search_helper",
+    "catalog_find_instance",
+    "catalog_list_agents",
+    "catalog_run_agent",
+    "catalog_get_agent_history",
+    "catalog_run_adhoc_analysis",
+    "catalog_get_adhoc_analysis",
+    "catalog_download_table_profile",
 ]
 
 
@@ -1229,3 +1238,495 @@ async def test_reset_compute_session_no_active_session(mcp_server_with_mock_clie
 
     assert result.data["status"] == "no_active_session"
     mock_client.delete.assert_not_called()
+
+
+# -----------------------------------------------------------------------
+# Information Catalog (Tier 7)
+# -----------------------------------------------------------------------
+
+
+async def test_catalog_search_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {
+            "count": 1,
+            "start": 0,
+            "limit": 20,
+            "items": [
+                {
+                    "id": "i1",
+                    "type": "casTable",
+                    "typeLabel": "CAS Table",
+                    "name": "HMEQ",
+                    "label": "HMEQ",
+                    "score": 1.0,
+                    "attributes": {"library": "Public", "rowCount": 5960},
+                    "links": [
+                        {"rel": "resource", "href": "/dataTables/x/tables/HMEQ"}
+                    ],
+                }
+            ],
+        }
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_search", {"query": "HMEQ", "limit": 20})
+        ).data
+
+    url = mock_client.get.call_args[0][0]
+    params = mock_client.get.call_args[1]["params"]
+    assert url.endswith("/catalog/search")
+    assert params["q"] == "HMEQ"
+    assert params["indices"] == "catalog"
+    assert result["items"][0]["id"] == "i1"
+    assert result["items"][0]["resource_uri"] == "/dataTables/x/tables/HMEQ"
+    # Enriched attributes are passed through.
+    assert result["items"][0]["attributes"] == {"library": "Public", "rowCount": 5960}
+
+
+async def test_catalog_search_helper_lists_facets(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {"items": [{"name": "AssetType", "type": "text", "indices": ["catalog"]}]}
+    )
+    async with Client(mcp) as client:
+        result = (await client.call_tool("catalog_search_helper", {})).data
+
+    assert mock_client.get.call_args[0][0].endswith("/catalog/search/facets")
+    assert result["facets"][0]["name"] == "AssetType"
+
+
+async def test_catalog_search_helper_suggests_values(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {"items": ["Report", "CAS Table"]}
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_search_helper", {"facet": "AssetType"})
+        ).data
+
+    url = mock_client.get.call_args[0][0]
+    params = mock_client.get.call_args[1]["params"]
+    assert url.endswith("/catalog/search/suggestions")
+    assert params["facet"] == "AssetType"
+    assert result["values"] == ["Report", "CAS Table"]
+
+
+async def test_catalog_list_agents_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {
+            "items": [
+                {
+                    "id": "a1",
+                    "name": "TableBot",
+                    "agentType": "DiscoveryAgent",
+                    "provider": "TABLE-BOT",
+                }
+            ]
+        }
+    )
+    async with Client(mcp) as client:
+        result = (await client.call_tool("catalog_list_agents", {"limit": 10})).data
+
+    assert mock_client.get.call_args[0][0].endswith("/catalog/bots")
+    assert result[0]["id"] == "a1"
+    assert result[0]["agentType"] == "DiscoveryAgent"
+
+
+async def test_catalog_run_agent_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.put.return_value = _make_mock_response(status_code=202, text="running")
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_run_agent", {"agent_id": "a1"})
+        ).data
+
+    url = mock_client.put.call_args[0][0]
+    params = mock_client.put.call_args[1]["params"]
+    assert "/catalog/bots/a1/state" in url
+    assert params["value"] == "running"
+    assert result["status"] == "running"
+    assert result["agent_id"] == "a1"
+
+
+async def test_catalog_get_agent_history_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {"items": [{"id": "r1", "status": "completed", "nAdded": 5, "nUpdated": 2}]}
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_get_agent_history", {"agent_id": "a1"})
+        ).data
+
+    assert "/catalog/bots/a1/history" in mock_client.get.call_args[0][0]
+    assert result[0]["status"] == "completed"
+    assert result[0]["nAdded"] == 5
+
+
+async def test_catalog_run_adhoc_analysis_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.post.return_value = _make_mock_response(
+        {"id": "job1", "status": "running", "name": "probe"}, status_code=201
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_run_adhoc_analysis",
+                {
+                    "resource_uri": "/dataTables/x/tables/HMEQ",
+                    "resource_type": "CASTable",
+                    "name": "probe",
+                },
+            )
+        ).data
+
+    url = mock_client.post.call_args[0][0]
+    body = mock_client.post.call_args[1]["json"]
+    assert url.endswith("/catalog/bots/adhocAnalysisJobs")
+    assert body["provider"] == "TABLE-BOT"
+    assert body["resources"][0]["uri"] == "/dataTables/x/tables/HMEQ"
+    assert body["resources"][0]["type"] == "CASTable"
+    # NLP enrichment params are on by default — they populate informationPrivacy,
+    # nlpTerms, nlpTags, mostImportantFields.
+    assert body["jobParameters"] == {
+        "identifyLanguage": "1",
+        "analyzeSentiment": "1",
+        "getNLPSemanticID": "1",
+    }
+    assert result["id"] == "job1"
+    assert result["status"] == "running"
+
+
+async def test_catalog_run_adhoc_analysis_infers_cas_type(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.post.return_value = _make_mock_response(
+        {"id": "job2", "status": "running", "name": "probe"}, status_code=201
+    )
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "catalog_run_adhoc_analysis",
+            {
+                "resource_uri": (
+                    "/dataTables/dataSources/cas~fs~cas-shared-default~fs~"
+                    "PUBLIC/tables/HMEQ"
+                ),
+                "name": "probe",
+            },
+        )
+
+    body = mock_client.post.call_args[1]["json"]
+    # No resource_type passed — inferred from the cas~fs~ URI.
+    assert body["resources"][0]["type"] == "CASMEMTable"
+
+
+async def test_catalog_run_adhoc_analysis_missing_type(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_run_adhoc_analysis",
+                {"resource_uri": "/files/files/abc123", "name": "probe"},
+            )
+        ).data
+
+    assert result["status"] == "missing_resource_type"
+    mock_client.post.assert_not_called()
+
+
+async def test_catalog_find_instance_ok(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {
+            "items": [
+                {
+                    "id": "inst1",
+                    "name": "HMEQ",
+                    "type": "casTable",
+                    "resourceId": "/dataTables/x/tables/HMEQ",
+                    "attributes": {
+                        "analysisTimeStamp": "2026-06-19T00:00:00Z",
+                        "informationPrivacy": "candidate",
+                    },
+                }
+            ]
+        }
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_find_instance",
+                {"resource_uri": "/dataTables/x/tables/HMEQ"},
+            )
+        ).data
+
+    url = mock_client.get.call_args[0][0]
+    params = mock_client.get.call_args[1]["params"]
+    assert url.endswith("/catalog/instances")
+    assert params["filter"] == 'eq(resourceId,"/dataTables/x/tables/HMEQ")'
+    assert result["status"] == "ok"
+    assert result["instance_id"] == "inst1"
+    assert result["profiled"] is True
+
+
+async def test_catalog_find_instance_not_found(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"items": []})
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_find_instance", {"resource_uri": "/dataTables/x/tables/NOPE"}
+            )
+        ).data
+
+    assert result["status"] == "not_found"
+
+
+async def test_catalog_get_adhoc_analysis_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {"id": "job1", "status": "completed", "name": "probe", "resources": []}
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_get_adhoc_analysis", {"job_id": "job1"})
+        ).data
+
+    assert mock_client.get.call_args[0][0].endswith(
+        "/catalog/bots/adhocAnalysisJobs/job1"
+    )
+    assert result["status"] == "completed"
+    # No resource on the job → no instance cross-check, profile not confirmed ready.
+    assert result["profile_ready"] is False
+
+
+async def test_catalog_get_adhoc_analysis_profile_ready(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    # First GET returns the job (terminal, with a resource); second GET resolves
+    # the instance and shows the profile has landed on the asset.
+    mock_client.get.side_effect = [
+        _make_mock_response(
+            {
+                "id": "job1",
+                "status": "completed",
+                "name": "probe",
+                "resources": [{"uri": "/dataTables/x/tables/HMEQ"}],
+            }
+        ),
+        _make_mock_response(
+            {
+                "items": [
+                    {
+                        "id": "inst1",
+                        "attributes": {
+                            "analysisTimeStamp": "2026-06-19T00:00:00Z",
+                            "informationPrivacy": "candidate",
+                        },
+                    }
+                ]
+            }
+        ),
+    ]
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_get_adhoc_analysis", {"job_id": "job1"})
+        ).data
+
+    assert result["status"] == "completed"
+    assert result["profile_ready"] is True
+    assert result["instance_id"] == "inst1"
+    assert result["information_privacy"] == "candidate"
+
+
+async def test_catalog_get_adhoc_analysis_not_found(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    resp = _make_mock_response(status_code=404)
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=MagicMock(status_code=404)
+        )
+    )
+    mock_client.get.return_value = resp
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_get_adhoc_analysis", {"job_id": "gone"})
+        ).data
+
+    assert result["status"] == "not_found"
+    assert result["id"] == "gone"
+
+
+async def test_catalog_download_table_profile_not_profiled(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response(
+        {"attributes": {}, "resourceId": "/dataTables/x/tables/RAW", "type": "CASTable"}
+    )
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_download_table_profile", {"instance_id": "t1"}
+            )
+        ).data
+
+    assert result["status"] == "not_profiled"
+    assert result["resource_uri"] == "/dataTables/x/tables/RAW"
+    assert result["resource_type"] == "CASTable"
+    # Only the instance was fetched — no CSV download for an unprofiled table.
+    mock_client.get.assert_called_once()
+
+
+async def test_catalog_download_table_profile_ok(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    instance_resp = _make_mock_response(
+        {
+            "attributes": {"analysisTimeStamp": "2026-06-15T00:00:00Z"},
+            "resourceId": "/dataTables/x/tables/HMEQ",
+            "type": "CASTable",
+        }
+    )
+    csv_resp = _make_mock_response(text="Name,Type\nBAD,Num\n")
+    original_get = mock_client.get.return_value
+
+    def route_get(url, **kwargs):
+        # The CSV download hits the collection endpoint (.../catalog/instances);
+        # the instance lookup hits .../catalog/instances/{id}.
+        if url.rstrip("/").endswith("/catalog/instances"):
+            return csv_resp
+        if "/catalog/instances/" in url:
+            return instance_resp
+        return original_get
+
+    mock_client.get.side_effect = route_get
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_download_table_profile",
+                {"instance_id": "t1", "level": "dataDictionaryAndProfile"},
+            )
+        ).data
+    mock_client.get.side_effect = None
+
+    csv_call = next(
+        c
+        for c in mock_client.get.call_args_list
+        if c[0][0].rstrip("/").endswith("/catalog/instances")
+    )
+    assert csv_call[1]["params"]["level"] == "dataDictionaryAndProfile"
+    assert "eq(id,'t1')" in csv_call[1]["params"]["filter"]
+    assert result["status"] == "ok"
+    assert "BAD" in result["csv"]
+
+
+async def test_catalog_download_table_profile_by_resource_uri(
+    mcp_server_with_mock_client,
+):
+    mcp, mock_client = mcp_server_with_mock_client
+    # The resourceId lookup returns a collection; the CSV download carries `level`.
+    lookup_resp = _make_mock_response(
+        {
+            "items": [
+                {
+                    "id": "inst1",
+                    "attributes": {"analysisTimeStamp": "2026-06-15T00:00:00Z"},
+                    "resourceId": "/dataTables/x/tables/HMEQ",
+                    "type": "casTable",
+                }
+            ]
+        }
+    )
+    csv_resp = _make_mock_response(text="Name,Type\nLOAN,Num\n")
+
+    def route_get(url, **kwargs):
+        if "level" in (kwargs.get("params") or {}):
+            return csv_resp
+        return lookup_resp
+
+    mock_client.get.side_effect = route_get
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_download_table_profile",
+                {"resource_uri": "/dataTables/x/tables/HMEQ"},
+            )
+        ).data
+    mock_client.get.side_effect = None
+
+    # The asset was resolved by resourceId, then the CSV download filtered by id.
+    lookup_call = next(
+        c
+        for c in mock_client.get.call_args_list
+        if "resourceId" in (c[1].get("params") or {}).get("filter", "")
+    )
+    assert lookup_call[1]["params"]["filter"] == (
+        'eq(resourceId,"/dataTables/x/tables/HMEQ")'
+    )
+    csv_call = next(
+        c for c in mock_client.get.call_args_list if "level" in (c[1].get("params") or {})
+    )
+    assert "eq(id,'inst1')" in csv_call[1]["params"]["filter"]
+    assert result["status"] == "ok"
+    assert result["instance_id"] == "inst1"
+    assert "LOAN" in result["csv"]
+
+
+async def test_catalog_download_table_profile_uri_not_found(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _make_mock_response({"items": []})
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_download_table_profile",
+                {"resource_uri": "/dataTables/x/tables/NOPE"},
+            )
+        ).data
+
+    assert result["status"] == "not_found"
+    assert result["resource_uri"] == "/dataTables/x/tables/NOPE"
+
+
+async def test_catalog_download_table_profile_missing_identifier(
+    mcp_server_with_mock_client,
+):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("catalog_download_table_profile", {})
+        ).data
+
+    assert result["status"] == "missing_identifier"
+    mock_client.get.assert_not_called()
+
+
+async def test_catalog_download_table_profile_invalid_level(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_download_table_profile",
+                {"instance_id": "t1", "level": "bogus"},
+            )
+        ).data
+
+    assert result["status"] == "invalid_level"
+
+
+async def test_catalog_download_table_profile_not_found(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    resp = _make_mock_response(status_code=404)
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=MagicMock(status_code=404)
+        )
+    )
+    mock_client.get.return_value = resp
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "catalog_download_table_profile", {"instance_id": "missing"}
+            )
+        ).data
+
+    assert result["status"] == "not_found"
+    assert result["instance_id"] == "missing"


### PR DESCRIPTION
## Summary

Adds a Tier 7 set of tools for the **SAS Information Catalog**, covering metadata discovery and table profiling end to end:

- **Search** — `catalog_search` and `catalog_search_helper` query the catalog index and discover the facets/values usable in a query.
- **Resolve** — `catalog_find_instance` resolves a catalog instance straight from a resource URI (`eq(resourceId,...)`), bridging a search hit to the profiling/download tools without handling an instance id by hand.
- **Discovery agents** — `catalog_list_agents`, `catalog_run_agent`, `catalog_get_agent_history` list, start, and inspect discovery agent runs.
- **Profiling** — `catalog_run_adhoc_analysis` submits a profiling job (NLP enrichment params on by default, so `informationPrivacy`/`nlpTerms`/`nlpTags`/`mostImportantFields` get populated; `resource_type` inferred as `CASMEMTable` for `cas~fs~` URIs). `catalog_get_adhoc_analysis` polls a job **and** cross-checks the target instance, reporting `profile_ready` so a download isn't fired before the profile lands on the asset.
- **Download** — `catalog_download_table_profile` returns the data dictionary and profile as CSV, identified by either `instance_id` or `resource_uri`.

## Design notes

- The NLP `jobParameters` and the `CASMEMTable` resource type mirror the working reference flow used to profile CAS tables, rather than submitting an empty/under-specified job.
- `catalog_get_adhoc_analysis` deliberately cross-checks the instance (`analysisTimeStamp`) because a job reaching a terminal state does **not** guarantee the profile has been written to the asset yet.

## Testing

- **Unit:** request-payload tests for every catalog tool (NLP `jobParameters` default, `CASMEMTable` inference + missing-type guard, `profile_ready` cross-check, instance resolution by `resourceId`, the `resource_uri` download path). Full mocked suite green.
- **Live integration:** `test_catalog_table_profile_loop` and `test_catalog_agents_workflow` run against a real SAS Viya environment (`2 passed`), exercising search → resolve → submit → poll → download. The ad-hoc poll window was widened to five minutes to match real cold-profiling latency.

## Notes

- Local reference material (API specs, course samples) under `docs/` is git-ignored and excluded from ruff; it is not part of this PR.

Assisted by Claude Code.
