### PR TITLE
docs(testing): clarify test runner commands + sync test-formats by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,12 +390,9 @@ Viya instance; there is no flag that "activates" them in a `not integration` run
 
 Integration tests call every tool against a live Viya environment. They require credentials, provided via `.env` or CLI arguments.
 
-For the **full** integration run (including the Excel `upload_data` test), install the
-optional format dependency first — plain `uv sync` does **not** include it:
-
-```sh
-uv sync --group test-formats
-```
+`uv sync` installs everything the integration suite needs, including `openpyxl` (used to
+build the Excel `upload_data` fixture). It lives in the `test-formats` dependency group,
+which `[tool.uv] default-groups` syncs by default — so no extra install step is required.
 
 **Full suite (unit + integration)** — reads `VIYA_ENDPOINT`, `VIYA_USERNAME`, `VIYA_PASSWORD` from `.env`:
 ```sh
@@ -430,8 +427,9 @@ uv run python -m pytest -m integration --no-cov -v   # any platform
 > when calling pytest directly (or use `--cov-fail-under=0`).
 
 **Binary upload formats.** The Excel `upload_data` integration test generates its `.xlsx`
-fixture with `openpyxl`, which lives in the optional `test-formats` group installed above.
-Without that group the test `importorskip`s (you'll see it as *skipped*, not failed). csv,
+fixture with `openpyxl`, from the `test-formats` group that `uv sync` installs by default
+(see above). If you deliberately sync without it (e.g. `uv sync --no-default-groups`), the
+test `importorskip`s — you'll see it as *skipped*, not failed. csv,
 tsv, and `file_path`/`data_format` coverage needs no extra deps. Generating a
 `sas7bdat`/`sashdat` fixture requires SAS itself, so those two formats are covered by
 unit-level payload tests only, not live.

--- a/README.md
+++ b/README.md
@@ -365,47 +365,76 @@ Collection mode is designed to be cheap enough to leave on. Measured on this rep
 
 The project includes two layers of tests: **unit tests** (fast, no credentials required) and **integration tests** (run against a real SAS Viya instance).
 
+> **`run_tests.sh` vs. running `pytest` directly — pick by platform.** `run_tests.sh` is a
+> Bash convenience wrapper (it adds the ruff + pyright gates, credential wiring, and JUnit
+> reporting). It runs on **Linux/macOS** — and on Windows only under **Git Bash or WSL**. On
+> **Windows PowerShell or `cmd`**, use the **`uv run python -m pytest …`** commands shown
+> under each mode below. They are cross-platform, do the same test selection, and need no
+> setup beyond `uv sync`.
+
 ### Running Unit Tests
 
 Unit tests verify tool schemas, request payloads, and internal logic without making any network calls:
 
 ```sh
-./run_tests.sh
+./run_tests.sh                                     # Linux/macOS (also runs ruff + pyright)
+uv run python -m pytest -m "not integration" -v    # any platform, incl. Windows PowerShell
 ```
 
-Or directly via pytest:
-
-```sh
-uv run python -m pytest -m "not integration" -v
-```
+This runs the unit suite and **deselects the integration tests**, which then show up in the
+summary as e.g. `27 deselected`. That is expected — those tests are *not* meant to run in a
+unit-only pass. They only execute in the integration modes below, because they need a live
+Viya instance; there is no flag that "activates" them in a `not integration` run.
 
 ### Running Integration Tests
 
-Integration tests call every tool against a live Viya environment. They require credentials, which can be provided via CLI arguments or `.env`:
+Integration tests call every tool against a live Viya environment. They require credentials, provided via `.env` or CLI arguments.
 
-**Using `.env`** (set `VIYA_ENDPOINT`, `VIYA_USERNAME`, `VIYA_PASSWORD`):
+For the **full** integration run (including the Excel `upload_data` test), install the
+optional format dependency first — plain `uv sync` does **not** include it:
+
 ```sh
-./run_tests.sh --integration
+uv sync --group test-formats
 ```
 
-**Using CLI arguments:**
+**Full suite (unit + integration)** — reads `VIYA_ENDPOINT`, `VIYA_USERNAME`, `VIYA_PASSWORD` from `.env`:
+```sh
+./run_tests.sh --integration      # Linux/macOS
+uv run python -m pytest -v        # any platform
+```
+
+**Passing credentials on the command line** (wrapper only):
 ```sh
 ./run_tests.sh --integration \
     --endpoint https://your-viya-server.com \
     --username youruser \
     --password yourpassword
 ```
+With the direct `pytest` command, set the same three variables in `.env` (or export them in your shell) instead.
 
 **Integration tests only** (skip unit tests):
 ```sh
-./run_tests.sh --integration-only
+./run_tests.sh --integration-only                    # Linux/macOS
+uv run python -m pytest -m integration --no-cov -v   # any platform
 ```
 
-**Binary upload formats.** The `upload_data` Excel integration test generates its `.xlsx`
-fixture with `openpyxl`. Install the optional group so it runs instead of `importorskip`-ing:
-`uv sync --group test-formats`. (csv, tsv, and `file_path`/`data_format` coverage needs no
-extra deps.) Generating a `sas7bdat`/`sashdat` fixture requires SAS itself, so those two
-formats are covered by unit-level payload tests only, not live.
+> **The pytest marker is `integration`, not `integration-only`.** `--integration-only` is a
+> flag of the `run_tests.sh` *wrapper*; the underlying pytest marker is just `integration`.
+> Running `pytest -m "integration-only"` matches no marker and silently deselects **all**
+> tests (`0 selected`). Use `-m integration`.
+>
+> **Why `--no-cov`?** `pytest.ini` enforces a 90% coverage floor that only the *full* unit
+> suite reaches. An integration-only run exercises far less code (~65%), so without
+> `--no-cov` pytest exits non-zero with a **coverage** failure even though every selected
+> test passed. `run_tests.sh --integration-only` adds `--no-cov` for you; add it yourself
+> when calling pytest directly (or use `--cov-fail-under=0`).
+
+**Binary upload formats.** The Excel `upload_data` integration test generates its `.xlsx`
+fixture with `openpyxl`, which lives in the optional `test-formats` group installed above.
+Without that group the test `importorskip`s (you'll see it as *skipped*, not failed). csv,
+tsv, and `file_path`/`data_format` coverage needs no extra deps. Generating a
+`sas7bdat`/`sashdat` fixture requires SAS itself, so those two formats are covered by
+unit-level payload tests only, not live.
 
 Every one of the 68 tools and 8 prompt templates has an integration test, enforced by the
 `test_every_tool_has_integration_coverage` / `test_every_prompt_has_integration_coverage`
@@ -413,7 +442,10 @@ guards — adding a new tool or prompt without integration coverage fails the su
 resource-dependent tests discover real targets on the instance: `score_data` scores the most
 recently modified MAS module (discovering a real step and its inputs), and `run_ml_project`
 re-runs the most recently modified `completed` ML project. They `skip` only if the instance
-has no such resource at all.
+has no such resource at all. Likewise, `test_catalog_agents_workflow` `skip`s with *"No
+discovery agent named 'Public'"* on instances where SAS Information Catalog has no discovery
+agent named `Public` configured — an expected skip, not a failure; ask a Viya admin to
+configure one if you need that test to run.
 
 **In CI:** the `.github/workflows/integration.yml` workflow runs this suite on demand
 (manual dispatch, or by adding the `run-integration` label to a PR) using repository

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ uv run python -m pytest -m "not integration" -v    # any platform, incl. Windows
 ```
 
 This runs the unit suite and **deselects the integration tests**, which then show up in the
-summary as e.g. `27 deselected`. That is expected — those tests are *not* meant to run in a
+summary as e.g. `28 deselected`. That is expected — those tests are *not* meant to run in a
 unit-only pass. They only execute in the integration modes below, because they need a live
 Viya instance; there is no flag that "activates" them in a `not integration` run.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,16 @@ dev = [
     "ruff>=0.14.4",
 ]
 # Writer used only to generate the binary .xlsx fixture for the upload_data
-# Excel integration test. Without it that test importorskips.
-# Install with: uv sync --group test-formats
+# Excel integration test; without it that test importorskips. Synced by default
+# via [tool.uv] default-groups below, so a plain `uv sync` installs it too.
 test-formats = [
     "openpyxl>=3.1",
 ]
+
+[tool.uv]
+# Include test-formats in a plain `uv sync` so the Excel upload_data integration
+# test runs out of the box, with no separate `--group test-formats` step.
+default-groups = ["dev", "test-formats"]
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
## What

Two small quality-of-life fixes to the **test setup and Testing docs**, so the suite runs out of the box (especially on Windows) and the README stops tripping contributors up.

## Changes

### `uv sync` installs everything the tests need
Adds `[tool.uv] default-groups = ["dev", "test-formats"]` so a plain `uv sync` also installs `openpyxl`. The Excel `upload_data` integration test builds its `.xlsx` fixture with `openpyxl`, which previously lived only in the optional `test-formats` group — so after a normal `uv sync` the test silently `importorskip`'d. This is the "still missing components after uv sync" friction a user reported. `uv.lock` is unchanged (the group was already resolved; `default-groups` only affects what gets *installed*).

### Testing docs: clarify runners and fix two real footguns
- **`run_tests.sh` vs. direct `pytest`, per platform.** `run_tests.sh` is a Bash wrapper (Linux/macOS, or Git Bash/WSL on Windows). The README now shows the cross-platform `uv run python -m pytest …` equivalent for **every** mode, so Windows PowerShell/`cmd` users aren't stuck on a Bash-only path.
- **The marker is `integration`, not `integration-only`.** `--integration-only` is a *wrapper* flag; `pytest -m "integration-only"` matches no marker and silently deselects **all** tests. Documented explicitly.
- **Why `--no-cov` on integration-only runs.** `pytest.ini` enforces a 90% coverage floor that only the full unit suite reaches; an integration-only subset exercises far less code, so without `--no-cov` pytest exits non-zero on *coverage* even though every selected test passed.
- **What "deselected" means.** A unit run (`-m "not integration"`) deselects the integration tests — expected, not a problem — shown in the summary as `28 deselected`.
- Documents the expected `test_catalog_agents_workflow` skip (`"No discovery agent named 'Public'"`) on instances without that discovery agent configured.

## Why it matters
Lower setup friction and fewer "why is my test run behaving weirdly?" questions — particularly for Windows contributors. Purely docs + a dependency-group default; no runtime or tool behavior changes.

## Verification
Rebased onto current `main` and checked every claim against the repo: the `[tool.uv]` block applies with no duplicate, the `integration` marker / 90% floor / `--no-cov` rationale match `pytest.ini`, the catalog skip message and `.github/workflows/integration.yml` exist, and the tool/prompt figures (68 / 8) are current. Corrected the unit-run example from 27 → 28 deselected to match the extra integration test added by the tiered-tools refactor (#26); confirmed against a live run (28 integration tests).

Assisted by Claude Code.
