### PR TITLE
docs(testing): clarify test-runner commands + install openpyxl by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed — BREAKING
 - **`export_report_package` has been replaced by `export_report`.** The old tool hit the wrong route (`/visualAnalytics/getExportedReportPackage/{id}/package`, the operationId rather than the path) and sent `reportObjects` as a JSON body on a GET. Use `export_report` with `export_format="package"`; report objects are passed via `report_objects`.
 
+### Removed — BREAKING
+- **`get_report_image` has been removed**, superseded by `export_report`. It used the `reportImages` service to return an async *job descriptor* (not the image itself) for a report section thumbnail. `export_report` with `export_format="png"` or `"svg"` renders the whole report or a single object and returns the actual image bytes as native MCP content.
+
 ## [1.3.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`export_report` tool** (#18) — one tool covering every synchronous Visual Analytics report export: `package` (zip), `pdf`, `png`, `svg`, `csv`, `tsv`, `xlsx`, and `summary`, for a whole report or selected report objects. Results are returned with native MCP content types — text inline for text formats, image content for `png`, and an embedded binary file (carrying the correct MIME type, e.g. `application/zip` for packages) for `package`/`pdf`/`xlsx` — instead of a hand-rolled base64 JSON blob. Per-format input validation enforces the API's object-count and `image_size` rules; binary exports larger than `MAX_EXPORT_INLINE_BYTES` (default 25 MiB) are refused with guidance rather than streamed through the model context; and a Viya HTTP error is surfaced as a structured `export_failed` result instead of a raised exception. The format registry, validation, and request execution live in `helpers/report_export_helpers.py` so the tool stays a thin wrapper.
+
+### Changed — BREAKING
+- **`export_report_package` has been replaced by `export_report`.** The old tool hit the wrong route (`/visualAnalytics/getExportedReportPackage/{id}/package`, the operationId rather than the path) and sent `reportObjects` as a JSON body on a GET. Use `export_report` with `export_format="package"`; report objects are passed via `report_objects`.
+
 ## [1.3.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -301,12 +301,9 @@ Viya instance; there is no flag that "activates" them in a `not integration` run
 
 Integration tests call every tool against a live Viya environment. They require credentials, provided via `.env` or CLI arguments.
 
-For the **full** integration run (including the Excel `upload_data` test), install the
-optional format dependency first — plain `uv sync` does **not** include it:
-
-```sh
-uv sync --group test-formats
-```
+`uv sync` installs everything the integration suite needs, including `openpyxl` (used to
+build the Excel `upload_data` fixture). It lives in the `test-formats` dependency group,
+which `[tool.uv] default-groups` syncs by default — so no extra install step is required.
 
 **Full suite (unit + integration)** — reads `VIYA_ENDPOINT`, `VIYA_USERNAME`, `VIYA_PASSWORD` from `.env`:
 ```sh
@@ -341,8 +338,9 @@ uv run python -m pytest -m integration --no-cov -v   # any platform
 > when calling pytest directly (or use `--cov-fail-under=0`).
 
 **Binary upload formats.** The Excel `upload_data` integration test generates its `.xlsx`
-fixture with `openpyxl`, which lives in the optional `test-formats` group installed above.
-Without that group the test `importorskip`s (you'll see it as *skipped*, not failed). csv,
+fixture with `openpyxl`, from the `test-formats` group that `uv sync` installs by default
+(see above). If you deliberately sync without it (e.g. `uv sync --no-default-groups`), the
+test `importorskip`s — you'll see it as *skipped*, not failed. csv,
 tsv, and `file_path`/`data_format` coverage needs no extra deps. Generating a
 `sas7bdat`/`sashdat` fixture requires SAS itself, so those two formats are covered by
 unit-level payload tests only, not live.

--- a/README.md
+++ b/README.md
@@ -276,47 +276,76 @@ run;
 
 The project includes two layers of tests: **unit tests** (fast, no credentials required) and **integration tests** (run against a real SAS Viya instance).
 
+> **`run_tests.sh` vs. running `pytest` directly — pick by platform.** `run_tests.sh` is a
+> Bash convenience wrapper (it adds the ruff + pyright gates, credential wiring, and JUnit
+> reporting). It runs on **Linux/macOS** — and on Windows only under **Git Bash or WSL**. On
+> **Windows PowerShell or `cmd`**, use the **`uv run python -m pytest …`** commands shown
+> under each mode below. They are cross-platform, do the same test selection, and need no
+> setup beyond `uv sync`.
+
 ### Running Unit Tests
 
 Unit tests verify tool schemas, request payloads, and internal logic without making any network calls:
 
 ```sh
-./run_tests.sh
+./run_tests.sh                                     # Linux/macOS (also runs ruff + pyright)
+uv run python -m pytest -m "not integration" -v    # any platform, incl. Windows PowerShell
 ```
 
-Or directly via pytest:
-
-```sh
-uv run python -m pytest -m "not integration" -v
-```
+This runs the unit suite and **deselects the integration tests**, which then show up in the
+summary as e.g. `27 deselected`. That is expected — those tests are *not* meant to run in a
+unit-only pass. They only execute in the integration modes below, because they need a live
+Viya instance; there is no flag that "activates" them in a `not integration` run.
 
 ### Running Integration Tests
 
-Integration tests call every tool against a live Viya environment. They require credentials, which can be provided via CLI arguments or `.env`:
+Integration tests call every tool against a live Viya environment. They require credentials, provided via `.env` or CLI arguments.
 
-**Using `.env`** (set `VIYA_ENDPOINT`, `VIYA_USERNAME`, `VIYA_PASSWORD`):
+For the **full** integration run (including the Excel `upload_data` test), install the
+optional format dependency first — plain `uv sync` does **not** include it:
+
 ```sh
-./run_tests.sh --integration
+uv sync --group test-formats
 ```
 
-**Using CLI arguments:**
+**Full suite (unit + integration)** — reads `VIYA_ENDPOINT`, `VIYA_USERNAME`, `VIYA_PASSWORD` from `.env`:
+```sh
+./run_tests.sh --integration      # Linux/macOS
+uv run python -m pytest -v        # any platform
+```
+
+**Passing credentials on the command line** (wrapper only):
 ```sh
 ./run_tests.sh --integration \
     --endpoint https://your-viya-server.com \
     --username youruser \
     --password yourpassword
 ```
+With the direct `pytest` command, set the same three variables in `.env` (or export them in your shell) instead.
 
 **Integration tests only** (skip unit tests):
 ```sh
-./run_tests.sh --integration-only
+./run_tests.sh --integration-only                    # Linux/macOS
+uv run python -m pytest -m integration --no-cov -v   # any platform
 ```
 
-**Binary upload formats.** The `upload_data` Excel integration test generates its `.xlsx`
-fixture with `openpyxl`. Install the optional group so it runs instead of `importorskip`-ing:
-`uv sync --group test-formats`. (csv, tsv, and `file_path`/`data_format` coverage needs no
-extra deps.) Generating a `sas7bdat`/`sashdat` fixture requires SAS itself, so those two
-formats are covered by unit-level payload tests only, not live.
+> **The pytest marker is `integration`, not `integration-only`.** `--integration-only` is a
+> flag of the `run_tests.sh` *wrapper*; the underlying pytest marker is just `integration`.
+> Running `pytest -m "integration-only"` matches no marker and silently deselects **all**
+> tests (`0 selected`). Use `-m integration`.
+>
+> **Why `--no-cov`?** `pytest.ini` enforces a 90% coverage floor that only the *full* unit
+> suite reaches. An integration-only run exercises far less code (~65%), so without
+> `--no-cov` pytest exits non-zero with a **coverage** failure even though every selected
+> test passed. `run_tests.sh --integration-only` adds `--no-cov` for you; add it yourself
+> when calling pytest directly (or use `--cov-fail-under=0`).
+
+**Binary upload formats.** The Excel `upload_data` integration test generates its `.xlsx`
+fixture with `openpyxl`, which lives in the optional `test-formats` group installed above.
+Without that group the test `importorskip`s (you'll see it as *skipped*, not failed). csv,
+tsv, and `file_path`/`data_format` coverage needs no extra deps. Generating a
+`sas7bdat`/`sashdat` fixture requires SAS itself, so those two formats are covered by
+unit-level payload tests only, not live.
 
 Every one of the 42 tools and 8 prompt templates has an integration test, enforced by the
 `test_every_tool_has_integration_coverage` / `test_every_prompt_has_integration_coverage`
@@ -324,7 +353,10 @@ guards — adding a new tool or prompt without integration coverage fails the su
 resource-dependent tests discover real targets on the instance: `score_data` scores the most
 recently modified MAS module (discovering a real step and its inputs), and `run_ml_project`
 re-runs the most recently modified `completed` ML project. They `skip` only if the instance
-has no such resource at all.
+has no such resource at all. Likewise, `test_catalog_agents_workflow` `skip`s with *"No
+discovery agent named 'Public'"* on instances where SAS Information Catalog has no discovery
+agent named `Public` configured — an expected skip, not a failure; ask a Viya admin to
+configure one if you need that test to run.
 
 **In CI:** the `.github/workflows/integration.yml` workflow runs this suite on demand
 (manual dispatch, or by adding the `run-integration` label to a PR) using repository

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ The server validates the token against Viya's JWKS and uses it upstream as-is, b
 #### Reports & Visualization
 - **list_reports**: List Visual Analytics reports
 - **get_report**: Get report metadata and definition
-- **get_report_image**: Render a report section as an image
 - **export_report**: export a report (or specific report objects) in any format the VA service supports — `package` (zip), `pdf`, `png`, `svg`, `csv`, `tsv`, `xlsx`, or `summary`. Text formats come back inline, `png` as image content, and binary formats (`package`/`pdf`/`xlsx`) as an embedded file with the right MIME type.
 
 #### Batch Jobs

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The server validates the token against Viya's JWKS and uses it upstream as-is, b
 - **list_reports**: List Visual Analytics reports
 - **get_report**: Get report metadata and definition
 - **get_report_image**: Render a report section as an image
-- **export_report_package**: exports a report as a package that you can use to embed the report on a website.
+- **export_report**: export a report (or specific report objects) in any format the VA service supports — `package` (zip), `pdf`, `png`, `svg`, `csv`, `tsv`, `xlsx`, or `summary`. Text formats come back inline, `png` as image content, and binary formats (`package`/`pdf`/`xlsx`) as an embedded file with the right MIME type.
 
 #### Batch Jobs
 - **submit_batch_job**: Submit a SAS job for async execution

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Here you can find getting articles on how to use and integrate the SAS MCP Serve
 ## Getting Started
 ### Prerequisites
 - Required
-    - [Python 3.12+](https://www.python.org/downloads) 
-    - [uv 0.8+](https://github.com/astral-sh/uv)  
+    - [Python 3.12+](https://www.python.org/downloads)
+    - [uv 0.8+](https://github.com/astral-sh/uv)
     - [SAS Viya environment](https://www.sas.com/en_us/software/viya.html) with compute service
     - Setup the Viya environment for MCP
         - See [configuration.md](/examples/configuration.md)
@@ -44,7 +44,7 @@ cd sas-mcp-server
 uv sync
 ```
 
-NOTE: This will by default create a virtual environment called .venv in the project's root directory. 
+NOTE: This will by default create a virtual environment called .venv in the project's root directory.
 
 If for some reason the virtual environment is not created, please run `uv venv` and then re-run `uv sync`.
 
@@ -169,6 +169,7 @@ The server validates the token against Viya's JWKS and uses it upstream as-is, b
 - **list_reports**: List Visual Analytics reports
 - **get_report**: Get report metadata and definition
 - **get_report_image**: Render a report section as an image
+- **export_report_package**: exports a report as a package that you can use to embed the report on a website.
 
 #### Batch Jobs
 - **submit_batch_job**: Submit a SAS job for async execution
@@ -368,8 +369,8 @@ Maintainers are accepting patches and contributions to this project. Please read
 
 ## License & Attribution
 
-Except for the the contents of the `/static` folder, this project is licensed under the [Apache 2.0 License](LICENSE). 
-Elements in the `/static` folder are owned by SAS and are not released under an open source license. 
+Except for the the contents of the `/static` folder, this project is licensed under the [Apache 2.0 License](LICENSE).
+Elements in the `/static` folder are owned by SAS and are not released under an open source license.
 SAS and all other SAS Institute Inc. product or service names are registered trademarks or trademarks of SAS Institute Inc. in the USA and other countries. ® indicates USA registration.
 
 Separate commercial licenses for SAS software (e.g., SAS Viya) are not included and are required to use these capabilities with SAS software.
@@ -389,4 +390,4 @@ This project requires the following dependencies.
 | FastMCP | [Apache License 2.0](https://github.com/PrefectHQ/fastmcp/blob/main/LICENSE) |
 | uvicorn | [BSD 3-Clause License](https://github.com/Kludex/uvicorn/blob/main/LICENSE.md) |
 | starlette | [BSD 3-Clause License](https://github.com/Kludex/starlette/blob/main/LICENSE.md)
-| httpx | [MIT License](https://github.com/projectdiscovery/httpx/blob/dev/LICENSE.md) | 
+| httpx | [MIT License](https://github.com/projectdiscovery/httpx/blob/dev/LICENSE.md) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,16 @@ dev = [
     "ruff>=0.14.4",
 ]
 # Writer used only to generate the binary .xlsx fixture for the upload_data
-# Excel integration test. Without it that test importorskips.
-# Install with: uv sync --group test-formats
+# Excel integration test; without it that test importorskips. Synced by default
+# via [tool.uv] default-groups below, so a plain `uv sync` installs it too.
 test-formats = [
     "openpyxl>=3.1",
 ]
+
+[tool.uv]
+# Include test-formats in a plain `uv sync` so the Excel upload_data integration
+# test runs out of the box, with no separate `--group test-formats` step.
+default-groups = ["dev", "test-formats"]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -85,6 +85,10 @@ HOST_PORT = int(os.getenv("HOST_PORT", "8134"))
 MCP_SIGNING_KEY = os.getenv("MCP_SIGNING_KEY", "default")
 CONTEXT_NAME = os.getenv("COMPUTE_CONTEXT_NAME", "SAS Job Execution compute context")
 MCP_BASE_URL = os.getenv("MCP_BASE_URL", f"http://localhost:{HOST_PORT}")
+# Upper bound on binary export bytes returned inline as an embedded resource by
+# ``export_report``. Larger exports are refused with guidance rather than
+# streamed through the model context (default 25 MiB).
+MAX_EXPORT_INLINE_BYTES = int(os.getenv("MAX_EXPORT_INLINE_BYTES", str(25 * 1024 * 1024)))
 
 if not VIYA_ENDPOINT:
     raise ConfigError(

--- a/src/sas_mcp_server/helpers/report_export_helpers.py
+++ b/src/sas_mcp_server/helpers/report_export_helpers.py
@@ -1,0 +1,204 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for the ``export_report`` tool.
+
+Holds the Visual Analytics export-format registry plus the request validation
+and execution logic, so the ``@mcp.tool`` in ``tools.py`` stays a thin wrapper
+(matching the ``helpers/`` pattern used elsewhere in the server).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from fastmcp.utilities.types import File, Image
+
+from sas_mcp_server.config import MAX_EXPORT_INLINE_BYTES, VIYA_ENDPOINT
+
+
+# One registry describing every synchronous Visual Analytics report export the
+# ``/visualAnalytics/reports/{id}/{suffix}`` endpoints expose. Each entry pins
+# the URL suffix, the Accept media type, and how report objects are addressed,
+# so the single ``export_report`` tool can validate inputs and shape its result
+# (text inline, image content, or an embedded binary file) per format. Adding a
+# format the VA service later supports is a one-line change here.
+@dataclass(frozen=True)
+class ReportExportFormat:
+    """A single synchronous VA report export endpoint."""
+
+    key: str  # value callers pass as ``export_format``
+    suffix: str  # path segment after the report id (the VA endpoint name)
+    file_ext: str  # download extension for the result (differs from suffix for zip/txt)
+    accept: str  # Accept media type requested and advertised on the result
+    object_param: str | None  # query param naming report object(s), or None
+    multi_object: bool  # True -> comma-joined list; False -> single label
+    object_required: bool  # at least one object label is mandatory
+    needs_size: bool  # image_size required (image endpoints)
+    is_text: bool  # response is UTF-8 text, returned inline
+    is_image: bool  # response is a raster image, returned as Image content
+
+
+REPORT_EXPORT_FORMATS: dict[str, ReportExportFormat] = {
+    fmt.key: fmt
+    for fmt in (
+        # key      suffix     ext    accept                            obj param       multi  req    size   text   image
+        ReportExportFormat("package", "package", "zip", "application/zip",
+            "reportObjects", True, False, False, False, False),
+        ReportExportFormat("pdf", "pdf", "pdf", "application/pdf",
+            "reportObjects", True, False, False, False, False),
+        ReportExportFormat("png", "png", "png", "image/png",
+            "reportObject", False, False, True, False, True),
+        ReportExportFormat("svg", "svg", "svg", "image/svg+xml",
+            "reportObject", False, False, True, True, False),
+        ReportExportFormat("csv", "csv", "csv", "text/csv",
+            "reportObject", False, True, False, True, False),
+        ReportExportFormat("tsv", "tsv", "tsv", "text/tsv",
+            "reportObject", False, True, False, True, False),
+        ReportExportFormat("xlsx", "xlsx", "xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "reportObject", False, True, False, False, False),
+        ReportExportFormat("summary", "summary", "txt", "text/plain",
+            None, False, False, False, True, False),
+    )
+}
+
+
+@dataclass
+class ReportExportRequest:
+    """A normalised ``export_report`` invocation."""
+
+    report_id: str
+    export_format: str
+    report_objects: list[str] = field(default_factory=list)
+    image_size: str | None = None
+    options: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        # Tolerate ``None`` and a single label passed as a bare string.
+        if self.report_objects is None:
+            self.report_objects = []
+        elif isinstance(self.report_objects, str):
+            self.report_objects = [self.report_objects]
+
+
+def validate_export_request(req: ReportExportRequest) -> dict[str, Any] | None:
+    """Return a structured error dict if *req* is invalid, else ``None``.
+
+    Enforces the per-format rules the VA endpoints impose (object cardinality
+    and the required ``image_size``) before any HTTP call is made.
+    """
+    fmt = REPORT_EXPORT_FORMATS.get(req.export_format)
+    if fmt is None:
+        return {
+            "status": "unsupported_format",
+            "export_format": req.export_format,
+            "supported": sorted(REPORT_EXPORT_FORMATS),
+        }
+    objects = req.report_objects
+    if fmt.object_param is None and objects:
+        return {
+            "status": "invalid_request",
+            "message": f"export_format '{fmt.key}' does not take report objects.",
+        }
+    if objects and not fmt.multi_object and len(objects) > 1:
+        return {
+            "status": "invalid_request",
+            "message": (
+                f"export_format '{fmt.key}' exports a single report object; "
+                f"got {len(objects)}. Pass exactly one label."
+            ),
+        }
+    if fmt.object_required and not objects:
+        return {
+            "status": "invalid_request",
+            "message": (
+                f"export_format '{fmt.key}' requires one report object label "
+                "in report_objects."
+            ),
+        }
+    if fmt.needs_size and not req.image_size:
+        return {
+            "status": "invalid_request",
+            "message": (
+                f"export_format '{fmt.key}' requires image_size, "
+                'e.g. "1200px,800px".'
+            ),
+        }
+    return None
+
+
+def build_export_params(fmt: ReportExportFormat, req: ReportExportRequest) -> dict[str, str]:
+    """Build the query parameters for the VA export request."""
+    params: dict[str, str] = {}
+    if fmt.object_param and req.report_objects:
+        params[fmt.object_param] = (
+            ",".join(req.report_objects) if fmt.multi_object else req.report_objects[0]
+        )
+    if fmt.needs_size and req.image_size:
+        params["size"] = req.image_size
+    if fmt.key == "pdf" and req.options:
+        params.update({key: str(value) for key, value in req.options.items()})
+    return params
+
+
+async def execute_export(req: ReportExportRequest, client: httpx.AsyncClient) -> Any:
+    """Call the VA export endpoint for a *validated* request and shape the result.
+
+    Returns text inline for text formats, ``Image`` content for ``png``, and an
+    embedded binary file (with the correct MIME type) for ``package``/``pdf``/
+    ``xlsx``. Binary results over ``MAX_EXPORT_INLINE_BYTES`` are refused with
+    guidance rather than streamed through the model context. A Viya HTTP error
+    is surfaced as a structured ``export_failed`` dict rather than raised.
+    """
+    fmt = REPORT_EXPORT_FORMATS[req.export_format]
+    params = build_export_params(fmt, req)
+    resp = await client.get(
+        f"{VIYA_ENDPOINT}/visualAnalytics/reports/{req.report_id}/{fmt.suffix}",
+        params=params,
+        headers={"Accept": fmt.accept},
+        follow_redirects=True,
+    )
+    if resp.status_code >= 400:
+        # Surface why Viya refused (bad object label, an object type that the
+        # exporter can't render, a server fault) as a structured error instead
+        # of raising an opaque one. Some VA export faults (e.g. data export of a
+        # non-tabular object) come back as a bare 500 with no body.
+        return {
+            "status": "export_failed",
+            "export_format": fmt.key,
+            "http_status": resp.status_code,
+            "report_id": req.report_id,
+            "message": (
+                f"Viya rejected the {fmt.key} export of report {req.report_id} "
+                f"(HTTP {resp.status_code}). The report or object may not support "
+                f"this export. Viya said: {resp.text[:400] or '(no response body)'}"
+            ),
+        }
+
+    if fmt.is_text:
+        return resp.text
+
+    content = resp.content
+    if len(content) > MAX_EXPORT_INLINE_BYTES:
+        return {
+            "status": "export_too_large",
+            "export_format": fmt.key,
+            "size_bytes": len(content),
+            "limit_bytes": MAX_EXPORT_INLINE_BYTES,
+            "message": (
+                f"The {fmt.key} export is {len(content):,} bytes, over the "
+                f"{MAX_EXPORT_INLINE_BYTES:,}-byte inline limit. Narrow the "
+                "export via report_objects, choose a lighter format, or "
+                "raise MAX_EXPORT_INLINE_BYTES."
+            ),
+        }
+
+    if fmt.is_image:
+        return Image(data=content, format=fmt.file_ext)
+    # ``format`` sets the embedded resource's filename extension; the explicit
+    # mime_type override gives it the real media type (the File helper would
+    # otherwise advertise ``application/<format>``).
+    return File(
+        data=content, format=fmt.file_ext, name=req.report_id
+    ).to_resource_content(mime_type=fmt.accept)

--- a/src/sas_mcp_server/helpers/report_export_helpers.py
+++ b/src/sas_mcp_server/helpers/report_export_helpers.py
@@ -70,7 +70,7 @@ class ReportExportRequest:
 
     report_id: str
     export_format: str
-    report_objects: list[str] = field(default_factory=list)
+    report_objects: list[str] | None = field(default_factory=list)
     image_size: str | None = None
     options: dict[str, Any] | None = None
 

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -801,37 +801,6 @@ def register_tools(
             return await get_json(f"/reports/reports/{report_id}", client)
 
     @mcp.tool()
-    async def get_report_image(
-        report_id: str, ctx: Context, image_type: str = "png", section_index: int = 0
-    ) -> dict[str, Any]:
-        """Render a Visual Analytics report section as an image.
-
-        Args:
-            report_id: ID of the report.
-            image_type: Image format — 'png' or 'svg' (default 'png').
-            section_index: Report section/page index (default 0).
-        """
-        async with viya_session("get_report_image", ctx) as client:
-            body = {
-                "reportUri": f"/reports/reports/{report_id}",
-                "layoutType": "thumbnail",
-                "selectionType": "perSection",
-                "sectionIndex": section_index,
-                "size": "800x600",
-                "renderLimit": 1,
-            }
-            resp = await client.post(
-                f"{VIYA_ENDPOINT}/reportImages/jobs",
-                content=json.dumps(body).encode(),
-                headers={
-                    "Content-Type": "application/vnd.sas.report.images.job.request+json",
-                    "Accept": "application/vnd.sas.report.images.job+json",
-                },
-            )
-            resp.raise_for_status()
-            return resp.json()
-
-    @mcp.tool()
     async def export_report(
         report_id: str,
         export_format: str,

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -6,7 +6,6 @@ Shared tool registration for both HTTP and stdio MCP servers.
 All tools are registered via ``register_tools(mcp, get_token)``.
 """
 
-import base64
 import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -16,6 +15,8 @@ from typing import Any
 
 import httpx
 from fastmcp import Context, FastMCP
+
+from sas_mcp_server.helpers import report_export_helpers
 
 from .config import CONTEXT_NAME, SSL_VERIFY, VIYA_ENDPOINT
 from .env import env_bool
@@ -264,6 +265,7 @@ async def _post_cas_upload(
     }
 
 
+# --- export_report: Visual Analytics export-format registry -------------------
 def register_tools(
     mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]
 ) -> None:
@@ -830,43 +832,57 @@ def register_tools(
             return resp.json()
 
     @mcp.tool()
-    async def export_report_package(report_id: str, ctx: Context, reportObjects: list[str]):
-        """Exports a package for the report or report objects in compressed (zip) format.
-        The returned content contains the report source files, plus the results of data
-        queries and image rendering, constituting all that is needed for remote viewing
-        of the report.
+    async def export_report(
+        report_id: str,
+        export_format: str,
+        ctx: Context,
+        report_objects: list[str] | None = None,
+        image_size: str | None = None,
+        options: dict[str, Any] | None = None,
+    ):
+        """Export a Visual Analytics report (or specific report objects) in any
+        format the VA service exposes, via its synchronous export endpoints.
+
+        Formats (``export_format``):
+          * ``package`` — full report bundle as a ``.zip`` (source files, query
+            results, and rendered content); whole report or selected objects.
+          * ``pdf`` — rendered PDF; whole report or selected objects. Pass
+            rendering overrides (e.g. ``orientation``, ``paperSize``, ``margin``,
+            ``includeCoverPage``) via ``options``.
+          * ``png`` / ``svg`` — image of the report or a single object;
+            ``image_size`` is required, e.g. ``"1200px,800px"``.
+          * ``csv`` / ``tsv`` / ``xlsx`` — the data behind a single report
+            object; exactly one object label is required.
+          * ``summary`` — the report's text summary.
 
         Args:
             report_id: ID of the report.
-            reportObjects: Optional list of report object IDs to include in the package.
-        """
-        async with viya_session("export_report_package", ctx) as client:
-            body = {
-                "reportObjects": reportObjects
-            }
-            resp = await client.request(
-                "GET",
-                f"{VIYA_ENDPOINT}/visualAnalytics/getExportedReportPackage/{report_id}/package",
-                content=json.dumps(body).encode(),
-                headers={
-                    "Accept": "application/zip, application/json, application/vnd.sas.error+json, application/json"
-                },
-            )
-            resp.raise_for_status()
+            export_format: One of package, pdf, png, svg, csv, tsv, xlsx, summary.
+            report_objects: Report object labels to export. ``package``/``pdf``
+                accept several; image and data formats accept exactly one;
+                ``summary`` accepts none. Omit to export the whole report where
+                the format allows it.
+            image_size: Required for ``png``/``svg``; format ``"<w>px,<h>px"``.
+            options: Optional ``pdf`` rendering overrides, passed through as query
+                parameters (e.g. ``{"orientation": "landscape"}``).
 
-            # Handle both zip and JSON responses based on content-type
-            content_type = resp.headers.get("content-type", "").lower()
-            if "application/zip" in content_type:
-                # Return zip file as base64-encoded string
-                return {
-                    "status": "success",
-                    "content_type": "application/zip",
-                    "data": base64.b64encode(resp.content).decode("utf-8"),
-                    "size_bytes": len(resp.content),
-                }
-            else:
-                # Return JSON response (error or success)
-                return resp.json()
+        Returns text inline for text formats, image content for ``png``, and an
+        embedded binary file (carrying the right MIME type) for ``package`` /
+        ``pdf`` / ``xlsx``. Binary results larger than ``MAX_EXPORT_INLINE_BYTES``
+        are refused with guidance rather than streamed through the model context.
+        """
+        req = report_export_helpers.ReportExportRequest(
+            report_id=report_id,
+            export_format=export_format,
+            report_objects=report_objects,
+            image_size=image_size,
+            options=options,
+        )
+        error = report_export_helpers.validate_export_request(req)
+        if error is not None:
+            return error
+        async with viya_session("export_report", ctx) as client:
+            return await report_export_helpers.execute_export(req, client)
 
     # ------------------------------------------------------------------
     # Tier 4 — Batch Jobs & Async Execution

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -26,6 +26,7 @@ from .viya_client import (
 )
 from .viya_utils import get_cached_session, reset_cached_session, run_one_snippet
 
+import base64
 
 def register_tools(
     mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]
@@ -549,6 +550,44 @@ def register_tools(
             )
             resp.raise_for_status()
             return resp.json()
+
+    @mcp.tool()
+    async def export_report_package(report_id: str, ctx: Context, reportObjects: list[str]):
+        """Exports a package for the report or report objects in compressed (zip) format.
+        The returned content contains the report source files, plus the results of data
+        queries and image rendering, constituting all that is needed for remote viewing
+        of the report.
+
+        Args:
+            report_id: ID of the report.
+            reportObjects: Optional list of report object IDs to include in the package.
+        """
+        async with viya_session("export_report_package", ctx) as client:
+            body = {
+                "reportObjects": reportObjects
+            }
+            resp = await client.get(
+                f"{VIYA_ENDPOINT}/visualAnalytics/getExportedReportPackage/{report_id}/package",
+                content=json.dumps(body).encode(),
+                headers={
+                    "Accept": "application/zip, application/json, application/vnd.sas.error+json, application/json"
+                },
+            )
+            resp.raise_for_status()
+
+            # Handle both zip and JSON responses based on content-type
+            content_type = resp.headers.get("content-type", "").lower()
+            if "application/zip" in content_type:
+                # Return zip file as base64-encoded string
+                return {
+                    "status": "success",
+                    "content_type": "application/zip",
+                    "data": base64.b64encode(resp.content).decode("utf-8"),
+                    "size_bytes": len(resp.content),
+                }
+            else:
+                # Return JSON response (error or success)
+                return resp.json()
 
     # ------------------------------------------------------------------
     # Tier 4 — Batch Jobs & Async Execution

--- a/src/sas_mcp_server/tools.py
+++ b/src/sas_mcp_server/tools.py
@@ -6,6 +6,7 @@ Shared tool registration for both HTTP and stdio MCP servers.
 All tools are registered via ``register_tools(mcp, get_token)``.
 """
 
+import base64
 import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -26,7 +27,6 @@ from .viya_client import (
 )
 from .viya_utils import get_cached_session, reset_cached_session, run_one_snippet
 
-import base64
 
 def register_tools(
     mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]
@@ -566,7 +566,8 @@ def register_tools(
             body = {
                 "reportObjects": reportObjects
             }
-            resp = await client.get(
+            resp = await client.request(
+                "GET",
                 f"{VIYA_ENDPOINT}/visualAnalytics/getExportedReportPackage/{report_id}/package",
                 content=json.dumps(body).encode(),
                 headers={

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ Integration tests that call MCP tools against a real SAS Viya instance.
 Requires VIYA_ENDPOINT, VIYA_USERNAME, and VIYA_PASSWORD environment variables.
 Run with:  uv run python -m pytest -m integration
 """
+import base64
 import contextlib
 import tempfile
 import time
@@ -23,6 +24,13 @@ from fastmcp import Client
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
 
 _SUFFIX = str(int(time.time()))[-6:]
+
+
+def _embedded_file_bytes(result) -> int:
+    """Decode the first embedded-resource block of a tool result, return its size."""
+    block = result.content[0]
+    assert block.type == "resource", f"expected an embedded resource, got {block.type}"
+    return len(base64.b64decode(block.resource.blob))
 
 
 async def _viya_get(token: str, path: str, params: dict | None = None) -> dict:
@@ -461,23 +469,34 @@ async def test_report_workflow(integration_mcp_server):
         })).data
         assert isinstance(report, dict)
 
-        # export_report: the report summary is the safest universal export
-        # (text, no report objects required), and the package export exercises
-        # the binary/embedded-file path.
+        # export_report: retrieve the whole report in the common deliverable
+        # formats. summary is text; pdf and package come back as embedded binary
+        # files; png as image content. Each must return non-empty content.
         summary = await client.call_tool("export_report", {
             "report_id": report_id,
             "export_format": "summary",
         })
-        assert summary.content
+        assert summary.content  # text block (may be an empty summary)
 
-        try:
-            package = await client.call_tool("export_report", {
-                "report_id": report_id,
-                "export_format": "package",
-            })
-            assert package.content
-        except Exception:
-            pass
+        pdf = await client.call_tool("export_report", {
+            "report_id": report_id,
+            "export_format": "pdf",
+        })
+        assert _embedded_file_bytes(pdf) > 0
+
+        png = await client.call_tool("export_report", {
+            "report_id": report_id,
+            "export_format": "png",
+            "image_size": "1200px,800px",
+        })
+        assert png.content and png.content[0].type == "image"
+        assert len(base64.b64decode(png.content[0].data)) > 0
+
+        package = await client.call_tool("export_report", {
+            "report_id": report_id,
+            "export_format": "package",
+        })
+        assert _embedded_file_bytes(package) > 0
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -447,7 +447,7 @@ async def test_batch_job_workflow(integration_mcp_server):
 
 
 async def test_report_workflow(integration_mcp_server):
-    """list_reports → get_report → get_report_image"""
+    """list_reports → get_report → export_report"""
     async with Client(integration_mcp_server) as client:
         reports = (await client.call_tool("list_reports", {"limit": 5})).data
         assert isinstance(reports, list)
@@ -460,14 +460,6 @@ async def test_report_workflow(integration_mcp_server):
             "report_id": report_id
         })).data
         assert isinstance(report, dict)
-
-        try:
-            image_job = (await client.call_tool("get_report_image", {
-                "report_id": report_id
-            })).data
-            assert isinstance(image_job, dict)
-        except Exception:
-            pass
 
         # export_report: the report summary is the safest universal export
         # (text, no report objects required), and the package export exercises
@@ -953,7 +945,6 @@ TOOL_COVERAGE = {
     "download_file": "test_file_service_workflow",
     "list_reports": "test_report_workflow",
     "get_report": "test_report_workflow",
-    "get_report_image": "test_report_workflow",
     "export_report": "test_report_workflow",
     "submit_batch_job": "test_batch_job_workflow",
     "get_job_status": "test_batch_job_workflow",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -469,6 +469,24 @@ async def test_report_workflow(integration_mcp_server):
         except Exception:
             pass
 
+        # export_report: the report summary is the safest universal export
+        # (text, no report objects required), and the package export exercises
+        # the binary/embedded-file path.
+        summary = await client.call_tool("export_report", {
+            "report_id": report_id,
+            "export_format": "summary",
+        })
+        assert summary.content
+
+        try:
+            package = await client.call_tool("export_report", {
+                "report_id": report_id,
+                "export_format": "package",
+            })
+            assert package.content
+        except Exception:
+            pass
+
 
 # -----------------------------------------------------------------------
 # ML Project Workflow
@@ -936,6 +954,7 @@ TOOL_COVERAGE = {
     "list_reports": "test_report_workflow",
     "get_report": "test_report_workflow",
     "get_report_image": "test_report_workflow",
+    "export_report": "test_report_workflow",
     "submit_batch_job": "test_batch_job_workflow",
     "get_job_status": "test_batch_job_workflow",
     "list_jobs": "test_batch_job_workflow",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ Run with:  uv run python -m pytest -m integration
 """
 import base64
 import contextlib
+import os
 import tempfile
 import time
 from pathlib import Path
@@ -460,10 +461,13 @@ async def test_report_workflow(integration_mcp_server):
         reports = (await client.call_tool("list_reports", {"limit": 5})).data
         assert isinstance(reports, list)
 
-        if not reports:
-            pytest.skip("No reports found on this Viya instance")
-
-        report_id = reports[0]["id"]
+        # Pin to TEST_REPORT_ID when set (deterministic CI); otherwise use the
+        # first report the instance returns.
+        report_id = os.getenv("TEST_REPORT_ID")
+        if not report_id:
+            if not reports:
+                pytest.skip("No reports found on this Viya instance")
+            report_id = reports[0]["id"]
         report = (await client.call_tool("get_report", {
             "report_id": report_id
         })).data

--- a/tests/test_report_export_helpers.py
+++ b/tests/test_report_export_helpers.py
@@ -1,0 +1,109 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the report_export helpers — pure logic, no MCP or network.
+
+These exercise the validation and query-param building that back the
+``export_report`` tool, which is the reusability win of the helpers split.
+"""
+
+from sas_mcp_server.helpers.report_export_helpers import (
+    REPORT_EXPORT_FORMATS,
+    ReportExportRequest,
+    build_export_params,
+    validate_export_request,
+)
+
+
+def _req(**kw):
+    kw.setdefault("report_id", "rep1")
+    return ReportExportRequest(**kw)
+
+
+# --- request normalisation ------------------------------------------------
+
+
+def test_request_normalises_none_objects():
+    assert _req(export_format="summary", report_objects=None).report_objects == []
+
+
+def test_request_normalises_string_object():
+    assert _req(export_format="csv", report_objects="ve1").report_objects == ["ve1"]
+
+
+# --- validation -----------------------------------------------------------
+
+
+def test_validate_unsupported_format():
+    err = validate_export_request(_req(export_format="docx"))
+    assert err["status"] == "unsupported_format"
+    assert "package" in err["supported"]
+
+
+def test_validate_summary_rejects_objects():
+    err = validate_export_request(_req(export_format="summary", report_objects=["ve1"]))
+    assert err["status"] == "invalid_request"
+
+
+def test_validate_data_requires_object():
+    err = validate_export_request(_req(export_format="csv"))
+    assert err["status"] == "invalid_request"
+
+
+def test_validate_data_rejects_multiple_objects():
+    err = validate_export_request(_req(export_format="xlsx", report_objects=["a", "b"]))
+    assert err["status"] == "invalid_request"
+
+
+def test_validate_image_requires_size():
+    err = validate_export_request(_req(export_format="png", report_objects=["ve1"]))
+    assert err["status"] == "invalid_request"
+
+
+def test_validate_accepts_valid_requests():
+    assert validate_export_request(_req(export_format="package")) is None
+    assert validate_export_request(
+        _req(export_format="package", report_objects=["a", "b"])
+    ) is None
+    assert validate_export_request(
+        _req(export_format="png", report_objects=["ve1"], image_size="800px,600px")
+    ) is None
+    assert validate_export_request(_req(export_format="csv", report_objects=["ve1"])) is None
+
+
+# --- param building -------------------------------------------------------
+
+
+def test_params_multi_object_comma_joined():
+    fmt = REPORT_EXPORT_FORMATS["package"]
+    params = build_export_params(fmt, _req(export_format="package", report_objects=["a", "b"]))
+    assert params == {"reportObjects": "a,b"}
+
+
+def test_params_single_object_uses_singular_key():
+    fmt = REPORT_EXPORT_FORMATS["csv"]
+    params = build_export_params(fmt, _req(export_format="csv", report_objects=["ve1"]))
+    assert params == {"reportObject": "ve1"}
+
+
+def test_params_image_includes_size():
+    fmt = REPORT_EXPORT_FORMATS["png"]
+    params = build_export_params(
+        fmt, _req(export_format="png", report_objects=["ve1"], image_size="800px,600px")
+    )
+    assert params["reportObject"] == "ve1"
+    assert params["size"] == "800px,600px"
+
+
+def test_params_pdf_passes_options_as_strings():
+    fmt = REPORT_EXPORT_FORMATS["pdf"]
+    params = build_export_params(
+        fmt, _req(export_format="pdf", options={"orientation": "landscape", "includeCoverPage": True})
+    )
+    assert params["orientation"] == "landscape"
+    assert params["includeCoverPage"] == "True"
+
+
+def test_params_summary_has_none():
+    fmt = REPORT_EXPORT_FORMATS["summary"]
+    assert build_export_params(fmt, _req(export_format="summary")) == {}

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -9,7 +9,6 @@ request that would be sent to Viya — URL path, method, body structure, query
 params, and headers.  These tests use a mock httpx client (no network calls).
 """
 
-import json
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -34,7 +33,6 @@ EXPECTED_TOOLS = [
     "download_file",
     "list_reports",
     "get_report",
-    "get_report_image",
     "export_report",
     "submit_batch_job",
     "get_job_status",
@@ -442,30 +440,6 @@ async def test_get_report_request(mcp_server_with_mock_client):
 
     url = mock_client.get.call_args[0][0]
     assert "/reports/reports/rpt-456" in url
-
-
-async def test_get_report_image_request(mcp_server_with_mock_client):
-    mcp, mock_client = mcp_server_with_mock_client
-    async with Client(mcp) as client:
-        await client.call_tool(
-            "get_report_image", {"report_id": "rpt-456", "section_index": 2}
-        )
-
-    url = mock_client.post.call_args[0][0]
-    assert "/reportImages/jobs" in url
-    kwargs = mock_client.post.call_args[1]
-    body = json.loads(kwargs["content"])
-    assert body["reportUri"] == "/reports/reports/rpt-456"
-    assert body["layoutType"] == "thumbnail"
-    assert body["selectionType"] == "perSection"
-    assert body["sectionIndex"] == 2
-    assert body["size"] == "800x600"
-    assert body["renderLimit"] == 1
-    headers = kwargs["headers"]
-    assert (
-        headers["Content-Type"] == "application/vnd.sas.report.images.job.request+json"
-    )
-    assert headers["Accept"] == "application/vnd.sas.report.images.job+json"
 
 
 def _binary_export_response(content: bytes, content_type: str):

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -35,6 +35,7 @@ EXPECTED_TOOLS = [
     "list_reports",
     "get_report",
     "get_report_image",
+    "export_report",
     "submit_batch_job",
     "get_job_status",
     "list_jobs",
@@ -465,6 +466,151 @@ async def test_get_report_image_request(mcp_server_with_mock_client):
         headers["Content-Type"] == "application/vnd.sas.report.images.job.request+json"
     )
     assert headers["Accept"] == "application/vnd.sas.report.images.job+json"
+
+
+def _binary_export_response(content: bytes, content_type: str):
+    resp = _make_mock_response()
+    resp.content = content
+    resp.headers = {"content-type": content_type}
+    return resp
+
+
+async def test_export_report_package_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _binary_export_response(
+        b"PK\x03\x04zip-bytes", "application/zip"
+    )
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "export_report",
+            {
+                "report_id": "abc123",
+                "export_format": "package",
+                "report_objects": ["ve123", "ve456"],
+            },
+        )
+
+    url = mock_client.get.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports/abc123/package")
+    params = mock_client.get.call_args[1]["params"]
+    assert params["reportObjects"] == "ve123,ve456"
+    assert mock_client.get.call_args[1]["headers"]["Accept"] == "application/zip"
+
+
+async def test_export_report_pdf_passes_options(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _binary_export_response(
+        b"%PDF-1.7", "application/pdf"
+    )
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "export_report",
+            {
+                "report_id": "rep1",
+                "export_format": "pdf",
+                "options": {"orientation": "landscape"},
+            },
+        )
+
+    url = mock_client.get.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports/rep1/pdf")
+    params = mock_client.get.call_args[1]["params"]
+    assert params["orientation"] == "landscape"
+    assert mock_client.get.call_args[1]["headers"]["Accept"] == "application/pdf"
+
+
+async def test_export_report_png_requires_size_param(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value = _binary_export_response(b"\x89PNG\r\n", "image/png")
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "export_report",
+            {
+                "report_id": "rep1",
+                "export_format": "png",
+                "report_objects": ["ve1"],
+                "image_size": "800px,600px",
+            },
+        )
+
+    url = mock_client.get.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports/rep1/png")
+    params = mock_client.get.call_args[1]["params"]
+    assert params["reportObject"] == "ve1"
+    assert params["size"] == "800px,600px"
+
+
+async def test_export_report_csv_returns_text(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    csv_resp = _make_mock_response(text="a,b\n1,2\n")
+    csv_resp.headers = {"content-type": "text/csv"}
+    mock_client.get.return_value = csv_resp
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "export_report",
+            {"report_id": "rep1", "export_format": "csv", "report_objects": ["ve1"]},
+        )
+
+    url = mock_client.get.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports/rep1/csv")
+    assert mock_client.get.call_args[1]["params"]["reportObject"] == "ve1"
+    assert "a,b" in result.content[0].text
+
+
+async def test_export_report_csv_requires_object(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "export_report", {"report_id": "rep1", "export_format": "csv"}
+        )
+
+    assert result.data["status"] == "invalid_request"
+    mock_client.get.assert_not_called()
+
+
+async def test_export_report_data_rejects_multiple_objects(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "export_report",
+            {
+                "report_id": "rep1",
+                "export_format": "xlsx",
+                "report_objects": ["ve1", "ve2"],
+            },
+        )
+
+    assert result.data["status"] == "invalid_request"
+    mock_client.get.assert_not_called()
+
+
+async def test_export_report_http_error_is_structured(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    err_resp = _make_mock_response(status_code=500)
+    err_resp.content = b""
+    err_resp.text = ""
+    err_resp.headers = {"content-type": "text/plain"}
+    mock_client.get.return_value = err_resp
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "export_report",
+            {"report_id": "rep1", "export_format": "csv", "report_objects": ["ve1"]},
+        )
+
+    assert result.data["status"] == "export_failed"
+    assert result.data["http_status"] == 500
+
+
+async def test_export_report_unsupported_format(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "export_report", {"report_id": "rep1", "export_format": "docx"}
+        )
+
+    assert result.data["status"] == "unsupported_format"
+    assert "package" in result.data["supported"]
+    mock_client.get.assert_not_called()
 
 
 # -----------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "aiofile"
 version = "3.9.0"


### PR DESCRIPTION
## Summary

Addresses user feedback on the **Testing** section of the README and removes a setup papercut around the Excel integration test.

**Docs — clarify the test-runner commands (`51d2f97`):**
- Explain `run_tests.sh` (Bash: Linux/macOS, or Git Bash/WSL) vs. the direct `uv run python -m pytest …` commands (any platform, incl. Windows PowerShell), and show both for every mode.
- Document the direct `pytest` equivalents for the integration and integration-only modes, which were previously wrapper-only.
- Clarify that the pytest marker is `integration`, **not** `integration-only` — `pytest -m "integration-only"` matches no marker and silently deselects **all** tests (`0 selected`).
- Explain why an integration-only run needs `--no-cov`: the 90% coverage floor is only met by the full unit suite, so the subset otherwise exits non-zero on *coverage* even when every test passed.
- Clarify that the "deselected" tests in a unit run are the integration tests (they only run in the integration modes).
- Document the `test_catalog_agents_workflow` discovery-agent skip ("No discovery agent named 'Public'") as an expected, environment-dependent skip.

**Deps — install the Excel test dependency by default (`8412e2a`):**
- Add `[tool.uv] default-groups = ["dev", "test-formats"]` so a plain `uv sync` installs `openpyxl` and the `upload_data` Excel integration test runs out of the box — no separate `uv sync --group test-formats` step. This fixes reported "still missing components after `uv sync`" friction.
- `uv.lock` is unchanged: the `test-formats` group was already resolved into the lock, and `default-groups` only affects what gets **installed**, not resolution.

## Note on scope

This branch is `sassoftware:main` + 13 commits. The two commits above are the net-new doc/deps change; the branch also brings the preceding **reports / `export_report` / v1.3.0 upload** work that had not yet landed on `main` (files `report_export_helpers.py`, `tools.py`, `test_integration.py`, `test_report_export_helpers.py`, `test_tool_payloads.py`, `CHANGELOG.md`, `config.py`, `uv.lock`). Happy to split the doc/deps change into its own focused PR if you'd prefer it reviewed in isolation.

## Verification

- `pyproject.toml` parses; `default-groups` resolves to `['dev', 'test-formats']`.
- `openpyxl 3.1.5` is importable in the venv.
- Confirmed the marker behavior: `pytest -m "integration-only" --collect-only` → `0 selected / 243 deselected`; `-m integration` → `27 selected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
