### PR TITLE
fix(stdio): skip expired cached tokens and refresh via refresh token

### DIFF
--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -5,7 +5,11 @@
 Stdio MCP Server for SAS Viya.
 
 Authenticates via OAuth 2.0. Three paths are tried in order; the first one
-that yields a token wins:
+that yields a *usable* token wins. A cached token counts as usable only if it
+is present and not expired — an expired token is skipped rather than served, so
+a stale cache never shadows a valid one. When a cache's access token is expired
+but it still holds a refresh token, the refresh token is exchanged for a fresh
+access token, which is written back to the same cache before use.
 
   1. Token cached by the SAS Viya CLI's ``sas-viya auth loginCode`` command.
      Default location: ``~/.sas/credentials.json`` (override the parent dir
@@ -35,6 +39,7 @@ import time
 import webbrowser
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import httpx
@@ -55,6 +60,15 @@ DEVICE_AUTH_URL = f"{VIYA_ENDPOINT}/SASLogon/oauth/device_authorization"
 TOKEN_URL = f"{VIYA_ENDPOINT}/SASLogon/oauth/token"
 DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
 
+# OAuth client that minted each cache's tokens — needed to refresh them. The
+# SAS Viya CLI uses ``sas.cli`` and ``sas-mcp-login`` uses ``vscode``; both are
+# overridable for sites that registered different public clients.
+SAS_CLI_CLIENT_ID = os.getenv("SAS_CLI_CLIENT_ID", "sas.cli")
+HELPER_CLIENT_ID = os.getenv("AUTH_HELPER_CLIENT_ID", "vscode")
+# Treat a token as expired this many seconds early, so we refresh before a call
+# in flight can race the real expiry.
+TOKEN_EXPIRY_SKEW = 60
+
 
 def _sas_cli_credentials_path() -> Path:
     """Location of the access token cached by ``sas-viya auth loginCode``."""
@@ -67,15 +81,50 @@ def _helper_credentials_path() -> Path:
     return Path.home() / ".sas-mcp-server" / "credentials.json"
 
 
-def _read_cached_token(path: Path) -> str | None:
-    """Return the ``Default.access-token`` value from *path*, or ``None``."""
+def _load_credentials(path: Path) -> dict | None:
+    """Return the ``Default`` credential block from *path*, or ``None``."""
     if not path.exists():
         return None
     try:
-        creds = json.loads(path.read_text())
-        token = creds["Default"]["access-token"]
+        return json.loads(path.read_text())["Default"]
     except (KeyError, json.JSONDecodeError, OSError) as exc:
         logger.warning("Could not read credentials at %s: %s", path, exc)
+        return None
+
+
+def _token_expired(creds: dict, skew_seconds: int = TOKEN_EXPIRY_SKEW) -> bool:
+    """Whether the cached token is at or past its expiry (minus a safety skew).
+
+    A missing or unparseable ``expiry`` is treated as *not* expired, so caches
+    that never recorded one keep working exactly as before.
+    """
+    raw = creds.get("expiry")
+    if not raw:
+        return False
+    try:
+        expiry = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if expiry.tzinfo is None:
+        expiry = expiry.replace(tzinfo=UTC)
+    return datetime.now(UTC) >= expiry - timedelta(seconds=skew_seconds)
+
+
+def _read_cached_token(path: Path) -> str | None:
+    """Return a *non-expired* ``Default.access-token`` from *path*, or ``None``.
+
+    An expired token returns ``None`` so the caller falls through to a refresh
+    or the next credential source instead of serving a token Viya will 401.
+    """
+    creds = _load_credentials(path)
+    if creds is None:
+        return None
+    token = creds.get("access-token")
+    if not token:
+        logger.warning("No access-token in credentials at %s", path)
+        return None
+    if _token_expired(creds):
+        logger.info("Cached token at %s is expired; will refresh or fall back", path)
         return None
     logger.info("Loaded access token from %s", path)
     return token
@@ -151,13 +200,98 @@ def _native_device_code_token() -> str:
     raise AuthenticationError("Device-code authentication timed out")
 
 
+def _refresh_access_token(refresh_token: str, client_id: str) -> dict | None:
+    """Exchange a refresh token for a fresh token set, or ``None`` on failure.
+
+    Best-effort: a wrong client, a revoked or expired refresh token, or a
+    network error all return ``None`` so the caller falls through cleanly.
+    """
+    try:
+        resp = httpx.post(
+            TOKEN_URL,
+            auth=(client_id, ""),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+            },
+            verify=SSL_VERIFY,
+            timeout=15.0,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("Token refresh request failed: %s", exc)
+        return None
+    if resp.status_code != 200:
+        logger.info(
+            "Token refresh rejected (HTTP %s) for client %s", resp.status_code, client_id
+        )
+        return None
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+def _write_credentials(
+    path: Path, access_token: str, refresh_token: str, expires_in: int
+) -> None:
+    """Persist a refreshed token set in the same shape ``sas-mcp-login`` writes."""
+    expiry = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
+    payload = {
+        "Default": {
+            "access-token": access_token,
+            "refresh-token": refresh_token,
+            "expiry": expiry,
+        }
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2))
+        with contextlib.suppress(OSError):
+            os.chmod(path, 0o600)
+    except OSError as exc:
+        logger.warning("Could not write refreshed credentials to %s: %s", path, exc)
+
+
+def _refresh_cached_token(path: Path, client_id: str) -> str | None:
+    """Refresh the token cached at *path* and return the new access token.
+
+    Returns ``None`` if there is no refresh token or the exchange fails.
+    """
+    creds = _load_credentials(path)
+    if creds is None:
+        return None
+    refresh_token = creds.get("refresh-token")
+    if not refresh_token:
+        return None
+    tokens = _refresh_access_token(refresh_token, client_id)
+    if not tokens or not tokens.get("access_token"):
+        return None
+    # SAS Logon may or may not rotate the refresh token; keep the old one if not.
+    new_refresh = tokens.get("refresh_token") or refresh_token
+    _write_credentials(
+        path, tokens["access_token"], new_refresh, int(tokens.get("expires_in", 0))
+    )
+    logger.info("Refreshed access token and updated cache at %s", path)
+    return tokens["access_token"]
+
+
 def _get_viya_token() -> str:
-    for path in (_sas_cli_credentials_path(), _helper_credentials_path()):
+    for path, client_id in (
+        (_sas_cli_credentials_path(), SAS_CLI_CLIENT_ID),
+        (_helper_credentials_path(), HELPER_CLIENT_ID),
+    ):
         token = _read_cached_token(path)
         if token:
             return token
+        # Present-but-expired (or absent access token): try a refresh before
+        # giving up on this source and moving to the next.
+        token = _refresh_cached_token(path, client_id)
+        if token:
+            return token
     logger.info(
-        "No cached credentials found at ~/.sas or ~/.sas-mcp-server; "
+        "No usable cached credentials at ~/.sas or ~/.sas-mcp-server; "
         "attempting native device-code flow"
     )
     return _native_device_code_token()

--- a/tests/test_stdio_server.py
+++ b/tests/test_stdio_server.py
@@ -5,6 +5,7 @@
 Unit tests for stdio-mode token resolution and the native device-code flow.
 """
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +13,30 @@ import pytest
 
 from sas_mcp_server import stdio_server
 from sas_mcp_server.exceptions import AuthenticationError
+
+
+def _iso(minutes_from_now: float) -> str:
+    """ISO-8601 timestamp offset from now, for building credential expiries."""
+    return (datetime.now(UTC) + timedelta(minutes=minutes_from_now)).isoformat()
+
+
+def _write_creds(
+    path: Path,
+    *,
+    access: str | None = "TOK",
+    expiry: str | None = None,
+    refresh: str | None = None,
+) -> Path:
+    """Write a credential file with only the keys provided."""
+    default: dict = {}
+    if access is not None:
+        default["access-token"] = access
+    if expiry is not None:
+        default["expiry"] = expiry
+    if refresh is not None:
+        default["refresh-token"] = refresh
+    path.write_text(json.dumps({"Default": default}))
+    return path
 
 
 @pytest.mark.asyncio
@@ -103,6 +128,154 @@ def test_get_viya_token_falls_back_to_device(tmp_path, monkeypatch):
 async def test_stdio_get_token_delegates(monkeypatch):
     monkeypatch.setattr(stdio_server, "_get_viya_token", lambda: "TOK")
     assert await stdio_server._stdio_get_token(None) == "TOK"
+
+
+# ---------------------------------------------------------------------------
+# _token_expired
+# ---------------------------------------------------------------------------
+
+
+def test_token_expired_future():
+    assert stdio_server._token_expired({"expiry": _iso(30)}) is False
+
+
+def test_token_expired_past():
+    assert stdio_server._token_expired({"expiry": _iso(-30)}) is True
+
+
+def test_token_expired_within_skew():
+    # 30 seconds left, but the 60s skew means we treat it as already expired.
+    assert stdio_server._token_expired({"expiry": _iso(0.5)}) is True
+
+
+def test_token_expired_missing_expiry_is_usable():
+    # No expiry recorded → treat as not expired (preserves legacy behavior).
+    assert stdio_server._token_expired({}) is False
+
+
+def test_token_expired_unparseable_is_usable():
+    assert stdio_server._token_expired({"expiry": "not-a-date"}) is False
+
+
+def test_token_expired_handles_z_suffix():
+    past_z = (datetime.now(UTC) - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert stdio_server._token_expired({"expiry": past_z}) is True
+
+
+# ---------------------------------------------------------------------------
+# _read_cached_token — expiry awareness
+# ---------------------------------------------------------------------------
+
+
+def test_read_cached_token_valid_with_future_expiry(tmp_path):
+    p = _write_creds(tmp_path / "c.json", access="GOOD", expiry=_iso(30))
+    assert stdio_server._read_cached_token(p) == "GOOD"
+
+
+def test_read_cached_token_expired_returns_none(tmp_path):
+    p = _write_creds(tmp_path / "c.json", access="STALE", expiry=_iso(-30))
+    assert stdio_server._read_cached_token(p) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_viya_token — expired CLI cache must not shadow a valid helper token
+# ---------------------------------------------------------------------------
+
+
+def test_expired_cli_cache_falls_through_to_valid_helper(tmp_path, monkeypatch):
+    cli = _write_creds(tmp_path / "cli.json", access="EXPIRED", expiry=_iso(-30))
+    helper = _write_creds(tmp_path / "helper.json", access="VALID", expiry=_iso(30))
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: cli)
+    monkeypatch.setattr(stdio_server, "_helper_credentials_path", lambda: helper)
+    # No refresh tokens, so no network calls should be attempted.
+    with patch("sas_mcp_server.stdio_server.httpx.post") as post:
+        assert stdio_server._get_viya_token() == "VALID"
+        post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# refresh-token support
+# ---------------------------------------------------------------------------
+
+
+def _refresh_ok(access="NEWTOK", refresh="NEWREFRESH", expires_in=3600):
+    resp = MagicMock(status_code=200)
+    resp.json = MagicMock(
+        return_value={
+            "access_token": access,
+            "refresh_token": refresh,
+            "expires_in": expires_in,
+        }
+    )
+    return resp
+
+
+def test_refresh_access_token_non_200_returns_none():
+    resp = MagicMock(status_code=400)
+    resp.text = "invalid_grant"
+    with patch("sas_mcp_server.stdio_server.httpx.post", return_value=resp):
+        assert stdio_server._refresh_access_token("RT", "vscode") is None
+
+
+def test_expired_token_is_refreshed_and_cache_updated(tmp_path, monkeypatch):
+    cli = _write_creds(
+        tmp_path / "cli.json", access="EXPIRED", expiry=_iso(-30), refresh="RT"
+    )
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: cli)
+    monkeypatch.setattr(
+        stdio_server, "_helper_credentials_path", lambda: tmp_path / "absent.json"
+    )
+    with patch(
+        "sas_mcp_server.stdio_server.httpx.post", return_value=_refresh_ok()
+    ) as post:
+        assert stdio_server._get_viya_token() == "NEWTOK"
+        # Refresh used the SAS-CLI client id and the cached refresh token.
+        sent = post.call_args[1]["data"]
+        assert sent["grant_type"] == "refresh_token"
+        assert sent["refresh_token"] == "RT"
+        assert post.call_args[1]["auth"] == (stdio_server.SAS_CLI_CLIENT_ID, "")
+    # The cache was rewritten with the new token, rotated refresh, future expiry.
+    updated = json.loads(cli.read_text())["Default"]
+    assert updated["access-token"] == "NEWTOK"
+    assert updated["refresh-token"] == "NEWREFRESH"
+    assert stdio_server._token_expired(updated) is False
+
+
+def test_refresh_keeps_old_refresh_token_when_not_rotated(tmp_path, monkeypatch):
+    cli = _write_creds(
+        tmp_path / "cli.json", access="EXPIRED", expiry=_iso(-30), refresh="KEEPME"
+    )
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: cli)
+    monkeypatch.setattr(
+        stdio_server, "_helper_credentials_path", lambda: tmp_path / "absent.json"
+    )
+    resp = _refresh_ok(refresh=None)  # response omits a new refresh token
+    with patch("sas_mcp_server.stdio_server.httpx.post", return_value=resp):
+        assert stdio_server._get_viya_token() == "NEWTOK"
+    assert json.loads(cli.read_text())["Default"]["refresh-token"] == "KEEPME"
+
+
+def test_failed_refresh_falls_through_to_next_source(tmp_path, monkeypatch):
+    cli = _write_creds(
+        tmp_path / "cli.json", access="EXPIRED", expiry=_iso(-30), refresh="BADRT"
+    )
+    helper = _write_creds(tmp_path / "helper.json", access="VALID", expiry=_iso(30))
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: cli)
+    monkeypatch.setattr(stdio_server, "_helper_credentials_path", lambda: helper)
+    bad = MagicMock(status_code=401)
+    bad.text = "invalid_grant"
+    with patch("sas_mcp_server.stdio_server.httpx.post", return_value=bad):
+        assert stdio_server._get_viya_token() == "VALID"
+
+
+def test_all_expired_no_refresh_falls_back_to_device(tmp_path, monkeypatch):
+    cli = _write_creds(tmp_path / "cli.json", access="EXPIRED", expiry=_iso(-30))
+    monkeypatch.setattr(stdio_server, "_sas_cli_credentials_path", lambda: cli)
+    monkeypatch.setattr(
+        stdio_server, "_helper_credentials_path", lambda: tmp_path / "absent.json"
+    )
+    monkeypatch.setattr(stdio_server, "_native_device_code_token", lambda: "DEVTOK")
+    assert stdio_server._get_viya_token() == "DEVTOK"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a stdio-mode auth bug where an **expired cached token shadows a valid one**, causing `401 Unauthorized` on every Viya call.

`_get_viya_token()` returned the first cached access token it found — checking `~/.sas/credentials.json` (SAS CLI) then `~/.sas-mcp-server/credentials.json` (login helper) — **without inspecting `expiry`**. So a stale SAS-CLI token (hours past expiry) was served on every call even when the helper cache held a perfectly valid token. Observed live: catalog search, CAS listing, everything returned 401 until the stale file was manually moved aside.

## Changes

- **Expiry-aware selection** — `_read_cached_token` now skips a token at or past its `expiry` (minus a 60s skew), so resolution falls through to the next source instead of serving a token Viya will reject.
- **Refresh-token support** — when a source's access token is expired but it still holds a `refresh-token`, exchange it for a fresh access token using the client that minted it (`sas.cli` for the CLI cache, `vscode` for the helper cache; both env-overridable), write the result back to that cache, and use it. This makes routine ~1-hour expiries self-heal instead of forcing a manual re-login.
- **Best-effort & backward-compatible** — a wrong client, revoked/expired refresh token, or network error falls through cleanly to the next source or the device-code flow. A missing or unparseable `expiry` is treated as not-expired, preserving behaviour for caches that never recorded one.

## Testing

`tests/test_stdio_server.py` extended (30 tests in file, full non-integration suite green at 167 passed):
- `_token_expired`: future / past / within-skew / missing / unparseable / `Z`-suffix.
- `_read_cached_token`: valid-with-future-expiry returns the token; expired returns `None`.
- The regression itself: **expired CLI cache falls through to a valid helper token** (and makes no network call when there's nothing to refresh).
- Refresh path: expired token is refreshed, cache rewritten with rotated refresh token + new expiry; non-rotating responses keep the old refresh token; failed refresh falls through to the next source; all-expired-no-refresh falls back to device-code.

## Notes
- No public API or tool surface changes — purely the stdio token resolver.
- Independent of the catalog-tools PR; branched from `main`.

Assisted by Claude Code.
