### PR TITLE
feat(telemetry): opt-in collection-mode usage telemetry

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,3 +28,67 @@ SAS_CLI_CONFIG=
 # MCP server in either HTTP or stdio mode.
 VIYA_USERNAME=
 VIYA_PASSWORD=
+
+# =============================================================================
+# OPT-IN COLLECTION MODE (telemetry)  --  DEFAULT: OFF
+# =============================================================================
+# When enabled, the server injects a required "goal" parameter into EVERY tool
+# schema (the model states, in one sentence, WHY it chose that tool) and appends
+# one JSON line per tool call — input arguments, output (see below), session id,
+# goal, status, and latency — to a local log file.
+#
+# INFORMED CONSENT — READ THIS: enabling this records YOUR TOOL INPUTS and the
+# model's stated "goal", and lets you share them with the maintainer. Captured
+# by default:
+#   * arguments (e.g. the SAS code / queries you submit) and the model's "goal"
+#   * status, error text, latency, and a session id
+#   * tool RESULTS are recorded as a content-free SHAPE SUMMARY only (type +
+#     item/key count or byte size), NOT their contents — unless you opt in with
+#     COLLECTION_LOG_RESULTS=true (see below).
+# Redaction is HEURISTIC and only covers credential-shaped KEYS (token,
+# password, authorization, api_key, ...) plus inline Bearer/JWT tokens; it does
+# NOT detect PII such as names, emails, SSNs, or account numbers in data values.
+# Each field is size-capped, but you MUST REVIEW the log before sharing it.
+# Leave this OFF unless you intend to contribute usage data.
+#
+# WINDOWS PERMISSIONS: the file/dir are locked to your user via icacls on
+# Windows (best-effort) and via chmod 0600/0700 on POSIX. The POSIX bits are a
+# NO-OP on Windows. On shared/multi-user or roaming-profile Windows hosts,
+# verify the ACL yourself and prefer a private path.
+#
+# MULTI-WORKER: with the HTTP server, run a single worker (the default) or use a
+# per-process COLLECTION_LOG_PATH — concurrent appends to one file from separate
+# processes are not lock-coordinated across processes.
+#
+# Master switch. OFF unless explicitly true/1/yes/on.
+# COLLECTION_MODE=false
+#
+# Log-file path. Default uses the DOTTED dir (~/.sas-mcp-server/) to match the
+# existing credentials directory and to stay OUTSIDE the tree the HTTP server
+# serves. Rotated files are named tool-usage.log.1, .2, ... (glob:
+# tool-usage.log*).
+# COLLECTION_LOG_PATH=~/.sas-mcp-server/tool-usage.log
+#
+# Per-field cap in bytes for arguments/goal/error (larger, to capture SAS code),
+# and a separate smaller cap for results. Truncated fields keep their JSON
+# object/array type and are flagged with arguments_truncated / result_truncated.
+# COLLECTION_MAX_FIELD_BYTES=16384
+# COLLECTION_MAX_RESULT_BYTES=8192
+#
+# Log rotation: max bytes per file before rollover (default 10 MiB) and how many
+# rotated backups to keep.
+# COLLECTION_MAX_LOG_BYTES=10485760
+# COLLECTION_LOG_BACKUPS=3
+#
+# Whether "goal" is REQUIRED in each tool schema. Set false as an escape hatch
+# if a strict-schema client rejects the extra param. NOTE: "goal" is a reserved
+# parameter name while collection mode is on; none of the current tools use it.
+# COLLECTION_REQUIRE_GOAL=true
+#
+# Privacy dial for tool RESULTS. DEFAULT false = record only a content-free
+# shape summary (type + item/key count or byte size), NOT result contents, so
+# you can contribute which tools are used, for what goals, with what inputs, and
+# where they fail — WITHOUT exporting table rows or SAS listings. Set true to
+# capture (capped + redacted) result contents for richer analysis. Arguments and
+# goal are captured either way.
+# COLLECTION_LOG_RESULTS=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Opt-in "collection mode" usage telemetry** — an off-by-default mode that helps maintainers (or organizations running the server internally) learn how the server is actually used: which tools, for what goals, with what inputs, and where they fall short. Implemented as a FastMCP middleware (`telemetry.py` plus a fastmcp-free `usage_logger.py`) that requires **no changes to any existing tool**. When enabled it (1) injects a required `goal` parameter into every tool's published schema asking the model to state in one sentence *why* it chose that tool — stripped from the arguments before the tool runs, so tools never see it — and (2) appends one redacted, size-bounded JSON Lines record per call (timestamp, session id, tool, goal, arguments, result, status, error, latency, transport) to a rotating local log file. Controlled by `COLLECTION_MODE` (off by default); **nothing is ever transmitted anywhere** — the log stays on the machine running the server and sharing it with the maintainers is a deliberate, manual step. Tool results are recorded as a content-free shape summary unless `COLLECTION_LOG_RESULTS=true`; secret-shaped keys and inline Bearer/JWT tokens are redacted, every field is size-capped, and the log file is locked to the current user. Wired into both the HTTP (`mcp_server.py`, registered outermost so it also records auth failures) and stdio (`stdio_server.py`) entry points and configured via seven `COLLECTION_*` variables documented in `.env.sample` and the README. Measured cost (45 tools): ~+2,400 prompt tokens/turn from the injected schema (largely prompt-cache-amortized) and ≈1.4 ms/call server overhead at the shape-only default — negligible against live Viya latency (the integration suite passes identically with it off and on).
+
 ## [1.4.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -275,6 +275,49 @@ run;
 
 **For more details, configuration options, and deployment options, please refer to the **examples** folder and follow the instructions listed there.**
 
+## Collection Mode (Usage Telemetry)
+
+An **opt-in**, **off-by-default** mode that records how the server is actually used — which tools, for what goals, with what inputs, and where they fall short. It serves two audiences:
+
+- **Contributors giving structured feedback to the maintainers.** Rather than filing prose bug reports, you can turn it on for a while and share the resulting log so maintainers can see which tools are used, which fail, and what goals have no good tool yet — a direct signal for improving existing tools and identifying new ones.
+- **Organizations running the server for their own users.** Teams that deploy the MCP server internally can enable it to understand what their users do with it and why, entirely within their own infrastructure.
+
+It is implemented as a FastMCP middleware wrapper (`telemetry.py` + `usage_logger.py`) and requires **no changes to any tool**.
+
+> 🔒 **Nothing is ever sent anywhere automatically.** Collection mode only appends to a local log file on the machine running the server. It is disabled unless you explicitly enable it, and even when enabled the data stays on your disk — sharing it with anyone (including the maintainers) is a deliberate, manual step you take by sending the file yourself. There is no phone-home, no network transmission, and no third party involved.
+
+When enabled it does two things:
+
+1. **Injects a required `goal` parameter** into every tool's schema, asking the model to state in one sentence *why* it chose that tool for the current
+   request. The `goal` is stripped from the arguments before the real tool runs, so tools never see it.
+2. **Appends one JSON line per tool call** (JSON Lines / NDJSON) to a local log file: timestamp, session id, tool name, goal, arguments, result, status,
+   error, and latency. Secret-shaped keys and inline Bearer/JWT tokens are redacted and every field is size-capped.
+
+### Enabling it
+
+Set the toggle in `.env` (all options are documented in `.env.sample`):
+
+```sh
+COLLECTION_MODE=true
+# optional overrides (defaults shown):
+# COLLECTION_LOG_PATH=~/.sas-mcp-server/tool-usage.log
+# COLLECTION_LOG_RESULTS=false   # false = record result shape only, not contents
+```
+
+By default (`COLLECTION_LOG_RESULTS=false`) tool **results** are recorded only as a content-free shape summary (e.g. `{"_type":"array","_items":500}`) — arguments, goal, status, and error text are still captured. Set it to `true` to capture (capped + redacted) result contents for richer analysis.
+
+> ⚠️ **Privacy:** when enabled, the log captures your tool inputs (e.g. the SAS code and queries you submit) and — if `COLLECTION_LOG_RESULTS=true` — real result data that may include table rows, SAS listings, and PII. Redaction is heuristic (credential-shaped keys + Bearer/JWT only) and does **not** detect PII in data values. **Review the log before sharing it.** The file is locked to your user (chmod 0600 on POSIX; icacls on Windows, best-effort).
+
+### Performance impact
+
+Collection mode is designed to be cheap enough to leave on. Measured on this repo (45 registered tools, FastMCP 3.4.2):
+
+- **Prompt tokens.** The injected `goal` field grows the `tools/list` schema the model sees by roughly **+2,400 input tokens (~29%) per turn**. Because the tool list is stable within a session it is served from the prompt cache after the first turn (steady-state ≈ +240 tokens/turn), plus ~15–30 output tokens per call for the model to write the `goal` sentence. This is the only client-visible cost and it applies only while collection mode is enabled. 
+- **Per-call latency.** Middleware + logging adds **≈1.4 ms per call** at the shape-only default (**≈5.3 ms** with `COLLECTION_LOG_RESULTS=true`). The JSONL
+  write is offloaded to a worker thread so it never blocks the event loop. Against real Viya calls (typically hundreds of milliseconds to seconds) this is
+  negligible — the live integration suite passed identically with collection mode off and on, the overhead lost in normal network variance.
+- **Disk.** Roughly **0.5–0.7 KB per tool call** at the shape-only default. The log rotates at `COLLECTION_MAX_LOG_BYTES` (default 10 MiB, ≈16k calls) and keeps `COLLECTION_LOG_BACKUPS` (default 3) rotated files, so on-disk growth is bounded.
+
 ## Testing
 
 The project includes two layers of tests: **unit tests** (fast, no credentials required) and **integration tests** (run against a real SAS Viya instance).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = [{name = "SAS Institute Inc."}]
 requires-python = ">=3.12"
 dependencies = [
+    "anyio>=4.0.0",
     "fastmcp>=3.0.0,<4.0.0",
     "httpx>=0.28.1",
     "pydantic>=2.12.4",

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -18,6 +18,39 @@ load_dotenv()
 SSL_VERIFY = env_bool("SSL_VERIFY", True)
 ALLOW_RAW_BEARER = env_bool("ALLOW_RAW_BEARER", False)
 
+# --- Opt-in collection mode (telemetry) -------------------------------------
+# Master switch. Default OFF; must be explicitly true/1/yes/on. When false,
+# install_telemetry() returns immediately: no middleware, no schema change,
+# zero overhead.
+COLLECTION_MODE = env_bool("COLLECTION_MODE", False)
+# DOTTED default matches the existing credentials dir ~/.sas-mcp-server/ (see
+# .env.sample note re: the user-stated dot-less path) and sits outside the tree
+# mcp.http_app() serves. Expanded with os.path.expanduser at install time.
+COLLECTION_LOG_PATH = os.getenv(
+    "COLLECTION_LOG_PATH", "~/.sas-mcp-server/tool-usage.log"
+)
+# Per-field cap (bytes) for arguments/goal/error. Raised from 4 KiB so the
+# submitted SAS code / queries — the core signal — are actually captured.
+COLLECTION_MAX_FIELD_BYTES = int(os.getenv("COLLECTION_MAX_FIELD_BYTES", "16384"))
+# Separate (smaller) cap for tool RESULTS. Results tend to be large and less
+# central to the analysis than the arguments, so they get a tighter bound.
+COLLECTION_MAX_RESULT_BYTES = int(os.getenv("COLLECTION_MAX_RESULT_BYTES", "8192"))
+# RotatingFileHandler rollover size (bytes); default 10 MiB.
+COLLECTION_MAX_LOG_BYTES = int(
+    os.getenv("COLLECTION_MAX_LOG_BYTES", str(10 * 1024 * 1024))
+)
+# RotatingFileHandler backupCount; rotated files glob as tool-usage.log*.
+COLLECTION_LOG_BACKUPS = int(os.getenv("COLLECTION_LOG_BACKUPS", "3"))
+# Whether 'goal' is appended to each schema's required[]. Escape hatch = false.
+COLLECTION_REQUIRE_GOAL = env_bool("COLLECTION_REQUIRE_GOAL", True)
+# Privacy dial for tool RESULTS. Default FALSE: results are recorded as a
+# content-free shape summary ({"_type":"array","_items":N} / ...), NOT their
+# contents, so data-sensitive shops contribute usage signal (which tools,
+# goals, inputs, success/failure, error text) WITHOUT exfiltrating table rows
+# or SAS listings. Set true to capture (capped + redacted) result contents.
+# Arguments and goal are captured either way.
+COLLECTION_LOG_RESULTS = env_bool("COLLECTION_LOG_RESULTS", False)
+
 _logger = logging.getLogger(__name__)
 
 

--- a/src/sas_mcp_server/mcp_server.py
+++ b/src/sas_mcp_server/mcp_server.py
@@ -20,6 +20,7 @@ from starlette.responses import JSONResponse
 from .config import VIYA_ENDPOINT, viya_auth
 from .exceptions import AuthenticationError
 from .prompts import register_prompts
+from .telemetry import install_telemetry
 from .tools import register_tools
 from .viya_client import logger
 from .viya_utils import shutdown_session_cache
@@ -66,6 +67,10 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict]:
 # Initialize the FastMCP server
 logger.info("Connecting to SAS Viya at %s", VIYA_ENDPOINT)
 mcp = FastMCP("SAS Viya Execution MCP Server", auth=viya_auth, lifespan=_lifespan)
+# Opt-in telemetry (no-op unless COLLECTION_MODE is enabled). Added FIRST so it
+# is the OUTERMOST middleware — it wraps AuthMiddleware and the tool, so an auth
+# failure is recorded as status="error" and re-raised unchanged.
+install_telemetry(mcp, "http")
 mcp.add_middleware(AuthMiddleware())
 
 

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -49,6 +49,7 @@ from fastmcp import Context, FastMCP
 from .config import CLIENT_ID, SSL_VERIFY, VIYA_ENDPOINT
 from .exceptions import AuthenticationError
 from .prompts import register_prompts
+from .telemetry import install_telemetry
 from .tools import register_tools
 from .viya_client import logger
 from .viya_utils import shutdown_session_cache
@@ -313,6 +314,8 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict]:
 logger.info("Connecting to SAS Viya at %s", VIYA_ENDPOINT)
 mcp = FastMCP("SAS Viya Execution MCP Server", lifespan=_lifespan)
 register_tools(mcp, _stdio_get_token)
+# Opt-in telemetry (no-op unless COLLECTION_MODE is enabled).
+install_telemetry(mcp, "stdio")
 register_prompts(mcp)
 
 

--- a/src/sas_mcp_server/telemetry.py
+++ b/src/sas_mcp_server/telemetry.py
@@ -1,0 +1,303 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in collection-mode telemetry middleware for the SAS MCP server.
+
+Injects a required ``goal`` parameter into every published tool schema and logs
+each tool call's input/output/session-id/goal/status/latency to a JSONL file.
+Default OFF; requires ZERO changes to existing tools; works identically in HTTP
+and stdio (it relies solely on ``context.message`` + a guarded
+``context.fastmcp_context.session_id`` and NEVER calls get_http_request).
+
+The disk write is offloaded to a worker thread via ``anyio.to_thread`` so the
+blocking file I/O and any RotatingFileHandler rollover never run on the asyncio
+event loop; the handler's own lock keeps each append atomic across threads.
+
+REJECTED ALTERNATIVES (do not "simplify" into these):
+  * ToolTransform / ArgTransform CANNOT add a brand-new ``goal`` arg
+    (ArgTransform only forwards EXISTING parent properties), would force
+    re-registering all ~45 tools, inherits ``additionalProperties: false`` +
+    the parent output_schema, and runs INNERMOST so it could not observe auth
+    failures. Middleware is the right layer.
+  * A Context wrapper is impossible: Context is built internally per request.
+  * A QueueHandler/QueueListener would move I/O off-loop too, but needs
+    lifespan shutdown wiring in both entry points to avoid a lost final flush;
+    anyio.to_thread keeps per-call flush semantics with no extra wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import anyio.to_thread
+import mcp.types
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+# Tool/ToolResult live in fastmcp.tools.base — the path FastMCP's own middleware
+# imports. A sys.modules shim in fastmcp.tools defeats Pyright's static resolver
+# for this submodule, so the import is runtime-correct but flagged; ignore it.
+from fastmcp.tools.base import Tool, ToolResult  # pyright: ignore[reportMissingImports]
+
+from .usage_logger import GOAL_KEY, UsageLogger, bounded_redact
+
+module_logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+GOAL_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "description": (
+        "Before the other arguments, state in ONE sentence WHY you are calling "
+        "THIS specific tool for the user's current request — the "
+        "underlying goal it serves."
+    ),
+}
+
+
+class TelemetryMiddleware(Middleware):
+    """Injects ``goal`` into every listed tool schema and logs each call."""
+
+    def __init__(
+        self,
+        logger: UsageLogger,
+        *,
+        require_goal: bool,
+        transport: str,
+        log_results: bool = True,
+    ) -> None:
+        self.logger = logger
+        self.require_goal = require_goal
+        self.transport = transport
+        self.log_results = log_results
+        # Per-process fallback session id (used only if the transport session
+        # id is unavailable).
+        self._proc_session = str(uuid4())
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mcp.types.ListToolsRequest],
+        call_next: CallNext[mcp.types.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        out: list[Tool] = []
+        for t in tools:
+            try:
+                params = dict(t.parameters or {})
+                props = dict(params.get("properties", {}))
+                if GOAL_KEY not in props:  # idempotent across repeated lists
+                    props = {GOAL_KEY: GOAL_SCHEMA, **props}  # goal FIRST
+                    params["properties"] = props
+                    if self.require_goal:
+                        req = [
+                            r for r in params.get("required", []) if r != GOAL_KEY
+                        ]
+                        params["required"] = [GOAL_KEY, *req]
+                    # NEW Tool; never mutate the shared registry singleton.
+                    out.append(t.model_copy(update={"parameters": params}))
+                else:
+                    out.append(t)
+            except Exception:  # noqa: BLE001 - per-tool isolation
+                out.append(t)
+        return out
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next: CallNext[mcp.types.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        raw = dict(context.message.arguments or {})
+        # LOAD-BEARING: a real tool's TypeAdapter raises
+        # unexpected_keyword_argument if 'goal' leaks through, so strip it
+        # from a COPY of the arguments before forwarding.
+        goal = raw.pop(GOAL_KEY, None)
+        cleaned_ctx = context.copy(
+            message=context.message.model_copy(update={"arguments": raw})
+        )
+        session_id = self._resolve_session(context)
+        status, is_error, error, result_obj = "success", False, None, None
+        t0 = time.perf_counter()
+        try:
+            result = await call_next(cleaned_ctx)
+            is_error = bool(getattr(result, "is_error", False))
+            if is_error:
+                status = "error"
+                error = self._extract_error_text(result)
+            result_obj = self._extract_output(result)
+            return result
+        except Exception as exc:  # noqa: BLE001 - record then re-raise UNCHANGED
+            status, is_error = "error", True
+            error = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            try:
+                dur_ms = (time.perf_counter() - t0) * 1000.0
+                record = self._build_record(
+                    context.message.name,
+                    goal,
+                    raw,
+                    result_obj,
+                    status,
+                    is_error,
+                    error,
+                    session_id,
+                    dur_ms,
+                )
+                # Offload the blocking write (and any rollover) off the event
+                # loop; the handler's own lock keeps each append atomic across
+                # worker threads.
+                await anyio.to_thread.run_sync(self.logger.write, record)
+            except Exception:  # noqa: BLE001 - logging must never break the call
+                pass
+
+    # -- helpers ---------------------------------------------------------- #
+
+    def _resolve_session(self, context: MiddlewareContext[Any]) -> str:
+        fc = getattr(context, "fastmcp_context", None)
+        if fc is not None:
+            try:
+                return fc.session_id
+            except RuntimeError:
+                pass
+            except Exception:  # noqa: BLE001 - never let session read break us
+                pass
+        return self._proc_session
+
+    def _extract_output(self, result: Any) -> Any:
+        # Cap joined text to a bounded prefix so a huge result is not fully
+        # materialized here before bounded_redact enforces the exact cap.
+        cap = getattr(self.logger, "max_result_bytes", 8192)
+        try:
+            sc = getattr(result, "structured_content", None)
+            if sc is not None:
+                return sc
+            content = getattr(result, "content", None)
+            if content:
+                texts: list[str] = []
+                total = 0
+                for block in content:
+                    text = getattr(block, "text", None)
+                    if text is None:
+                        continue
+                    texts.append(text)
+                    total += len(text)
+                    if total > cap * 2:  # generous prefix; capped exactly later
+                        break
+                if texts:
+                    return "\n".join(texts)
+            return None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _extract_error_text(self, result: Any) -> str | None:
+        try:
+            out = self._extract_output(result)
+            if isinstance(out, str):
+                return out
+            if out is not None:
+                return json.dumps(out, default=str, ensure_ascii=False)
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+
+    @staticmethod
+    def _result_shape(result_obj: Any) -> Any:
+        """Content-free description of a result (used when log_results=False)."""
+        if result_obj is None:
+            return None
+        try:
+            if isinstance(result_obj, dict):
+                return {"_type": "object", "_keys": len(result_obj)}
+            if isinstance(result_obj, (list, tuple)):
+                return {"_type": "array", "_items": len(result_obj)}
+            if isinstance(result_obj, str):
+                return {"_type": "string", "_bytes": len(result_obj.encode("utf-8"))}
+            return {"_type": type(result_obj).__name__}
+        except Exception:  # noqa: BLE001
+            return {"_type": "unknown"}
+
+    def _build_record(
+        self,
+        tool: str,
+        goal: Any,
+        arguments: dict[str, Any],
+        result_obj: Any,
+        status: str,
+        is_error: bool,
+        error: Any,
+        session_id: str,
+        dur_ms: float,
+    ) -> dict[str, Any]:
+        field_bytes = self.logger.max_field_bytes
+        result_bytes = getattr(self.logger, "max_result_bytes", field_bytes)
+
+        args_val, args_trunc = bounded_redact(arguments, field_bytes)
+        # goal is model-authored free text that can restate the user's request
+        # (incl. anything they pasted) -> redact + bound it like other fields.
+        goal_val, _ = (
+            bounded_redact(goal, field_bytes) if goal is not None else (None, False)
+        )
+        if self.log_results:
+            res_val, res_trunc = bounded_redact(result_obj, result_bytes)
+        else:
+            res_val, res_trunc = self._result_shape(result_obj), False
+        err_val, _ = (
+            bounded_redact(error, field_bytes) if error is not None else (None, False)
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "ts": datetime.now(UTC).isoformat(),
+            "session_id": session_id,
+            "tool": tool,
+            "goal": goal_val,
+            "arguments": args_val,
+            "arguments_truncated": args_trunc,
+            "result": res_val,
+            "result_truncated": res_trunc,
+            "result_logged": self.log_results,
+            "status": status,
+            "is_error": is_error,
+            "error": err_val,
+            "duration_ms": dur_ms,
+            "transport": self.transport,
+        }
+
+
+def install_telemetry(mcp: Any, transport: str) -> TelemetryMiddleware | None:
+    """Add the telemetry middleware to ``mcp`` iff collection mode is enabled.
+
+    config is imported LAZILY (config.py raises ConfigError when VIYA_ENDPOINT
+    is unset, which would otherwise make this module unimportable in tests)."""
+    from . import config
+
+    if not config.COLLECTION_MODE:
+        return None
+    try:
+        logger = UsageLogger(
+            path=os.path.expanduser(config.COLLECTION_LOG_PATH),
+            max_log_bytes=config.COLLECTION_MAX_LOG_BYTES,
+            backup_count=config.COLLECTION_LOG_BACKUPS,
+            max_field_bytes=config.COLLECTION_MAX_FIELD_BYTES,
+            max_result_bytes=config.COLLECTION_MAX_RESULT_BYTES,
+        )
+    except OSError as exc:
+        module_logger.warning(
+            "Collection mode requested but log path unusable (%s); "
+            "telemetry disabled",
+            exc,
+        )
+        return None  # server runs exactly as before
+    mw = TelemetryMiddleware(
+        logger,
+        require_goal=config.COLLECTION_REQUIRE_GOAL,
+        transport=transport,
+        log_results=config.COLLECTION_LOG_RESULTS,
+    )
+    mcp.add_middleware(mw)
+    return mw

--- a/src/sas_mcp_server/usage_logger.py
+++ b/src/sas_mcp_server/usage_logger.py
@@ -1,0 +1,304 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Redaction, bounded serialization, path resolution, and a synchronous JSONL
+writer for opt-in collection-mode telemetry. Deliberately free of any fastmcp
+imports so its logic can be exercised in a bare unit environment.
+
+``bounded_redact`` is the load-bearing addition: it redacts AND caps size/work
+in a single pass, so an arbitrarily large tool result (e.g. a 25 MiB base64
+export or a million-row table) is never fully materialized, deep-scanned, or
+double-serialized on the event loop, and object type is preserved on
+truncation (keeping JSONL columns object-typed for DuckDB/pandas)."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any
+
+module_logger = logging.getLogger(__name__)
+
+GOAL_KEY = "goal"
+
+REDACT_KEY_RE = re.compile(
+    r"(?i)(token|password|passwd|pwd|secret|authorization|bearer|credential"
+    r"|api[_-]?key|refresh[_-]?token|access[_-]?token)"
+)
+
+_BEARER_RE = re.compile(r"Bearer\s+\S+")
+_JWT_RE = re.compile(r"eyJ[A-Za-z0-9._-]{20,}")  # JWT-like
+
+_REDACTED = "[REDACTED]"
+_TRUNC_MARK = "…<truncated>"
+
+
+def _scrub_str(s: str) -> str:
+    return _JWT_RE.sub(_REDACTED, _BEARER_RE.sub(_REDACTED, s))
+
+
+def redact(obj: Any) -> Any:
+    """Recursively mask secret-looking dict keys and inline-scrub JWT/Bearer
+    strings. Leaves other scalars alone. Never raises.
+
+    UNBOUNDED convenience/back-compat helper (unit-tested directly). The hot
+    path uses ``bounded_redact`` instead, which also caps work and size.
+    """
+    try:
+        if isinstance(obj, dict):
+            out: dict[Any, Any] = {}
+            for k, v in obj.items():
+                if isinstance(k, str) and REDACT_KEY_RE.search(k):
+                    out[k] = _REDACTED
+                else:
+                    out[k] = redact(v)
+            return out
+        if isinstance(obj, (list, tuple)):
+            return [redact(v) for v in obj]
+        if isinstance(obj, str):
+            return _scrub_str(obj)
+        return obj
+    except Exception:  # noqa: BLE001 - redaction must never break logging
+        return _REDACTED
+
+
+def truncate(value: Any, max_bytes: int) -> tuple[Any, bool]:
+    """Cap a field's serialized form at ``max_bytes`` utf-8 bytes.
+
+    Returns (value_or_clipped_string, truncated_flag). Kept for back-compat and
+    direct unit tests; ``bounded_redact`` is the size-and-work bounded
+    replacement used on the hot path.
+    """
+    try:
+        if value is None:
+            return None, False
+        if isinstance(value, (dict, list)):
+            encoded = json.dumps(value, default=str, ensure_ascii=False)
+        elif isinstance(value, str):
+            encoded = value
+        else:
+            encoded = str(value)
+        raw = encoded.encode("utf-8")
+        if len(raw) <= max_bytes:
+            return value, False
+        clipped = raw[:max_bytes].decode("utf-8", errors="ignore")
+        return f"{clipped}…<truncated {len(raw)} bytes>", True
+    except Exception:  # noqa: BLE001
+        return _REDACTED, True
+
+
+class _Budget:
+    """Mutable byte budget shared across a single bounded_redact traversal."""
+
+    __slots__ = ("remaining", "exceeded")
+
+    def __init__(self, total: int) -> None:
+        self.remaining = max(0, int(total))
+        self.exceeded = False
+
+    def take(self, n: int) -> None:
+        self.remaining -= n
+        if self.remaining < 0:
+            self.exceeded = True
+
+
+def _br(obj: Any, b: _Budget) -> Any:
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        # Clip cheaply (by chars; len() is O(1)) BEFORE the scrub regex runs,
+        # so a 25 MiB blob is never scanned — only a bounded prefix is.
+        n = len(obj)
+        if n > b.remaining:
+            clip = obj[: b.remaining] if b.remaining > 0 else ""
+            b.take(n)  # marks exceeded
+            return (_scrub_str(clip) + _TRUNC_MARK) if clip else _TRUNC_MARK
+        b.take(n)
+        return _scrub_str(obj)
+    if isinstance(obj, bool):  # bool before int
+        b.take(5)
+        return obj
+    if isinstance(obj, (int, float)):
+        b.take(8)
+        return obj
+    if isinstance(obj, dict):
+        out: dict[Any, Any] = {}
+        for k, v in obj.items():
+            if b.remaining <= 0:
+                b.exceeded = True
+                out["_truncated"] = True
+                break
+            ks = k if isinstance(k, str) else str(k)
+            b.take(len(ks) + 3)
+            if isinstance(k, str) and REDACT_KEY_RE.search(k):
+                out[k] = _REDACTED
+            else:
+                out[k] = _br(v, b)
+        return out
+    if isinstance(obj, (list, tuple)):
+        out_l: list[Any] = []
+        for v in obj:
+            if b.remaining <= 0:
+                b.exceeded = True
+                out_l.append(_TRUNC_MARK)
+                break
+            b.take(1)
+            out_l.append(_br(v, b))
+        return out_l
+    # Other scalars: stringify (bounded) and scrub.
+    return _br(str(obj), b)
+
+
+def bounded_redact(obj: Any, max_bytes: int) -> tuple[Any, bool]:
+    """Redact AND bound size/work in a single pass. Returns (value, truncated).
+
+    * Strings are clipped to the remaining budget BEFORE the JWT/Bearer scrub
+      regex runs, so an arbitrarily large field (e.g. a 25 MiB base64 export)
+      is never fully materialized or CPU-scanned on the event loop.
+    * dict/list recursion carries a shared byte budget and stops as soon as it
+      is exhausted (a million-row result is bounded to a prefix).
+    * Object type is PRESERVED — a truncated container returns a dict/list
+      (marked with ``_truncated``), never a bare string — so JSONL columns stay
+      object-typed for DuckDB/pandas analysis.
+    """
+    try:
+        b = _Budget(max_bytes)
+        value = _br(obj, b)
+        return value, b.exceeded
+    except Exception:  # noqa: BLE001 - redaction must never break logging
+        return _REDACTED, True
+
+
+def _win_harden(path: Path) -> None:
+    """Best-effort Windows ACL lock-down (POSIX chmod is a no-op on win32).
+
+    Removes inherited ACEs and grants only the current user Full control, so a
+    log that may contain SAS code, table rows, and PII is not group/world
+    readable on shared or roaming-profile hosts. Silently best-effort.
+
+    Only ever call this on a path we own the lifecycle of — the log FILE itself,
+    or a directory this process just created. Never call it on a pre-existing,
+    potentially shared directory: ``/inheritance:r`` strips inheritance so that
+    NEW sibling subdirectories inherit an empty DACL and become unusable.
+    """
+    if sys.platform != "win32":
+        return
+    user = os.environ.get("USERNAME")
+    if not user:
+        return
+    with contextlib.suppress(Exception):
+        subprocess.run(
+            ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:F"],
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+
+
+def resolve_log_path(raw: str) -> Path:
+    """Expand ~, create the parent dir, and tighten perms ONLY on a directory
+    this call creates itself.
+
+    We must never re-permission a directory that already exists. If a user points
+    ``COLLECTION_LOG_PATH`` at a shared or standard location (e.g. ``~`` or the
+    system temp dir), chmod-ing it to 0700 (POSIX) or stripping its ACL
+    inheritance (Windows, via ``_win_harden``) would damage a directory shared
+    with other software. On Windows this is especially harmful: once inheritance
+    is stripped, sibling subdirectories created afterwards inherit an empty DACL
+    and become unusable. So we lock down the leaf parent only when we just created
+    it; a pre-existing parent is left untouched. The log file itself is always
+    hardened separately (see ``UsageLogger.__init__``).
+
+    NOTE: os.chmod(0o700/0o600) is effectively a NO-OP on Windows; icacls is
+    applied there instead. See .env.sample for the shared-host caveat.
+    """
+    path = Path(os.path.expanduser(raw))
+    parent = path.parent
+    created_parent = not parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if created_parent:
+        # We own this directory's lifecycle, so it is safe to lock it to the
+        # current user; a directory we did not create is left as-is.
+        with contextlib.suppress(OSError):
+            os.chmod(parent, 0o700)
+        _win_harden(parent)
+    return path
+
+
+class UsageLogger:
+    """Synchronous JSONL writer backed by a RotatingFileHandler.
+
+    The stdlib handler acquires an internal lock per emit, so concurrent tool
+    calls — including from multiple worker threads (the middleware offloads
+    write() via anyio.to_thread) — cannot interleave partial lines: one record
+    == one atomic newline-terminated append. utf-8, NO BOM (avoids the Windows
+    / PowerShell UTF-16+BOM trap). ``write`` never raises.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        max_log_bytes: int,
+        backup_count: int,
+        max_field_bytes: int,
+        max_result_bytes: int | None = None,
+    ) -> None:
+        self.path = resolve_log_path(path)
+        self.max_field_bytes = max_field_bytes
+        self.max_result_bytes = (
+            max_result_bytes if max_result_bytes is not None else max_field_bytes
+        )
+        self._logger = logging.getLogger(
+            f"sas_mcp_server.usage_logger.instance.{id(self)}"
+        )
+        self._logger.setLevel(logging.INFO)
+        self._logger.propagate = False
+        handler = RotatingFileHandler(
+            filename=str(self.path),
+            maxBytes=max_log_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
+        handler.terminator = "\n"
+        handler.setFormatter(logging.Formatter("%(message)s"))  # raw line only
+        with contextlib.suppress(OSError):
+            os.chmod(self.path, 0o600)  # no-op on Windows; icacls covers win32
+        # Lock the log file to the current user on Windows too. Hardening the
+        # file (not just the dir) keeps the privacy guarantee even when the
+        # parent dir pre-existed and was therefore intentionally left untouched
+        # by resolve_log_path. Safe: it only affects this one file.
+        _win_harden(self.path)
+        self._logger.handlers = [handler]
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        path: str,
+        max_log_bytes: int,
+        backup_count: int,
+        max_field_bytes: int,
+        max_result_bytes: int | None = None,
+    ) -> UsageLogger:
+        return cls(
+            path,
+            max_log_bytes=max_log_bytes,
+            backup_count=backup_count,
+            max_field_bytes=max_field_bytes,
+            max_result_bytes=max_result_bytes,
+        )
+
+    def write(self, record: dict[str, Any]) -> None:
+        try:
+            line = json.dumps(record, default=str, ensure_ascii=False)
+            self._logger.info(line)
+        except Exception as exc:  # noqa: BLE001 - logging must NEVER propagate
+            module_logger.debug("usage log write failed: %s", exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,12 @@ def integration_mcp_server(viya_token):
         return _token
 
     from sas_mcp_server.prompts import register_prompts
+    from sas_mcp_server.telemetry import install_telemetry
     from sas_mcp_server.tools import register_tools
+    # Mirror the production HTTP server so integration runs exercise telemetry
+    # when COLLECTION_MODE is enabled. No-op (adds no middleware) when off, so
+    # the default suite is byte-identical.
+    install_telemetry(mcp, "http")
     register_tools(mcp, real_get_token)
     register_prompts(mcp)
     return mcp

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,386 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.tools.base import ToolResult
+
+from sas_mcp_server.telemetry import (
+    GOAL_SCHEMA,
+    TelemetryMiddleware,
+    install_telemetry,
+)
+
+
+class FakeLogger:
+    """Captures records instead of writing to disk."""
+
+    max_field_bytes = 4096
+    max_result_bytes = 4096
+
+    def __init__(self):
+        self.records = []
+
+    def write(self, record):
+        self.records.append(record)
+
+
+def _build_server(box):
+    mcp = FastMCP("test")
+
+    @mcp.tool()
+    def echo(text: str, count: int = 1) -> dict:
+        box["received"] = {"text": text, "count": count}
+        return {"echoed": text * count, "count": count}
+
+    return mcp
+
+
+# ----------------------------- OFF by default ------------------------------ #
+
+
+def test_install_off_by_default(monkeypatch, tmp_path):
+    import sas_mcp_server.config as config
+
+    monkeypatch.setattr(config, "COLLECTION_MODE", False, raising=False)
+    mcp = FastMCP("test")
+    before = list(mcp.middleware)
+    assert install_telemetry(mcp, "stdio") is None
+    # A fresh FastMCP already carries its own default middleware, so assert the
+    # list is UNCHANGED (no telemetry added) rather than empty.
+    assert mcp.middleware == before
+    assert not any(isinstance(m, TelemetryMiddleware) for m in mcp.middleware)
+
+
+# ----------------------------- schema injection ---------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_on_list_tools_injects_goal_first_and_required():
+    box = {}
+    mcp = _build_server(box)
+    mcp.add_middleware(
+        TelemetryMiddleware(FakeLogger(), require_goal=True, transport="stdio")
+    )
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        schema = tools[0].inputSchema
+        props = schema["properties"]
+        assert list(props.keys())[0] == "goal"
+        assert props["goal"] == GOAL_SCHEMA
+        assert "goal" in schema["required"]
+        assert "text" in props and "count" in props
+        assert len(tools) == 1  # count unchanged -> coverage guard stays green
+
+
+@pytest.mark.asyncio
+async def test_on_list_tools_require_goal_false_omits_required():
+    box = {}
+    mcp = _build_server(box)
+    mcp.add_middleware(
+        TelemetryMiddleware(FakeLogger(), require_goal=False, transport="stdio")
+    )
+    async with Client(mcp) as client:
+        schema = (await client.list_tools())[0].inputSchema
+        assert "goal" in schema["properties"]
+        assert "goal" not in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_on_list_tools_idempotent():
+    mw = TelemetryMiddleware(FakeLogger(), require_goal=True, transport="stdio")
+
+    tool = SimpleNamespace(
+        name="x",
+        parameters={"type": "object", "properties": {"a": {"type": "string"}}},
+    )
+
+    def _copy(update):
+        return SimpleNamespace(name="x", parameters=update["parameters"])
+
+    tool.model_copy = _copy  # type: ignore[attr-defined]
+
+    async def call_next(_):
+        return [tool]
+
+    out1 = await mw.on_list_tools(MagicMock(), call_next)
+    assert list(out1[0].parameters["properties"].keys()) == ["goal", "a"]
+
+    async def call_next2(_):
+        return out1  # already injected
+
+    out2 = await mw.on_list_tools(MagicMock(), call_next2)
+    assert list(out2[0].parameters["properties"].keys()).count("goal") == 1
+
+
+# ----------------------------- call + strip + log -------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_strips_goal_and_logs():
+    box = {}
+    logger = FakeLogger()
+    mcp = _build_server(box)
+    mcp.add_middleware(
+        TelemetryMiddleware(logger, require_goal=True, transport="stdio")
+    )
+    async with Client(mcp) as client:
+        res = await client.call_tool(
+            "echo", {"goal": "user asked to echo", "text": "ab", "count": 2}
+        )
+    # underlying tool ran WITHOUT goal
+    assert box["received"] == {"text": "ab", "count": 2}
+    assert res.structured_content == {"echoed": "abab", "count": 2}
+    # a well-formed record was written
+    rec = logger.records[-1]
+    assert rec["tool"] == "echo"
+    assert rec["goal"] == "user asked to echo"
+    assert "goal" not in rec["arguments"]
+    assert rec["arguments"]["text"] == "ab"
+    assert rec["result"] is not None
+    assert rec["result_logged"] is True
+    assert rec["session_id"]
+    assert rec["ts"]
+    assert rec["status"] == "success"
+    assert isinstance(rec["duration_ms"], float)
+    assert rec["transport"] == "stdio"
+    assert "arguments_truncated" in rec and "result_truncated" in rec
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_records_redacted_and_truncated():
+    logger = FakeLogger()
+    logger.max_field_bytes = 50
+    logger.max_result_bytes = 50
+    mw = TelemetryMiddleware(logger, require_goal=True, transport="http")
+
+    msg = SimpleNamespace(
+        name="echo",
+        arguments={"goal": "g", "password": "hunter2", "blob": "x" * 500},
+    )
+    msg.model_copy = lambda update: SimpleNamespace(
+        name="echo", arguments=update["arguments"]
+    )
+    ctx = SimpleNamespace(message=msg, fastmcp_context=None)
+    ctx.copy = lambda **kw: SimpleNamespace(
+        message=kw["message"], fastmcp_context=None
+    )
+
+    async def call_next(_):
+        return ToolResult(structured_content={"ok": True})
+
+    await mw.on_call_tool(ctx, call_next)
+    rec = logger.records[-1]
+    # object type preserved even when truncated
+    assert isinstance(rec["arguments"], dict)
+    assert rec["arguments"]["password"] == "[REDACTED]"
+    assert rec["arguments_truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_goal_is_redacted_and_bounded():
+    logger = FakeLogger()
+    mw = TelemetryMiddleware(logger, require_goal=True, transport="stdio")
+    jwt = "eyJ" + "a" * 40
+
+    msg = SimpleNamespace(
+        name="echo", arguments={"goal": f"rerun with Bearer {jwt}", "text": "q"}
+    )
+    msg.model_copy = lambda update: SimpleNamespace(
+        name="echo", arguments=update["arguments"]
+    )
+    ctx = SimpleNamespace(message=msg, fastmcp_context=None)
+    ctx.copy = lambda **kw: SimpleNamespace(
+        message=kw["message"], fastmcp_context=None
+    )
+
+    async def call_next(_):
+        return ToolResult(structured_content={"ok": True})
+
+    await mw.on_call_tool(ctx, call_next)
+    rec = logger.records[-1]
+    assert "[REDACTED]" in rec["goal"] and jwt not in rec["goal"]
+
+
+@pytest.mark.asyncio
+async def test_log_results_false_records_shape_only():
+    logger = FakeLogger()
+    mw = TelemetryMiddleware(
+        logger, require_goal=True, transport="stdio", log_results=False
+    )
+
+    msg = SimpleNamespace(name="q", arguments={"goal": "g", "table": "t"})
+    msg.model_copy = lambda update: SimpleNamespace(
+        name="q", arguments=update["arguments"]
+    )
+    ctx = SimpleNamespace(message=msg, fastmcp_context=None)
+    ctx.copy = lambda **kw: SimpleNamespace(
+        message=kw["message"], fastmcp_context=None
+    )
+
+    async def call_next(_):
+        # structured_content must be a dict for a real ToolResult; wrap the
+        # PII-bearing rows so we can assert the shape summary omits them.
+        return ToolResult(
+            structured_content={"rows": [{"ssn": "123-45-6789", "email": "a@b.com"}]}
+        )
+
+    await mw.on_call_tool(ctx, call_next)
+    rec = logger.records[-1]
+    assert rec["result_logged"] is False
+    assert "123-45-6789" not in json.dumps(rec["result"])
+    assert rec["result"]["_type"] == "object"
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_error_records_and_reraises():
+    logger = FakeLogger()
+    mw = TelemetryMiddleware(logger, require_goal=True, transport="stdio")
+
+    msg = SimpleNamespace(name="boom", arguments={"goal": "g"})
+    msg.model_copy = lambda update: SimpleNamespace(
+        name="boom", arguments=update["arguments"]
+    )
+    ctx = SimpleNamespace(message=msg, fastmcp_context=None)
+    ctx.copy = lambda **kw: SimpleNamespace(
+        message=kw["message"], fastmcp_context=None
+    )
+
+    async def call_next(_):
+        raise ValueError("kaboom")
+
+    with pytest.raises(ValueError, match="kaboom"):
+        await mw.on_call_tool(ctx, call_next)
+
+    rec = logger.records[-1]
+    assert rec["status"] == "error"
+    assert rec["is_error"] is True
+    assert rec["error"] == "ValueError: kaboom"
+
+
+@pytest.mark.asyncio
+async def test_logger_failure_never_breaks_call():
+    class Exploding:
+        max_field_bytes = 4096
+        max_result_bytes = 4096
+
+        def write(self, record):
+            raise RuntimeError("disk full")
+
+    mw = TelemetryMiddleware(Exploding(), require_goal=True, transport="stdio")
+    msg = SimpleNamespace(name="echo", arguments={"goal": "g", "text": "q"})
+    msg.model_copy = lambda update: SimpleNamespace(
+        name="echo", arguments=update["arguments"]
+    )
+    ctx = SimpleNamespace(message=msg, fastmcp_context=None)
+    seen = {}
+
+    def _copy(**kw):
+        return SimpleNamespace(message=kw["message"], fastmcp_context=None)
+
+    ctx.copy = _copy
+
+    async def call_next(c):
+        seen["args"] = dict(c.message.arguments)
+        return ToolResult(structured_content={"ok": True})
+
+    res = await mw.on_call_tool(ctx, call_next)
+    assert res.structured_content == {"ok": True}
+    assert "goal" not in seen["args"]
+
+
+def test_session_fallback_when_no_context():
+    mw = TelemetryMiddleware(FakeLogger(), require_goal=True, transport="stdio")
+    ctx = SimpleNamespace(fastmcp_context=None)
+    assert mw._resolve_session(ctx) == mw._proc_session
+
+
+def test_session_fallback_when_session_id_raises():
+    mw = TelemetryMiddleware(FakeLogger(), require_goal=True, transport="stdio")
+
+    class RaisingFC:
+        @property
+        def session_id(self):
+            raise RuntimeError("no session")
+
+    ctx = SimpleNamespace(fastmcp_context=RaisingFC())
+    assert mw._resolve_session(ctx) == mw._proc_session
+
+
+def test_extract_output_prefers_structured_then_content():
+    mw = TelemetryMiddleware(FakeLogger(), require_goal=True, transport="stdio")
+    # structured_content wins
+    r1 = SimpleNamespace(structured_content={"a": 1}, content=None)
+    assert mw._extract_output(r1) == {"a": 1}
+    # falls back to joined text of content blocks
+    blocks = [SimpleNamespace(text="line1"), SimpleNamespace(text="line2")]
+    r2 = SimpleNamespace(structured_content=None, content=blocks)
+    assert mw._extract_output(r2) == "line1\nline2"
+    # nothing extractable -> None
+    r3 = SimpleNamespace(structured_content=None, content=None)
+    assert mw._extract_output(r3) is None
+
+
+# --------------------- end-to-end install + on-disk write ------------------- #
+
+
+@pytest.mark.asyncio
+async def test_install_enabled_end_to_end_writes_jsonl(monkeypatch, tmp_path):
+    """install_telemetry() with COLLECTION_MODE on wires a real logger and a
+    call produces one JSONL record on disk (exercises the actual entry point)."""
+    import sas_mcp_server.config as config
+
+    log_path = tmp_path / "sub" / "tool-usage.log"
+    monkeypatch.setattr(config, "COLLECTION_MODE", True, raising=False)
+    monkeypatch.setattr(config, "COLLECTION_LOG_PATH", str(log_path), raising=False)
+    monkeypatch.setattr(config, "COLLECTION_REQUIRE_GOAL", True, raising=False)
+    monkeypatch.setattr(config, "COLLECTION_LOG_RESULTS", True, raising=False)
+
+    box = {}
+    mcp = _build_server(box)
+    mw = install_telemetry(mcp, "stdio")
+    assert mw is not None
+    assert any(isinstance(m, TelemetryMiddleware) for m in mcp.middleware)
+
+    async with Client(mcp) as client:
+        await client.call_tool("echo", {"goal": "why echo", "text": "hi", "count": 1})
+
+    # underlying tool ran without goal
+    assert box["received"] == {"text": "hi", "count": 1}
+    lines = [
+        json.loads(x)
+        for x in log_path.read_text(encoding="utf-8").splitlines()
+        if x.strip()
+    ]
+    assert len(lines) == 1
+    rec = lines[0]
+    assert rec["tool"] == "echo"
+    assert rec["goal"] == "why echo"
+    assert "goal" not in rec["arguments"]
+    assert rec["arguments"]["text"] == "hi"
+    assert rec["result_logged"] is True
+    assert rec["status"] == "success"
+    assert rec["transport"] == "stdio"
+    assert rec["session_id"]
+
+
+def test_install_disabled_log_path_unusable_returns_none(monkeypatch, tmp_path):
+    """If the log path can't be opened, install_telemetry disables telemetry
+    (returns None) rather than breaking the server."""
+    import sas_mcp_server.config as config
+
+    monkeypatch.setattr(config, "COLLECTION_MODE", True, raising=False)
+    # Point at a path whose parent is a FILE, so mkdir/open fails with OSError.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x")
+    monkeypatch.setattr(
+        config, "COLLECTION_LOG_PATH", str(blocker / "nested" / "x.log"), raising=False
+    )
+    mcp = FastMCP("test")
+    before = list(mcp.middleware)
+    assert install_telemetry(mcp, "stdio") is None
+    assert mcp.middleware == before

--- a/tests/test_usage_logger.py
+++ b/tests/test_usage_logger.py
@@ -1,0 +1,207 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from sas_mcp_server.usage_logger import (
+    UsageLogger,
+    bounded_redact,
+    redact,
+    resolve_log_path,
+    truncate,
+)
+
+
+def test_redact_masks_secret_keys():
+    r = redact(
+        {
+            "password": "hunter2",
+            "authorization": "Bearer abc",
+            "api_key": "k",
+            "refresh_token": "rt",
+            "safe": "keep-me",
+        }
+    )
+    assert r["password"] == "[REDACTED]"
+    assert r["authorization"] == "[REDACTED]"
+    assert r["api_key"] == "[REDACTED]"
+    assert r["refresh_token"] == "[REDACTED]"
+    assert r["safe"] == "keep-me"
+
+
+def test_redact_scrubs_inline_jwt_and_bearer():
+    jwt = "eyJ" + "a" * 40
+    r = redact({"note": f"header Bearer xyz and {jwt} inside"})
+    assert "[REDACTED]" in r["note"]
+    assert jwt not in r["note"]
+    assert "Bearer xyz" not in r["note"]
+
+
+def test_redact_recurses_into_nested_and_lists():
+    r = redact({"outer": {"secret": "s"}, "items": [{"token": "t"}, "plain"]})
+    assert r["outer"]["secret"] == "[REDACTED]"
+    assert r["items"][0]["token"] == "[REDACTED]"
+    assert r["items"][1] == "plain"
+
+
+def test_truncate_caps_and_flags():
+    value, truncated = truncate("x" * 5000, 100)
+    assert truncated is True
+    assert "truncated" in value
+    assert len(value.encode("utf-8")) < 5000
+
+
+def test_truncate_leaves_small_values():
+    value, truncated = truncate("short", 100)
+    assert truncated is False
+    assert value == "short"
+
+
+def test_truncate_none():
+    assert truncate(None, 100) == (None, False)
+
+
+# ---------------------------- bounded_redact ------------------------------- #
+
+
+def test_bounded_redact_masks_and_scrubs():
+    jwt = "eyJ" + "a" * 40
+    v, trunc = bounded_redact(
+        {"password": "hunter2", "note": f"use Bearer {jwt} now"}, 4096
+    )
+    assert v["password"] == "[REDACTED]"
+    assert "[REDACTED]" in v["note"] and jwt not in v["note"]
+    assert trunc is False
+
+
+def test_bounded_redact_clips_huge_string_without_full_scan():
+    big = "z" * (25 * 1024 * 1024)  # ~25 MiB (export_report shape)
+    v, trunc = bounded_redact({"safe": "keep", "blob": big}, 4096)
+    assert trunc is True
+    assert isinstance(v, dict)  # object type preserved, not a bare string
+    assert v["safe"] == "keep"  # small field ordered first is captured
+    assert isinstance(v["blob"], str) and len(v["blob"]) < 10_000
+
+
+def test_bounded_redact_bounds_million_row_list():
+    rows = [{"id": i, "email": f"u{i}@x.com"} for i in range(1_000_000)]
+    v, trunc = bounded_redact(rows, 4096)
+    assert isinstance(v, list)  # stays a list
+    assert trunc is True
+    assert len(v) < 5000  # bounded prefix only
+
+
+def test_bounded_redact_small_value_unchanged_and_object_typed():
+    v, trunc = bounded_redact({"sas_code": "data _null_;"}, 4096)
+    assert v == {"sas_code": "data _null_;"}
+    assert trunc is False
+
+
+def test_resolve_log_path_creates_parent(tmp_path):
+    target = tmp_path / "a" / "b" / "tool-usage.log"
+    resolved = resolve_log_path(str(target))
+    assert resolved.parent.exists()
+
+
+def test_resolve_log_path_hardens_only_dirs_it_creates(tmp_path, monkeypatch):
+    """We lock down a directory we create, but never a pre-existing (possibly
+    shared) parent such as ~ or the system temp dir — stripping its ACL
+    inheritance would break newly-created sibling directories on Windows."""
+    import sas_mcp_server.usage_logger as usage_logger
+
+    hardened: list = []
+    monkeypatch.setattr(usage_logger, "_win_harden", hardened.append)
+
+    # A parent that already exists must be left untouched.
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    resolve_log_path(str(existing / "tool-usage.log"))
+    assert existing not in hardened
+
+    # A parent we create ourselves is hardened.
+    fresh = tmp_path / "fresh"
+    resolve_log_path(str(fresh / "tool-usage.log"))
+    assert fresh in hardened
+
+
+def test_win_harden_noop_off_windows(tmp_path, monkeypatch):
+    """On non-Windows, _win_harden returns immediately without shelling out."""
+    import sas_mcp_server.usage_logger as usage_logger
+
+    calls: list = []
+    monkeypatch.setattr(usage_logger.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(usage_logger.sys, "platform", "linux")
+    usage_logger._win_harden(tmp_path / "tool-usage.log")
+    assert calls == []
+
+
+def test_win_harden_noop_without_username(tmp_path, monkeypatch):
+    """On Windows with no USERNAME, _win_harden bails before calling icacls."""
+    import sas_mcp_server.usage_logger as usage_logger
+
+    calls: list = []
+    monkeypatch.setattr(usage_logger.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(usage_logger.sys, "platform", "win32")
+    monkeypatch.delenv("USERNAME", raising=False)
+    usage_logger._win_harden(tmp_path / "tool-usage.log")
+    assert calls == []
+
+
+def test_from_config_builds_working_logger(tmp_path):
+    """The from_config classmethod constructs a UsageLogger that writes."""
+    log = tmp_path / "tool-usage.log"
+    lg = UsageLogger.from_config(
+        path=str(log),
+        max_log_bytes=10_000,
+        backup_count=1,
+        max_field_bytes=1024,
+    )
+    lg.write({"ok": True})
+    assert log.exists()
+    assert '"ok": true' in log.read_text(encoding="utf-8")
+
+
+def test_write_emits_one_valid_json_line_no_bom(tmp_path):
+    log = tmp_path / "tool-usage.log"
+    ul = UsageLogger(
+        str(log), max_log_bytes=10_000, backup_count=1, max_field_bytes=4096
+    )
+    ul.write({"tool": "echo", "n": 1})
+    ul.write({"tool": "echo", "n": 2})
+    data = log.read_bytes()
+    assert not data.startswith(b"\xef\xbb\xbf")  # no BOM
+    assert data.endswith(b"\n")
+    lines = [json.loads(x) for x in data.decode("utf-8").splitlines() if x.strip()]
+    assert len(lines) == 2
+    assert lines[0]["tool"] == "echo"
+
+
+def test_usage_logger_has_result_cap(tmp_path):
+    log = tmp_path / "tool-usage.log"
+    ul = UsageLogger(
+        str(log),
+        max_log_bytes=10_000,
+        backup_count=1,
+        max_field_bytes=16384,
+        max_result_bytes=8192,
+    )
+    assert ul.max_field_bytes == 16384
+    assert ul.max_result_bytes == 8192
+
+
+def test_result_cap_defaults_to_field_cap(tmp_path):
+    log = tmp_path / "tool-usage.log"
+    ul = UsageLogger(
+        str(log), max_log_bytes=10_000, backup_count=1, max_field_bytes=4096
+    )
+    assert ul.max_result_bytes == 4096
+
+
+def test_write_swallows_errors(tmp_path):
+    log = tmp_path / "tool-usage.log"
+    ul = UsageLogger(
+        str(log), max_log_bytes=10_000, backup_count=1, max_field_bytes=4096
+    )
+    # Force an internal failure; write() must not raise.
+    ul._logger = None  # type: ignore[assignment]
+    ul.write({"tool": "echo"})  # returns None, no exception

--- a/uv.lock
+++ b/uv.lock
@@ -1277,6 +1277,7 @@ name = "sas-mcp-server"
 version = "1.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -1298,6 +1299,7 @@ test-formats = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "fastmcp", specifier = ">=3.0.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.12.4" },


### PR DESCRIPTION
## Summary

Adds an **opt-in, off-by-default "collection mode"** that helps maintainers — or organizations running the server internally — learn how the SAS MCP server is actually used: which tools, for what goals, with what inputs, and where they fall short. It is a FastMCP middleware (`telemetry.py` + a fastmcp-free `usage_logger.py`) and requires **no changes to any existing tool** (tool count stays 45; the `test_every_tool_has_integration_coverage` guard is unaffected).

## What it does (when enabled)

1. **Injects a required `goal` parameter** into every tool's published schema, asking the model to state in one sentence *why* it chose that tool. The `goal` is stripped from the arguments before the real tool runs, so tools never see it.
2. **Appends one JSON Lines record per call** to a rotating local log: timestamp, session id, tool, goal, arguments, result, status, error, latency, transport.

Wired into both entry points: HTTP (`mcp_server.py`, registered **outermost** so it also records auth failures) and stdio (`stdio_server.py`). Both calls are no-ops unless `COLLECTION_MODE` is set, so default behaviour is byte-identical to today.

## Privacy / data handling

- **Off by default**, controlled by a single `.env` toggle (`COLLECTION_MODE`).
- **Nothing is ever transmitted anywhere.** The log is a local file on the machine running the server; sharing it (with the maintainers or anyone) is a deliberate, manual step the operator takes.
- Tool **results** are recorded only as a content-free shape summary (e.g. `{"_type":"array","_items":500}`) unless `COLLECTION_LOG_RESULTS=true`.
- Secret-shaped keys and inline Bearer/JWT tokens are redacted, every field is size-capped, and the log file is locked to the current user (chmod 0600 / icacls, best-effort).

## Configuration

Seven `COLLECTION_*` variables documented in `.env.sample` and the README (master toggle, log path, per-field/result/log byte caps, backup count, require-goal, log-results).

## Performance impact (measured, 45 tools)

- **Prompt tokens:** the injected `goal` field grows `tools/list` by ~**+2,400 input tokens/turn (~29%)** — stable within a session, so largely prompt-cache-amortized (steady-state ≈ +240/turn) — plus ~15–30 output tokens/call for the goal sentence.
- **Per-call latency:** ≈**1.4 ms** at the shape-only default (≈5.3 ms with results logged); the JSONL write is offloaded off the event loop via `anyio.to_thread`.
- **Live integration suite passes identically off and on** (27/27 both ways); the overhead is lost in normal Viya network variance.
- **Disk:** ~0.5–0.7 KB/call, bounded by rotation (default 10 MiB × 3 backups).

## Testing

- New unit tests: `tests/test_telemetry.py`, `tests/test_usage_logger.py`.
- Full non-integration suite: **256 passed, 93.11% coverage** (gate 90%), ruff clean.
- Live integration suite run with collection mode **off and on**: 27/27 passed both ways.

## Note on log-file hardening

`usage_logger` only tightens permissions on a log directory **it creates itself** (never a pre-existing/shared parent) and hardens the log **file** directly. This prevents pointing `COLLECTION_LOG_PATH` at a shared directory (e.g. `~` or a temp dir) from stripping that directory's ACL inheritance on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
