### PR TITLE
feat(reports): Visual Analytics report-authoring tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+- **Visual Analytics report-authoring tools (6)** — author VA reports through the API rather than only reading and exporting them: `create_report` (create, optionally building the whole report in one atomic call via an `operations` array), `apply_report_operations` (the workhorse — apply an ordered, atomic batch of native VA operations: `addData`, `addPage`, `addObject`, `updateObject`, `setParameterValue`, `updateData`, `changeData`, `applyDataView`, with placement via `page`/`relativeToObject`/`container`/`report`, `dry_run`, the ETag concurrency handshake, and save-as via `result_report_name`/`result_folder`), `describe_report_objects` (the self-describing catalog the authoring loop reads — every operation and addable object with data roles, options, an intent→object map, placement guide, and hard limits), `get_report_outline` (read structure back, returning the object handles the other tools need), `copy_report`, and `delete_report`. Validation, the operation/object catalog, and payload construction live in `helpers/report_authoring_helpers.py` so the tools stay thin wrappers. Brings the tool count to 74.
+- **`build_va_dashboard` prompt** — guides a polished multi-page dashboard build from a CAS table as a discover → shape → structure → polish → verify method over the report-authoring tools.
+
+### Fixed
+- **Tolerant coercion for list/dict tool parameters** — some MCP clients serialize optional list/dict parameters as JSON-encoded strings (`'[{"addData": ...}]'` instead of the array), which pydantic rejected before the tool body ran, and which the model could not correct from its side. `tools/_common.py` now absorbs the whole failure class server-side via `BeforeValidator` coercions, leaving the published JSON schema unchanged. Applied to the report-authoring and decisioning list parameters.
+- **`get_castable_columns` returns a structured `not_found`** — a missing CAS table now explains the two usual causes (an unloaded source table vs a session-scoped table created without `PROMOTE=YES`) instead of surfacing a raw HTTP 404.
+
 ## [1.6.1] - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server for executing SAS code, training AutoML pr
 
 ## Features
 
-- 68 tools across 9 selectable tiers, spanning the Analytics Life Cycle on SAS Viya
+- 74 tools across 9 selectable tiers, spanning the Analytics Life Cycle on SAS Viya
 - Prompt Templates for improving your SAS Code
 - OAuth2 authentication with PKCE flow
 - HTTP-based MCP server compatible with MCP clients
@@ -205,6 +205,12 @@ The headings below match the numbered **tiers** above, so `MCP_TIERS` maps direc
 - **list_reports**: List Visual Analytics reports
 - **get_report**: Get report metadata and definition
 - **export_report**: export a report (or specific report objects) in any format the VA service supports — `package` (zip), `pdf`, `png`, `svg`, `csv`, `tsv`, `xlsx`, or `summary`. Text formats come back inline, `png` as image content, and binary formats (`package`/`pdf`/`xlsx`) as an embedded file with the right MIME type.
+- **describe_report_objects**: Discover what a report can contain — the eight report operations and every addable object (bar chart, list table, geo map, key value, …) with a one-line purpose, its data roles, common options, and an example payload. Call with no arguments for the catalog (including an intent→object map, placement guide, layout recipes, and the API's hard limits), `object_type=` for one object's contract (colloquial aliases like `kpi` resolve), `category=` to filter, or `operation=` for one operation's full shape — `operation="addData"` documents `dataItems` (column renames, SAS formats, aggregations, geography classification). Backs the `apply_report_operations` loop.
+- **create_report**: Create a Visual Analytics report and return its id. Optionally pass an `operations` array to build the whole report in one atomic call; the result carries the created page/object names+labels and a verify hint.
+- **apply_report_operations**: The authoring workhorse — apply an ordered batch of native VA operations (`addData`, `addPage`, `addObject`, `updateObject`, `setParameterValue`, `updateData`, `changeData`, `applyDataView`) to a report. Give a page a **title** with `addPage`'s `title` field (a text band at the top of the page body — VA headers are controls-only); title every chart at add time via `options.object.title`; arrange objects with **placement** — `page`, `relativeToObject` (left/right/top/bottom for columns, rows, and grids), `container` (group into a `standardContainer`), or `report` (`new_page` creates-and-names a page inline for one-batch multi-page reports). The batch is atomic. Validates every operation, object key, and placement against the catalog first (reporting all errors at once), supports `dry_run`, handles the ETag concurrency handshake, and — with `result_report_name`/`result_folder` — applies the batch **save-as** to a new report, leaving the source untouched. Typical loop: `describe_report_objects` → `get_castable_columns` → `apply_report_operations` → `get_report_outline` / `export_report` (png, page-by-page) to verify.
+- **get_report_outline**: Read a report's structure back — pages → objects with the handles the other tools need (object `name` for placement/`updateObject` targets, `label` for `export_report`, page `label` for page placement).
+- **copy_report**: Copy a report to a new one (optionally renaming/refoldering). Pairs with a `changeData` operation for the copy-and-replace pattern.
+- **delete_report**: Delete a report and its content.
 
 #### Tier 4 — Batch Jobs & Async Execution
 - **submit_batch_job**: Submit a SAS job for async execution
@@ -257,6 +263,7 @@ Build and manage SAS Intelligent Decisioning rule sets and decision flows end to
 - **explain_sas_code**: Block-by-block code explanation
 - **sas_macro_builder**: Build production-quality SAS macros
 - **generate_report**: Generate ODS/PROC REPORT code
+- **build_va_dashboard**: Guide a polished multi-page Visual Analytics dashboard build from a CAS table — a discover → shape → structure → polish → verify method over the report-authoring tools
 
 ## MCP Client Configuration
 
@@ -443,7 +450,7 @@ tsv, and `file_path`/`data_format` coverage needs no extra deps. Generating a
 `sas7bdat`/`sashdat` fixture requires SAS itself, so those two formats are covered by
 unit-level payload tests only, not live.
 
-Every one of the 68 tools and 8 prompt templates has an integration test, enforced by the
+Every one of the 74 tools and 9 prompt templates has an integration test, enforced by the
 `test_every_tool_has_integration_coverage` / `test_every_prompt_has_integration_coverage`
 guards — adding a new tool or prompt without integration coverage fails the suite. The
 resource-dependent tests discover real targets on the instance: `score_data` scores the most
@@ -479,7 +486,7 @@ gh gist create reports/integration.xml                          # full XML as a 
 
 | File | Description |
 |---|---|
-| `tests/test_tool_payloads.py` | Payload assertions for all 68 tools (URL paths, JSON body, query params, headers) plus error-path coverage |
+| `tests/test_tool_payloads.py` | Payload assertions for all 74 tools (URL paths, JSON body, query params, headers) plus error-path coverage |
 | `tests/test_integration.py` | End-to-end workflow tests against a real Viya instance |
 | `tests/test_tools.py` | Unit tests for the generic Viya REST helpers in `viya_client` (`get_json`, `post_json`, `make_client`, …) |
 | `tests/test_viya_utils.py` | Unit tests for Viya compute session and job orchestration |

--- a/src/sas_mcp_server/helpers/report_authoring_helpers.py
+++ b/src/sas_mcp_server/helpers/report_authoring_helpers.py
@@ -1,0 +1,2674 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for the Visual Analytics report-authoring tools.
+
+Backs ``create_report``, ``apply_report_operations``, ``describe_report_objects``,
+and ``get_report_outline`` (all Tier 3, in ``tools/reports.py``), keeping each
+``@mcp.tool`` a thin wrapper — matching the ``helpers/`` pattern used by
+``report_export_helpers.py``.
+
+The SAS Visual Analytics REST API has a single authoring shape: you POST a new
+report or PUT an existing one with an ordered ``operations`` array, and the
+service applies every operation atomically (all succeed or nothing persists).
+Rather than one tool per chart type, the authoring tools pass that native array
+straight through — so a new VA object type needs no new tool — and this module
+supplies the *validation* and *discovery* that make the generic surface safe:
+
+* :data:`REPORT_OBJECT_TYPES` — one frozen registry of every API-addable object
+  and its data roles, the single source of truth consumed by all three tools.
+* :func:`validate_operations` — structured, pre-flight checks (known object
+  type, addable/updatable gating, data-role names + arity) returning an
+  actionable error dict *before* any HTTP call, so the LLM self-corrects.
+* :func:`describe` — progressive-disclosure discovery over the registry.
+* :func:`execute_operations` — the GET-etag → ``If-Match`` → PUT round-trip
+  (with a transparent 412 retry) that the caller never has to manage, plus an
+  optional *save-as* mode (``resultReportName``/``resultFolder``) that applies
+  the batch to a new report and leaves the source untouched.
+* :func:`execute_outline` — the read-back path: reduces the stored report
+  definition (BIRD content) to the page → object names/labels that placement,
+  updateObject, and export_report consume.
+
+The ETag is read from the generic Reports service resource
+(``/reports/reports/{id}``) while the operations PUT targets the Visual
+Analytics service (``/visualAnalytics/reports/{id}``) — the two-path handshake
+the SAS sample notebooks use.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import difflib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from sas_mcp_server.config import VIYA_ENDPOINT
+
+# --- endpoints ------------------------------------------------------------
+
+CREATE_PATH = "/visualAnalytics/reports"
+OPERATIONS_PATH = "/visualAnalytics/reports/{report_id}"
+COPY_PATH = "/visualAnalytics/reports/{report_id}/copy"
+DELETE_PATH = "/visualAnalytics/reports/{report_id}"
+# The current ETag comes from the Reports service view of the report, not the
+# Visual Analytics operations endpoint (mirrors the SAS sample notebooks).
+ETAG_PATH = "/reports/reports/{report_id}"
+# The stored report definition (BIRD document) — the only read-back path for a
+# report's page/object structure. Requires the vnd Accept type (plain
+# application/json is answered with 415).
+CONTENT_PATH = "/reports/reports/{report_id}/content"
+CONTENT_ACCEPT = "application/vnd.sas.report.content+json"
+
+CONFLICT_VALUES = frozenset({"abort", "rename", "replace"})
+
+# The eight report operations the API accepts in an operations array. Meta keys
+# may sit alongside the single operation key on an element.
+OPERATION_KEYS = frozenset(
+    {
+        "addData",
+        "updateData",
+        "changeData",
+        "applyDataView",
+        "addPage",
+        "addObject",
+        "updateObject",
+        "setParameterValue",
+    }
+)
+_META_OP_KEYS = frozenset({"operationId", "includeObjectInResponse"})
+
+# How an addObject may be placed. Each variant carries a target and/or a
+# context/position from a fixed enum. VA has no absolute width/height/x/y in the
+# request — objects are auto-sized — so layout is built from placement (relative
+# positioning + containers + page assignment), not geometry.
+# NOTE: the live report-context enum is snake_case "new_page" (the published
+# OpenAPI spec says "newPage", but current Viya rejects that spelling with a
+# 400); normalize_operations translates "newPage" for callers that follow the
+# spec. Page/report "header" bands accept ONLY control objects — never text.
+PLACEMENT_VARIANTS: tuple[str, ...] = ("page", "relativeToObject", "container", "report")
+_PLACEMENT_TARGET_REQUIRED = frozenset({"page", "relativeToObject", "container"})
+_PLACEMENT_ENUMS: dict[str, dict[str, frozenset[str]]] = {
+    "page": {"context": frozenset({"header", "body"}), "position": frozenset({"start", "end"})},
+    "relativeToObject": {"position": frozenset({"before", "after", "left", "right", "top", "bottom"})},
+    "container": {"position": frozenset({"start", "end"})},
+    "report": {"context": frozenset({"new_page", "header"}), "position": frozenset({"start", "end"})},
+}
+# VA enforces additionalProperties:false, so unknown placement keys fail the
+# whole atomic batch server-side — reject them pre-flight instead.
+_PLACEMENT_ALLOWED_KEYS: dict[str, frozenset[str]] = {
+    "page": frozenset({"target", "context", "position"}),
+    "relativeToObject": frozenset({"target", "position"}),
+    "container": frozenset({"target", "position"}),
+    "report": frozenset({"context", "position", "pageName", "pagePosition"}),
+}
+
+# The placement vocabulary and layout recipes surfaced by describe() so an agent
+# can build structured pages rather than a single auto-flow stack.
+PLACEMENT_GUIDE: tuple[dict[str, Any], ...] = (
+    {
+        "variant": "page",
+        "shape": {"page": {"target": "<pageName>", "context": "header | body", "position": "start | end"}},
+        "purpose": (
+            "Put the object on a page (defaults: body/end). context 'header' is the control band "
+            "across the top — it accepts ONLY control objects (dropdownList, buttonBar, ...), never "
+            "text or visuals; a title text belongs in the body with position 'start'."
+        ),
+    },
+    {
+        "variant": "relativeToObject",
+        "shape": {"relativeToObject": {"target": "<objectName>", "position": "left|right|top|bottom|before|after"}},
+        "purpose": (
+            "Anchor next to an EXISTING object by name — build columns, rows, and grids. "
+            "left/right/top/bottom are geometric (VA auto-wraps both objects in a layout container "
+            "when the direction crosses the parent's flow); before/after insert in flow order. The "
+            "target must already exist when the operation applies — same-batch forward references fail."
+        ),
+    },
+    {
+        "variant": "container",
+        "shape": {"container": {"target": "<containerName>", "position": "start | end"}},
+        "purpose": "Place inside a standardContainer added earlier, to group objects together.",
+    },
+    {
+        "variant": "report",
+        "shape": {
+            "report": {
+                "context": "new_page | header",
+                "position": "start | end",
+                "pageName": "<name for the new page>",
+                "pagePosition": 0,
+            }
+        },
+        "purpose": (
+            "Place at the report level. context 'new_page' creates a page as it places the object; "
+            "give it a pageName (becomes the page label, targetable by later ops in the SAME batch) "
+            "and an optional numeric pagePosition (0 = first — a NUMBER here, unlike the string "
+            "addPage.pagePosition). context 'header' is the report-wide control band (controls only)."
+        ),
+    },
+)
+
+LAYOUT_RECIPES: tuple[str, ...] = (
+    "Default page skeleton — the page body auto-flows VERTICALLY, so N page-placed objects render "
+    "as one tall ugly stack. Structure every page instead: KPI tiles side by side in a "
+    "standardContainer at the top, then each chart row built with relativeToObject left/right. "
+    "Page placement alone is only right for a page's FIRST object per row.",
+    'Page title: give addPage a "title", e.g. {"addPage": {"pageName": "Overview", "title": "Sales '
+    'Overview"}} — it expands into a text band at the TOP OF THE PAGE BODY. Page and report headers '
+    "accept only control objects, so titles never go in a header.",
+    'Chart titles: pass {"options": {"object": {"title": "Revenue by Region"}}} inside the object '
+    "spec at add time (every addable type except standardContainer — title a container via a "
+    "follow-up updateObject using its returned name). Untitled charts fall back to auto-labels "
+    'like "Frequency of Origin".',
+    "One-batch multi-page report: create each page with its first object via placement "
+    '{"report": {"context": "new_page", "pageName": "Trends", "pagePosition": 1}}, then target that '
+    'pageName from later operations in the SAME batch with {"page": {"target": "Trends"}}. Page '
+    "names are caller-chosen; object names are not.",
+    "Two columns: add chart A in one call, read its returned object name, then add chart B with "
+    '{"relativeToObject": {"target": "<A\'s name>", "position": "right"}}. Targets must already '
+    "exist — a same-batch forward reference fails the whole atomic batch. before/after insert in "
+    "flow order; left/right/top/bottom are geometric side-by-side.",
+    "2x2 grid: place obj2 right of obj1, obj3 bottom of obj1, obj4 right of obj3 — chaining the "
+    "object names each apply_report_operations call returns.",
+    "Grouped strip (e.g. a KPI row of keyValue tiles): add a standardContainer (bare {} — it "
+    "accepts no options at add time), then in a follow-up apply add each tile with placement "
+    '{"container": {"target": "<container\'s returned name>"}}.',
+    "Placement and dataRoles are WRITE-ONCE: updateObject changes only options (title, etc.) and "
+    "there is no move/resize/remove operation — get placement right at add time, or rebuild via "
+    "save-as/copy.",
+    'Creating a report with inline operations leaves VA\'s empty default "Page 1" as the first '
+    "page, so whole-report exports can render blank — verify page-by-page with "
+    "export_report(..., report_objects=['<page label>']) and inspect structure with "
+    "get_report_outline.",
+)
+
+
+# --- object registry ------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoleSpec:
+    """A single data role a VA object accepts.
+
+    ``multi`` marks an array-valued role (e.g. ``measures``, ``columns``,
+    ``variables``) versus a single-column role (e.g. ``category``, ``xAxis``).
+    """
+
+    name: str
+    multi: bool = False
+
+
+@dataclass(frozen=True)
+class VaObject:
+    """One VA report object and the data roles it exposes.
+
+    ``commonly_required`` is a curated heuristic from the SAS ``vaobj``
+    documentation (the OpenAPI spec marks *every* role optional), used only for
+    non-blocking warnings — never to reject a payload. ``purpose`` is a one-line
+    picking hint surfaced by describe() so an agent can choose the right object
+    for an analytical intent instead of defaulting to barChart for everything.
+    """
+
+    schema_key: str
+    category: str
+    addable: bool
+    updatable: bool
+    roles: tuple[RoleSpec, ...]
+    commonly_required: tuple[str, ...] = ()
+    purpose: str = ""
+    # Role groups where at least ONE member must be filled or the object is
+    # accepted by VA but RENDERS EMPTY ("required roles not assigned") — the
+    # API does not auto-apply Frequency the way the VA UI does. Live-observed.
+    render_required: tuple[tuple[str, ...], ...] = ()
+
+    @property
+    def role_names(self) -> tuple[str, ...]:
+        return tuple(r.name for r in self.roles)
+
+
+# Registry generated from the SAS Visual Analytics v8 OpenAPI spec (every object
+# in the ``addObjectRequest`` union) and role semantics from the ``vaobj`` docs.
+# Adding or retiring an object when VA changes is a one-line edit here that
+# describe, validation, and the example builder all pick up automatically.
+_R = RoleSpec
+_O = VaObject
+_OBJECTS: tuple[VaObject, ...] = (
+    _O(
+        "crosstab",
+        "Tables",
+        True,
+        True,
+        (_R("rows", multi=True), _R("columns", multi=True), _R("measures", multi=True)),
+        (),
+        purpose="Pivot table — measures at row x column category intersections.",
+    ),
+    _O(
+        "listTable",
+        "Tables",
+        True,
+        True,
+        (_R("columns", multi=True),),
+        ("columns",),
+        purpose="Detail rows, spreadsheet-style — one row per record.",
+    ),
+    _O(
+        "buttonBar",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Row of buttons picking one category value (prompt control; not auto-wired to filter).",
+    ),
+    _O(
+        "dropdownList",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Compact dropdown picking a category value (prompt control; not auto-wired to filter).",
+    ),
+    _O(
+        "list",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Scrollable multi-select list of category values (prompt control).",
+    ),
+    _O(
+        "slider",
+        "Controls",
+        True,
+        True,
+        (_R("measure"),),
+        (),
+        purpose="Numeric range slider (prompt control).",
+    ),
+    _O(
+        "textInput",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Free-text search box (prompt control).",
+    ),
+    _O(
+        "standardContainer",
+        "Containers",
+        True,
+        True,
+        (),
+        (),
+        purpose="Groups objects into one auto-arranged block — the KPI-row / panel building block.",
+    ),
+    _O(
+        "dataDrivenContent",
+        "Content",
+        True,
+        True,
+        (_R("variables", multi=True),),
+        (),
+        purpose="Embeds a custom third-party visualization fed by report data (its URL is NOT settable here).",
+    ),
+    _O(
+        "image",
+        "Content",
+        True,
+        True,
+        (),
+        (),
+        purpose="Static image from a URL or a Viya folder — logos and branding.",
+    ),
+    _O(
+        "text",
+        "Content",
+        True,
+        True,
+        (),
+        (),
+        purpose="Static narrative text — title bands, section intros, footnotes.",
+    ),
+    _O(
+        "geoBubble",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("size"), _R("color")),
+        ("geography",),
+        purpose="Map with bubbles sized/colored by measures at locations.",
+    ),
+    _O(
+        "geoCluster",
+        "Geo Maps",
+        True,
+        False,
+        (_R("geography"), _R("size"), _R("color")),
+        ("geography",),
+        purpose="Map clustering dense point locations.",
+    ),
+    _O(
+        "geoContour",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("color")),
+        ("geography",),
+        purpose="Map with density contours over locations.",
+    ),
+    _O(
+        "geoCoordinate",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("size"), _R("color")),
+        ("geography",),
+        purpose="Map plotting individual coordinate points.",
+    ),
+    _O(
+        "geoLine",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("width"), _R("color"), _R("pattern")),
+        ("geography",),
+        purpose="Map drawing lines/routes between geo points.",
+    ),
+    _O(
+        "geoLineCoordinate",
+        "Geo Maps",
+        True,
+        True,
+        (
+            _R("geographyLine"),
+            _R("widthLine"),
+            _R("colorLine"),
+            _R("patternLine"),
+            _R("geographyScatter"),
+            _R("sizeScatter"),
+            _R("colorScatter"),
+        ),
+        (),
+        purpose="Map combining a line layer with a coordinate-point layer.",
+    ),
+    _O(
+        "geoNetwork",
+        "Geo Maps",
+        True,
+        True,
+        (_R("source"), _R("target"), _R("size"), _R("color"), _R("dataLabel")),
+        (),
+        purpose="Map of source-to-target links (flows) between locations.",
+    ),
+    _O(
+        "geoPie",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("size"), _R("response"), _R("group")),
+        ("geography",),
+        purpose="Map with pie markers at locations.",
+    ),
+    _O(
+        "geoRegion",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("color")),
+        ("geography",),
+        purpose="Choropleth — regions filled by a measure.",
+    ),
+    _O(
+        "geoRegionCoordinate",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geographyRegion"), _R("colorRegion"), _R("geographyScatter"), _R("sizeScatter"), _R("colorScatter")),
+        (),
+        purpose="Choropleth plus a coordinate-point overlay.",
+    ),
+    _O(
+        "automatedExplanation",
+        "Analytics",
+        True,
+        True,
+        (_R("response"), _R("underlyingFactors", multi=True)),
+        (),
+        purpose="Auto-generated narrative explaining what drives a measure.",
+    ),
+    _O(
+        "forecasting",
+        "Analytics",
+        True,
+        True,
+        (_R("timeAxis"), _R("measures", multi=True), _R("underlyingFactors", multi=True)),
+        ("timeAxis",),
+        purpose="Time-series forecast with confidence bands.",
+    ),
+    _O(
+        "networkAnalysis",
+        "Analytics",
+        True,
+        True,
+        (_R("source"), _R("target"), _R("size"), _R("color"), _R("linkWidth"), _R("linkColor")),
+        (),
+        purpose="Node-link network diagram of relationships.",
+    ),
+    _O(
+        "pathAnalysis",
+        "Analytics",
+        True,
+        True,
+        (_R("event"), _R("sequenceOrder"), _R("transactionId"), _R("weight")),
+        (),
+        purpose="Sankey-style flow of event sequences (journeys, funnels).",
+    ),
+    _O(
+        "cluster",
+        "Statistics",
+        True,
+        True,
+        (_R("variables", multi=True),),
+        (),
+        purpose="Cluster analysis grouping observations across variables.",
+    ),
+    _O(
+        "linearRegression",
+        "Statistics",
+        False,
+        True,
+        (_R("response"), _R("continuousEffects", multi=True), _R("classificationEffects", multi=True)),
+        (),
+        purpose="Linear regression fit summary (update-only via the API).",
+    ),
+    _O(
+        "logisticRegression",
+        "Statistics",
+        True,
+        False,
+        (_R("response"), _R("continuousEffects", multi=True)),
+        (),
+        purpose="Logistic regression fit summary.",
+    ),
+    _O(
+        "nonparametricLogisticRegression",
+        "Statistics",
+        True,
+        True,
+        (_R("response"), _R("splineEffects", multi=True)),
+        (),
+        purpose="Spline-based (GAM-like) logistic regression.",
+    ),
+    _O(
+        "bayesianNetwork",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Bayesian network model of a response and predictors.",
+    ),
+    _O(
+        "factorizationMachine",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Factorization machine model (sparse interactions).",
+    ),
+    _O(
+        "forest",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Random-forest model assessment.",
+    ),
+    _O(
+        "gradientBoosting",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Gradient-boosting model assessment (nearest to a decision tree).",
+    ),
+    _O(
+        "neuralNetwork",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Neural network model assessment.",
+    ),
+    _O(
+        "supportVectorMachine",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Support vector machine model assessment.",
+    ),
+    _O(
+        "barChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True), _R("frequency")),
+        ("category",),
+        purpose="Bars comparing measures across categories — the general workhorse.",
+        render_required=(("measures", "frequency"),),
+    ),
+    _O(
+        "boxPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True)),
+        ("measures",),
+        purpose="Distribution quartiles and outliers per category.",
+    ),
+    _O(
+        "bubbleChangePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xStart"), _R("xEnd"), _R("yStart"), _R("yEnd"), _R("sizeStart"), _R("sizeEnd"), _R("group")),
+        (),
+        purpose="Bubbles showing movement between a start and an end state.",
+    ),
+    _O(
+        "bubblePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("size"), _R("group")),
+        ("xAxis", "yAxis", "size"),
+        purpose="Scatter with a third measure encoded as bubble size.",
+    ),
+    _O(
+        "butterflyChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureBar"), _R("measureBar2")),
+        (),
+        purpose="Two measures diverging left/right from a shared category axis.",
+    ),
+    _O(
+        "comparativeTimeSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("timeAxis"), _R("measureTimeSeries1"), _R("measureTimeSeries2")),
+        (),
+        purpose="Two stacked time-series panels over the same time axis.",
+    ),
+    _O(
+        "correlationMatrix",
+        "Graphs",
+        True,
+        True,
+        (_R("measures", multi=True),),
+        ("measures",),
+        purpose="Heat-colored pairwise correlations between measures.",
+    ),
+    _O(
+        "dotPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        ("category",),
+        purpose="Dots marking a measure per category — lighter than bars.",
+    ),
+    _O(
+        "dualAxisBarChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureBar"), _R("measureBar2")),
+        (),
+        purpose="Bars for two measures on independent Y axes.",
+    ),
+    _O(
+        "dualAxisBarLineChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureBar"), _R("measureLine")),
+        (),
+        purpose="Bars plus a line on independent Y axes — volume vs rate.",
+    ),
+    _O(
+        "dualAxisLineChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureLine"), _R("measureLine2")),
+        (),
+        purpose="Two lines on independent Y axes.",
+    ),
+    _O(
+        "dualAxisTimeSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("timeAxis"), _R("measureLine"), _R("measureLine2")),
+        (),
+        purpose="Two time series on independent Y axes.",
+    ),
+    _O(
+        "gauge",
+        "Graphs",
+        True,
+        True,
+        (_R("measure"), _R("target"), _R("group")),
+        ("measure",),
+        purpose="KPI dial of a measure against a target.",
+    ),
+    _O(
+        "heatMap",
+        "Graphs",
+        True,
+        True,
+        (_R("axisItems", multi=True), _R("color")),
+        ("axisItems",),
+        purpose="Grid cells colored by a measure.",
+    ),
+    _O(
+        "histogram",
+        "Graphs",
+        True,
+        True,
+        (_R("measure"), _R("frequency")),
+        ("measure",),
+        purpose="Distribution of a single measure.",
+    ),
+    _O(
+        "keyValue",
+        "Graphs",
+        True,
+        True,
+        (_R("measure"), _R("latticeCategory")),
+        ("measure",),
+        purpose="Big-number KPI tile — one headline value.",
+    ),
+    _O(
+        "lineChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True), _R("frequency")),
+        ("category",),
+        purpose="Lines across ordered categories — trends over a non-date axis.",
+        render_required=(("measures", "frequency"),),
+    ),
+    _O(
+        "needlePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("group")),
+        (),
+        purpose="Vertical needles from a baseline — sparse event values.",
+    ),
+    _O(
+        "numericSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("group")),
+        (),
+        purpose="Line over a numeric (non-date) X axis.",
+    ),
+    _O(
+        "parallelCoordinatePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("variables", multi=True),),
+        (),
+        purpose="Profile lines across many variables at once.",
+    ),
+    _O(
+        "pieChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True), _R("frequency")),
+        ("category",),
+        purpose="Part-to-whole share per category (keep to a few slices).",
+        render_required=(("measures", "frequency"),),
+    ),
+    _O(
+        "scatterPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("measures", multi=True), _R("color")),
+        ("measures",),
+        purpose="Point cloud relating two or more measures.",
+    ),
+    _O(
+        "scheduleChart",
+        "Graphs",
+        True,
+        True,
+        (_R("task"), _R("start"), _R("finish"), _R("group")),
+        (),
+        purpose="Gantt-style bars of tasks over start/finish times.",
+    ),
+    _O(
+        "stepPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("group")),
+        (),
+        purpose="Stepped line — values holding constant between changes.",
+    ),
+    _O(
+        "targetedBarChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measure"), _R("target")),
+        (),
+        purpose="Bars with target markers — actual vs goal.",
+    ),
+    _O(
+        "timeSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("timeAxis"), _R("measure"), _R("group")),
+        ("timeAxis",),
+        purpose="Trend of a measure over a date/time axis.",
+    ),
+    _O(
+        "treeMap",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        ("category",),
+        purpose="Nested rectangles sized by a measure — hierarchical part-to-whole.",
+    ),
+    _O(
+        "vectorPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("xOrigin"), _R("yOrigin"), _R("color")),
+        (),
+        purpose="Arrows from origin to point — direction and magnitude of change.",
+    ),
+    _O(
+        "waterfallChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("response")),
+        (),
+        purpose="Cumulative running total across categories.",
+    ),
+    _O(
+        "wordCloud",
+        "Graphs",
+        True,
+        True,
+        (_R("word"), _R("size"), _R("color")),
+        (),
+        purpose="Words sized by frequency or a measure.",
+        render_required=(("size",),),
+    ),
+)
+del _R, _O
+
+REPORT_OBJECT_TYPES: dict[str, VaObject] = {o.schema_key: o for o in _OBJECTS}
+
+# Objects that appear in the VA UI but have NO schema in the report API. Mapping
+# each to the nearest addable alternative lets the tools redirect an agent
+# instead of letting it fail with an opaque VA error.
+NOT_ADDABLE: dict[str, str] = {
+    "textTopics": "wordCloud",
+    "decisionTree": "gradientBoosting",
+    "generalizedAdditiveModel": "nonparametricLogisticRegression",
+    "generalizedLinearModel": "logisticRegression",
+}
+
+CATEGORIES: tuple[str, ...] = (
+    "Tables",
+    "Controls",
+    "Containers",
+    "Content",
+    "Graphs",
+    "Geo Maps",
+    "Analytics",
+    "Statistics",
+    "Machine Learning",
+)
+
+# Colloquial names an agent is likely to try, mapped to real schema keys —
+# consulted before difflib so describe('kpi') lands on keyValue instead of
+# nothing (difflib alone scores kpi->keyValue below its cutoff).
+ALIASES: dict[str, str] = {
+    "kpi": "keyValue",
+    "tile": "keyValue",
+    "bignumber": "keyValue",
+    "indicator": "keyValue",
+    "map": "geoRegion",
+    "choropleth": "geoRegion",
+    "table": "listTable",
+    "datatable": "listTable",
+    "pivot": "crosstab",
+    "pivottable": "crosstab",
+    "filter": "dropdownList",
+    "dropdown": "dropdownList",
+    "donut": "pieChart",
+    "gantt": "scheduleChart",
+    "sankey": "pathAnalysis",
+    "trend": "timeSeriesPlot",
+    "sparkline": "timeSeriesPlot",
+    "container": "standardContainer",
+    "textbox": "text",
+    "label": "text",
+    "logo": "image",
+    "funnel": "pathAnalysis",
+}
+
+def _normalize_key(value: str) -> str:
+    """Case/spacing-insensitive lookup form: 'Decision Tree' -> 'decisiontree'."""
+    return value.strip().lower().replace(" ", "").replace("-", "").replace("_", "")
+
+
+_NORMALIZED_TYPES: dict[str, str] = {_normalize_key(k): k for k in REPORT_OBJECT_TYPES}
+_NORMALIZED_NOT_ADDABLE: dict[str, str] = {_normalize_key(k): k for k in NOT_ADDABLE}
+
+
+# Analytical intent -> the object types that serve it, surfaced in the describe
+# index so an agent picks variety deliberately instead of barChart-for-everything.
+INTENT_MAP: dict[str, list[str]] = {
+    "single KPI number": ["keyValue", "gauge"],
+    "KPI row of tiles": ["standardContainer", "keyValue"],
+    "trend over time": ["timeSeriesPlot", "lineChart"],
+    "compare categories": ["barChart", "dotPlot"],
+    "actual vs target": ["targetedBarChart", "gauge"],
+    "part-to-whole": ["pieChart", "treeMap"],
+    "distribution": ["histogram", "boxPlot"],
+    "relationship between measures": ["scatterPlot", "bubblePlot", "heatMap"],
+    "geographic distribution": ["geoRegion", "geoBubble"],
+    "detail rows": ["listTable"],
+    "pivot / cross-tab": ["crosstab"],
+    "filter control": ["dropdownList", "buttonBar", "slider"],
+    "narrative text / title band": ["text"],
+    "logo / branding": ["image"],
+    "forecast": ["forecasting"],
+    "what drives a measure": ["automatedExplanation"],
+    "flows / sequences": ["pathAnalysis", "networkAnalysis"],
+}
+
+# Honest boundaries of the operations API, surfaced by describe() so an agent
+# does not burn round-trips hunting for capabilities that do not exist.
+API_LIMITS: tuple[str, ...] = (
+    "Controls are added UNWIRED: no operation creates filters, actions, or links between objects "
+    "— interactive wiring needs the VA UI (or raw report-content editing).",
+    "setParameterValue only sets EXISTING report parameters; parameters cannot be created here.",
+    "Calculated items, hierarchies, and custom sorts cannot be created via operations — save a "
+    "data view once in the VA UI, then import it with applyDataView.",
+    "No theme/page-numbering/footer operation exists; retheming lives in the SAS Report "
+    "Transforms API.",
+    "Placement and dataRoles are write-once: updateObject changes only options, and there is no "
+    "move/resize/remove operation (delete_report or save-as/copy and rebuild instead).",
+    "Objects are auto-named and auto-sized: no width/height/x/y anywhere, and VA rejects a "
+    "caller-supplied object 'name' at add time — chain layouts on the names each apply returns.",
+    "Page and report headers accept ONLY control objects — titles are text objects placed at the "
+    "top of the page body.",
+)
+
+# dataItems vocabularies from the VA v8 OpenAPI spec (dataItemProperties),
+# validated pre-flight because VA rejects unknown values with a whole-batch 400.
+AGGREGATIONS: frozenset[str] = frozenset(
+    {
+        "sum",
+        "average",
+        "min",
+        "max",
+        "count",
+        "median",
+        "variance",
+        "numberMissing",
+        "standardDeviation",
+        "standardError",
+        "firstQuartile",
+        "thirdQuartile",
+        "skewness",
+        "kurtosis",
+        "coefficientOfVariation",
+        "correctedSumOfSquares",
+        "uncorrectedSumOfSquares",
+        "tStatistic",
+        "pValue",
+    }
+)
+CLASSIFICATIONS: frozenset[str] = frozenset({"category", "measure", "geography"})
+# The geographyDataSource union from the spec: named-region contexts OR raw
+# lat/long coordinates (geographyCoordinates) — exactly one of the two.
+GEO_SOURCE_KEYS: frozenset[str] = frozenset(
+    {
+        "geographyNameCodeContext",
+        "geographyCountryRegion",
+        "geographyDataProvider",
+        "geographyCoordinates",
+    }
+)
+# Named SAS format: optional $, leading letter, optional width, dot, optional
+# decimals (DOLLAR12.2, COMMA10., PERCENT8.1, DATE9., $CHAR20.). VA rejects
+# bare numeric w.d forms like "8.1" — and the whole atomic batch with them.
+_SAS_FORMAT_RE = re.compile(r"^\$?[A-Za-z][A-Za-z0-9_]*\.\d*$")
+GEO_NAME_CODE_CONTEXTS: frozenset[str] = frozenset(
+    {
+        "CountryRegionNames",
+        "CountryRegionISO2LetterCodes",
+        "CountryRegionISO3LetterCodes",
+        "CountryRegionISONumericCodes",
+        "CountryRegionSASMapIdValues",
+        "SubdivisionNames",
+        "SubdivisionSASMapIdValues",
+        "USStateNames",
+        "USStateAbbreviations",
+        "USZipCodes",
+    }
+)
+
+# The eight operations, with a worked example each, for describe(operation=...)
+# and the tool docstrings. The index lists key+purpose; the full entry (example,
+# notes) is returned by describe_report_objects(operation='addData') etc.
+OPERATIONS: tuple[dict[str, Any], ...] = (
+    {
+        "key": "addData",
+        "purpose": (
+            "Bind a CAS table as a data source; dataItems is where reports get polish — "
+            "readable labels, formats, aggregations, geography."
+        ),
+        "required": ["cas.{server, library, table}"],
+        "example": {
+            "addData": {
+                "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"},
+                "dataItems": [
+                    {
+                        "dataItem": "Revenue",
+                        "properties": {"name": "Revenue (USD)", "format": "DOLLAR12.2", "aggregation": "average"},
+                    },
+                    {
+                        "dataItem": "State",
+                        "properties": {
+                            "classification": "geography",
+                            "geographyDataSource": {"geographyNameCodeContext": "USStateNames"},
+                        },
+                    },
+                ],
+            }
+        },
+        "notes": [
+            "addObject.dataSource references the addData 'name', defaulting to cas.table.",
+            "After a rename, dataRoles must use the NEW name (e.g. 'Revenue (USD)').",
+            f"aggregation: one of {sorted(AGGREGATIONS)}.",
+            "format must be a NAMED SAS format (DOLLAR12.2, PERCENT8.1, COMMA10., DATE9.) — "
+            "bare numeric forms like '8.1' are rejected.",
+            "classification: category | measure | geography — geography classification is the "
+            "precondition for every Geo Map object.",
+            f"geographyNameCodeContext: one of {sorted(GEO_NAME_CODE_CONTEXTS)}.",
+            "Raw lat/long point data: {'classification': 'geography', 'geographyDataSource': "
+            "{'geographyCoordinates': {'latitudeDataItem': 'LATITUDE', 'longitudeDataItem': "
+            "'LONGITUDE'}}} — coordinates OR a name-code context, never both.",
+        ],
+    },
+    {
+        "key": "addPage",
+        "purpose": (
+            "Add a page; a 'title' becomes a text band at the top of the page body; reference the "
+            "page by pageName when placing objects."
+        ),
+        "required": [],
+        "example": {"addPage": {"pageName": "Overview", "title": "Sales Overview", "pagePosition": "0"}},
+        "notes": [
+            "pagePosition is a STRING here ('0' = first) — unlike the numeric "
+            "report-placement pagePosition.",
+            "The title text lands in the page body (page headers accept only controls).",
+        ],
+    },
+    {
+        "key": "addObject",
+        "purpose": "Add a visual/control/content object, titled and placed.",
+        "required": ["object.<type>  (or reportObject)"],
+        "example": {
+            "addObject": {
+                "object": {
+                    "barChart": {
+                        "dataSource": "SALES",
+                        "dataRoles": {"category": "Region", "measures": ["Revenue (USD)"]},
+                        "options": {"object": {"title": "Revenue by Region"}},
+                    }
+                },
+                "placement": {"page": {"target": "Overview"}},
+            }
+        },
+        "notes": [
+            "Allowed object-spec keys: dataSource, dataRoles, options (VA rejects anything else, "
+            "including a caller-supplied 'name').",
+            "options.object.title/alternativeText work at add time on every type except "
+            "standardContainer.",
+        ],
+    },
+    {
+        "key": "updateObject",
+        "purpose": "Change an existing object's options (title, etc.) — never its placement or data roles.",
+        "required": ["object.<type>.name"],
+        "example": {
+            "updateObject": {
+                "object": {"barChart": {"name": "ve15", "options": {"object": {"title": "MSRP by Region"}}}}
+            }
+        },
+        "notes": ["'name' is the object name (ve*) or label returned by a previous apply or get_report_outline."],
+    },
+    {
+        "key": "setParameterValue",
+        "purpose": "Set an EXISTING report parameter's value (parameters cannot be created here).",
+        "required": ["name", "value"],
+        "example": {"setParameterValue": {"name": "originFilter", "value": "Asia"}},
+    },
+    {
+        "key": "updateData",
+        "purpose": "Update an existing data source's items in place.",
+        "required": ["data"],
+        "example": {"updateData": {"data": {"name": "SALES"}}},
+    },
+    {
+        "key": "changeData",
+        "purpose": "Swap a data source for a different CAS table (copy-and-replace).",
+        "required": ["originalData", "replacementData"],
+        "example": {
+            "changeData": {
+                "originalData": {"cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"}},
+                "replacementData": {
+                    "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES_2025"}
+                },
+            }
+        },
+    },
+    {
+        "key": "applyDataView",
+        "purpose": (
+            "Import a data view saved in the VA UI — the sanctioned route to calculated items, "
+            "hierarchies, and custom sorts."
+        ),
+        "required": ["targetData", "dataView"],
+        "example": {
+            "applyDataView": {
+                "dataItemConflictResolution": "createDuplicate",
+                "targetData": {"name": "SALES"},
+                "dataView": {"name": "SALES View 1"},
+            }
+        },
+        "notes": [
+            "dataItemConflictResolution: abort (default) | createDuplicate | replaceExisting | "
+            "keepExisting | dataMapping.",
+            "dataView takes {'name': ...} or {'uri': ...}; there is no API to create or list data "
+            "views — save one in the VA UI first.",
+        ],
+    },
+)
+
+
+# --- discovery ------------------------------------------------------------
+
+
+def _example_for(obj: VaObject) -> dict[str, Any]:
+    """Build a minimal, copy-paste ``addObject`` payload for *obj*.
+
+    The role-less content objects get their real payloads (probing showed the
+    generic dataSource template is rejected or useless for them), and every
+    other object carries an inline ``options.object.title`` — titled-at-add-time
+    is the single cheapest polish an authoring agent can apply.
+    """
+    if obj.schema_key == "text":
+        body: dict[str, Any] = {"options": {"content": "Your narrative text here."}}
+    elif obj.schema_key == "image":
+        body = {"options": {"url": "https://example.com/logo.png"}}
+    elif obj.schema_key == "standardContainer":
+        body = {}
+    else:
+        seed = obj.commonly_required or (obj.role_names[:1] if obj.role_names else ())
+        roles: dict[str, Any] = {}
+        for name in seed:
+            spec = next((r for r in obj.roles if r.name == name), None)
+            placeholder = f"<{name}Column>"
+            roles[name] = [placeholder] if (spec and spec.multi) else placeholder
+        body = {"dataSource": "<dataSourceName>"}
+        if roles:
+            body["dataRoles"] = roles
+        # keyValue tiles render their measure's label prominently — a title
+        # just duplicates it; name the measure well via dataItems instead.
+        if obj.schema_key != "keyValue":
+            body["options"] = {"object": {"title": "<Meaningful chart title>"}}
+    return {"addObject": {"object": {obj.schema_key: body}, "placement": {"page": {"target": "<pageName>"}}}}
+
+
+def describe(
+    object_type: str | None = None,
+    category: str | None = None,
+    operation: str | None = None,
+) -> dict[str, Any]:
+    """Return the object/operation catalog, one object's contract, or one operation's shape.
+
+    * No args → an index: the eight operations, every object (schema key,
+      purpose, category, addable/updatable), the placement guide, layout
+      recipes, an intent→object map, and the API's honest limits.
+    * ``category`` → the index filtered to that category.
+    * ``object_type`` → one object's roles (name + whether it takes a list),
+      the commonly-required roles, common options, and a ready-to-send example
+      payload; or a ``not_addable`` / ``unknown_object_type`` redirect.
+      Colloquial aliases (``kpi``, ``choropleth``, ...) resolve to the nearest
+      schema key.
+    * ``operation`` → that operation's full entry (purpose, required keys,
+      worked example, notes).
+    """
+    if object_type:
+        return _describe_one(object_type)
+    if operation:
+        return _describe_operation(operation)
+
+    objects = [
+        {
+            "schema_key": o.schema_key,
+            "purpose": o.purpose,
+            "category": o.category,
+            "addable": o.addable,
+            "updatable": o.updatable,
+        }
+        for o in _OBJECTS
+        if category is None or o.category == category
+    ]
+    result: dict[str, Any] = {
+        "operations": [{"key": op["key"], "purpose": op["purpose"]} for op in OPERATIONS],
+        "categories": list(CATEGORIES),
+        "objects": objects,
+        "intent_map": dict(INTENT_MAP),
+        "placement": list(PLACEMENT_GUIDE),
+        "layout_recipes": list(LAYOUT_RECIPES),
+        "limits": list(API_LIMITS),
+        "hint": (
+            "Call describe_report_objects(object_type='barChart') for one object's data roles and "
+            "an example payload, describe_report_objects(operation='addData') for an operation's "
+            "full shape (addData's dataItems is where formats/aggregations/geography live), and "
+            "get_castable_columns to map columns to roles. Use intent_map to pick the right object "
+            "and the placement variants + layout_recipes to arrange objects instead of stacking them."
+        ),
+    }
+    if category is not None and not objects:
+        result["note"] = f"No objects in category '{category}'. Valid categories: {list(CATEGORIES)}."
+    return result
+
+
+def _describe_operation(operation: str) -> dict[str, Any]:
+    for op in OPERATIONS:
+        if op["key"] == operation:
+            return dict(op)
+    return {
+        "status": "unknown_operation",
+        "operation": operation,
+        "valid_operations": sorted(OPERATION_KEYS),
+        "did_you_mean": difflib.get_close_matches(operation, OPERATION_KEYS, n=3, cutoff=0.5),
+    }
+
+
+# Extra guidance for objects whose real-world contract probing showed to be
+# surprising; merged into the describe() detail.
+_OBJECT_NOTES: dict[str, dict[str, str]] = {
+    "text": {
+        "content_note": (
+            "Set the text via options.content (a plain string — no markup). Caveat: some Viya "
+            "builds misroute options.content to the report's FIRST text object on both add and "
+            "update, so keep one content-bearing text per report, or write additional texts via "
+            "the report content endpoint (PUT /reports/reports/{id}/content)."
+        ),
+    },
+    "image": {
+        "options_note": (
+            "options is a oneOf directly under it (no wrapper): {'url': 'https://.../logo.png'} "
+            "for a web image, OR {'imageName': 'logo.png', 'imageFolder': '/folders/folders/"
+            "{folderId}'} for a repository image (imageFolder is the folders-service URI, not a "
+            "display path). URL extension must look like an image (.png/.jpg); reachability is "
+            "NOT checked at add time, repository existence IS."
+        ),
+    },
+    "standardContainer": {
+        "options_note": (
+            "Accepts NO properties at add time — VA rejects even 'options'. Add it bare ({}), "
+            "then title it via a follow-up updateObject using the name the apply returned. "
+            "Containers auto-arrange their children; there is no layout/direction knob."
+        ),
+    },
+    "dataDrivenContent": {
+        "options_note": (
+            "The content URL is NOT settable via the operations API — a dataDrivenContent added "
+            "here renders empty until the URL is set in the VA UI."
+        ),
+    },
+    "histogram": {
+        "data_note": (
+            "A dataItem carrying a preset aggregation breaks histogram binning (the rendered "
+            "object shows 'missing data item'). Point the histogram's measure at the raw, "
+            "unaggregated column — or use a boxPlot for aggregated comparisons."
+        ),
+    },
+    "keyValue": {
+        "title_note": (
+            "Skip options.object.title on KPI tiles — the tile already renders its measure's "
+            "label prominently, so a title duplicates it. Give the measure a good display name "
+            "via addData dataItems (e.g. 'Avg Loan (USD)') instead, and place tiles side by side "
+            "in a standardContainer, never stacked on the page."
+        ),
+    },
+}
+
+
+def _describe_one(object_type: str) -> dict[str, Any]:
+    resolved_from: str | None = None
+    normalized = _normalize_key(object_type)
+    obj = REPORT_OBJECT_TYPES.get(object_type)
+    if obj is None:
+        target = _NORMALIZED_TYPES.get(normalized) or ALIASES.get(normalized)
+        if target:
+            resolved_from = object_type
+            obj = REPORT_OBJECT_TYPES[target]
+    if obj is not None:
+        detail: dict[str, Any] = {
+            "schema_key": obj.schema_key,
+            "purpose": obj.purpose,
+            "category": obj.category,
+            "addable": obj.addable,
+            "updatable": obj.updatable,
+            "data_roles": [
+                {
+                    "name": r.name,
+                    "takes": "list" if r.multi else "single",
+                    "commonly_required": r.name in obj.commonly_required,
+                }
+                for r in obj.roles
+            ],
+            "commonly_required": list(obj.commonly_required),
+        }
+        if resolved_from:
+            detail["resolved_from_alias"] = resolved_from
+        if obj.addable:
+            detail["example"] = _example_for(obj)
+            detail["placement_hint"] = (
+                "The example uses page placement. To arrange it precisely, swap placement for a "
+                "relativeToObject / container variant — see describe_report_objects() placement + layout_recipes."
+            )
+        else:
+            detail["note"] = f"'{obj.schema_key}' can be updated (updateObject) but not added via the API."
+        if obj.schema_key == "standardContainer":
+            detail["common_options"] = {
+                "note": _OBJECT_NOTES["standardContainer"]["options_note"],
+            }
+        else:
+            detail["common_options"] = {
+                "shape": {"options": {"object": {"title": "<title>", "alternativeText": "<alt text>"}}},
+                "note": (
+                    "Accepted inline at add time — title every visual meaningfully instead of "
+                    "relying on VA's auto-labels."
+                ),
+            }
+        detail.update(_OBJECT_NOTES.get(obj.schema_key, {}))
+        if obj.render_required:
+            detail["render_required"] = [list(group) for group in obj.render_required]
+        if obj.category == "Geo Maps":
+            detail["precondition"] = (
+                "Geo objects need their column classified as geography first — in the same batch is "
+                "fine: addData with dataItems [{'dataItem': 'State', 'properties': {'classification': "
+                "'geography', 'geographyDataSource': {'geographyNameCodeContext': 'USStateNames'}}}]. "
+                "For raw lat/long point data use geographyCoordinates instead: {'geographyDataSource': "
+                "{'geographyCoordinates': {'latitudeDataItem': 'LATITUDE', 'longitudeDataItem': "
+                "'LONGITUDE'}}}. See describe_report_objects(operation='addData') for the full shape."
+            )
+        return detail
+
+    not_addable_key = object_type if object_type in NOT_ADDABLE else _NORMALIZED_NOT_ADDABLE.get(normalized)
+    if not_addable_key:
+        alt = NOT_ADDABLE[not_addable_key]
+        return {
+            "status": "not_addable",
+            "object_type": object_type,
+            "nearest": alt,
+            "message": f"'{object_type}' is a VA UI object with no report-API support. Use '{alt}' instead.",
+        }
+
+    candidates = list(REPORT_OBJECT_TYPES) + list(ALIASES) + list(NOT_ADDABLE)
+    matches = difflib.get_close_matches(object_type, candidates, n=3, cutoff=0.5)
+    suggestions = list(dict.fromkeys(ALIASES.get(m, m) for m in matches))
+    return {
+        "status": "unknown_object_type",
+        "object_type": object_type,
+        "did_you_mean": suggestions,
+        "hint": "Call describe_report_objects() with no arguments to list every object type.",
+    }
+
+
+# --- normalisation --------------------------------------------------------
+
+
+def normalize_operations(operations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of *operations* with tolerant, non-semantic coercions.
+
+    * Coerces an integer ``addPage.pagePosition`` to the string index that
+      operation expects (report-placement ``pagePosition`` is the opposite: a
+      number — a digit string there is coerced to int).
+    * Translates the spec spelling ``newPage`` to the ``new_page`` the live
+      report-placement enum actually accepts.
+    * Wraps a bare column string in a list for array-valued (``multi``) data
+      roles, so ``measures="MSRP"`` works as well as ``measures=["MSRP"]``.
+    * Expands an ``addPage`` convenience ``title`` into a text object placed at
+      the top of that page's body (VA rejects text in page headers) — the
+      addPage keeps its ``pageName`` and the title text is appended as a
+      following ``addObject``.
+
+    Never raises — malformed input is caught by :func:`validate_operations`.
+    """
+    try:
+        ops = json.loads(json.dumps(operations))
+    except (TypeError, ValueError):
+        return operations
+    if not isinstance(ops, list):
+        return operations
+    out: list[dict[str, Any]] = []
+    title_ops: list[dict[str, Any]] = []
+    for op in ops:
+        if not isinstance(op, dict):
+            out.append(op)
+            continue
+        page = op.get("addPage")
+        if isinstance(page, dict):
+            position = page.get("pagePosition")
+            if isinstance(position, int) and not isinstance(position, bool):
+                page["pagePosition"] = str(position)
+            # Expand a page title into a body text band, but only when the
+            # page is named (the text object must target the page by name).
+            # Always strip the tool-only 'title' key — VA rejects unknown
+            # properties — and skip the text op for an empty title.
+            if "title" in page and page.get("pageName"):
+                title = page.pop("title")
+                if title:
+                    title_ops.append(_page_title_object(page["pageName"], str(title)))
+        add = op.get("addObject")
+        if isinstance(add, dict):
+            _normalize_roles(add.get("object"))
+            _normalize_placement(add.get("placement"))
+        out.append(op)
+    # Synthesized title ops go at the END of the batch so the caller's
+    # operation indices survive normalization — op_index in validation errors
+    # and VA's failed-at-index messages keep pointing at the caller's array.
+    # position "start" still renders the text at the top of the page body
+    # regardless of when in the batch it is applied.
+    out.extend(title_ops)
+    return out
+
+
+def _page_title_object(page_name: str, title: str) -> dict[str, Any]:
+    """Build an addObject op putting *title* text at the top of *page_name*'s body.
+
+    Page (and report) headers accept only control objects — a text placed with
+    ``context: "header"`` fails the whole atomic batch — so a page title is a
+    text band at the start of the body.
+    """
+    return {
+        "addObject": {
+            "object": {"text": {"options": {"content": title}}},
+            "placement": {"page": {"target": page_name, "context": "body", "position": "start"}},
+        }
+    }
+
+
+def _normalize_placement(placement: Any) -> None:
+    """In-place report-placement coercions: enum spelling and pagePosition typing."""
+    if not isinstance(placement, dict):
+        return
+    report = placement.get("report")
+    if not isinstance(report, dict):
+        return
+    if report.get("context") == "newPage":  # published-spec spelling; live enum is snake_case
+        report["context"] = "new_page"
+    position = report.get("pagePosition")
+    if isinstance(position, str):
+        # A non-numeric string is left for validation to reject with the typed message.
+        with contextlib.suppress(ValueError):
+            report["pagePosition"] = int(position)
+
+
+def _normalize_roles(obj: Any) -> None:
+    if not isinstance(obj, dict) or len(obj) != 1:
+        return
+    (type_key,) = obj
+    vo = REPORT_OBJECT_TYPES.get(type_key)
+    spec = obj[type_key]
+    if vo is None or not isinstance(spec, dict):
+        return
+    roles = spec.get("dataRoles")
+    if not isinstance(roles, dict):
+        return
+    multi = {r.name for r in vo.roles if r.multi}
+    for name, value in list(roles.items()):
+        if name in multi and isinstance(value, str):
+            roles[name] = [value]
+
+
+# --- validation -----------------------------------------------------------
+
+
+def _err(status: str, index: int, message: str, **extra: Any) -> dict[str, Any]:
+    return {"status": status, "op_index": index, "message": message, **extra}
+
+
+def validate_operations(operations: Any) -> dict[str, Any] | None:
+    """Return a structured error dict for the invalid operations, else None.
+
+    Enforces the rules the VA endpoints impose *before* any HTTP call: exactly
+    one known operation per array element; for ``addObject`` a known + addable
+    object type with only the spec-allowed keys, whose ``dataRoles`` are a
+    subset of that type's roles with the right list/single arity, and a valid
+    placement; for ``updateObject`` a known + updatable type with a ``name``;
+    and the required blocks for the data operations. Every invalid operation is
+    reported at once (the batch is atomic, so serial fix-one-resend loops are
+    expensive): the returned dict is the first error, carrying ``all_errors``
+    when more than one operation failed.
+    """
+    if not isinstance(operations, list) or not operations:
+        return {"status": "invalid_operation", "message": "operations must be a non-empty list of operation objects."}
+    errors = [err for i, op in enumerate(operations) for err in [_validate_one(op, i)] if err is not None]
+    if not errors:
+        return None
+    if len(errors) == 1:
+        return errors[0]
+    return {**errors[0], "error_count": len(errors), "all_errors": errors}
+
+
+def _validate_one(op: Any, i: int) -> dict[str, Any] | None:
+    if not isinstance(op, dict):
+        return _err("invalid_operation", i, "each operation must be an object.")
+    keys = [k for k in op if k in OPERATION_KEYS]
+    if not keys:
+        unknown = [k for k in op if k not in _META_OP_KEYS]
+        return _err(
+            "invalid_operation",
+            i,
+            f"no known operation key. Expected one of {sorted(OPERATION_KEYS)}.",
+            unknown_keys=unknown,
+        )
+    if len(keys) > 1:
+        return _err("invalid_operation", i, f"exactly one operation per array element; got {sorted(keys)}.")
+    stray = [k for k in op if k not in OPERATION_KEYS and k not in _META_OP_KEYS]
+    if stray:
+        return _err(
+            "invalid_operation",
+            i,
+            f"unknown key(s) {sorted(stray)} alongside '{keys[0]}' — VA rejects unrecognised "
+            f"properties; allowed meta keys: {sorted(_META_OP_KEYS)}.",
+            unknown_keys=sorted(stray),
+        )
+    key = keys[0]
+    val = op[key]
+    if key == "addObject":
+        return _validate_add_object(val, i)
+    if key == "updateObject":
+        return _validate_update_object(val, i)
+    if key == "addData":
+        err = _require_keys(val, i, "addData", ("cas",), nested={"cas": ("library", "table")})
+        # The OpenAPI spec marks cas.server optional, but live Viya rejects the
+        # whole batch without it ("Missing the required property: server").
+        if err is None and isinstance(val.get("cas"), dict) and not val["cas"].get("server"):
+            err = _err(
+                "invalid_operation",
+                i,
+                "'addData.cas' requires 'server' (the CAS server name — list_cas_servers returns "
+                "it; typically 'cas-shared-default').",
+            )
+        return err if err is not None else _validate_data_items(val, i, "addData")
+    if key == "changeData":
+        return _require_keys(val, i, "changeData", ("originalData", "replacementData"))
+    if key == "applyDataView":
+        return _require_keys(val, i, "applyDataView", ("targetData", "dataView"))
+    if key == "setParameterValue":
+        return _require_keys(val, i, "setParameterValue", ("name", "value"))
+    if key == "addPage":
+        return _validate_add_page(val, i)
+    if key == "updateData":
+        err = _require_keys(val, i, "updateData", ("data",))
+        if err is not None:
+            return err
+        data = val.get("data")
+        if not isinstance(data, dict):
+            return _err("invalid_operation", i, "'updateData.data' must be an object.")
+        return _validate_data_items(data, i, "updateData")
+    return None
+
+
+def _validate_add_page(val: Any, i: int) -> dict[str, Any] | None:
+    if not isinstance(val, dict):
+        return _err("invalid_operation", i, "'addPage' must be an object.")
+    # A title becomes a body text object targeting the page by name, so the
+    # page must be named. (When pageName is present, normalize strips the title
+    # before validation, so this only fires on the unnamed case.)
+    if "title" in val and not val.get("pageName"):
+        return _err(
+            "invalid_operation",
+            i,
+            "'addPage.title' requires 'pageName' — a page title is a text object placed at the "
+            "top of the named page's body.",
+        )
+    position = val.get("pagePosition")
+    if position is not None and (isinstance(position, bool) or not isinstance(position, (str, int))):
+        return _err(
+            "invalid_operation",
+            i,
+            "'addPage.pagePosition' must be a string index like '0' (an int is coerced for you) — "
+            "unlike the numeric report-placement pagePosition.",
+        )
+    return None
+
+
+def _validate_data_items(val: Any, i: int, op: str) -> dict[str, Any] | None:
+    """Validate the optional ``dataItems`` polish block against the spec enums."""
+    items = val.get("dataItems")
+    if items is None:
+        return None
+    if not isinstance(items, list):
+        return _err("invalid_operation", i, f"'{op}.dataItems' must be a list of {{dataItem, properties}} objects.")
+    for item in items:
+        if not isinstance(item, dict) or not item.get("dataItem"):
+            return _err(
+                "invalid_operation",
+                i,
+                f"each '{op}.dataItems' entry needs 'dataItem' (the column name) plus 'properties'.",
+            )
+        props = item.get("properties")
+        if props is None:
+            continue
+        if not isinstance(props, dict):
+            return _err("invalid_operation", i, f"'{op}.dataItems[].properties' must be an object.")
+        aggregation = props.get("aggregation")
+        if aggregation is not None and aggregation not in AGGREGATIONS:
+            return _err(
+                "invalid_operation",
+                i,
+                f"unknown aggregation '{aggregation}' for data item '{item['dataItem']}'.",
+                valid_values=sorted(AGGREGATIONS),
+            )
+        fmt = props.get("format")
+        if fmt is not None and (not isinstance(fmt, str) or not _SAS_FORMAT_RE.match(fmt)):
+            return _err(
+                "invalid_operation",
+                i,
+                f"format '{fmt}' is not a named SAS format — VA rejects bare numeric w.d forms "
+                f"(and the whole atomic batch with them). Use e.g. DOLLAR12.2, COMMA10., "
+                f"PERCENT8.1, DATE9.",
+            )
+        classification = props.get("classification")
+        if classification is not None and classification not in CLASSIFICATIONS:
+            return _err(
+                "invalid_operation",
+                i,
+                f"unknown classification '{classification}' for data item '{item['dataItem']}'.",
+                valid_values=sorted(CLASSIFICATIONS),
+            )
+        geo = props.get("geographyDataSource")
+        if geo is not None:
+            if classification != "geography":
+                return _err(
+                    "invalid_operation",
+                    i,
+                    "'geographyDataSource' is only allowed together with classification 'geography'.",
+                )
+            if not isinstance(geo, dict):
+                return _err(
+                    "invalid_operation",
+                    i,
+                    "'geographyDataSource' must be an object, e.g. "
+                    "{'geographyNameCodeContext': 'USStateNames'}.",
+                )
+            if isinstance(geo, dict):
+                unknown = sorted(set(geo) - GEO_SOURCE_KEYS)
+                if unknown:
+                    return _err(
+                        "invalid_operation",
+                        i,
+                        f"unknown geographyDataSource key(s) {unknown} — for lat/long point data "
+                        f"use geographyCoordinates: {{'latitudeDataItem': '<col>', "
+                        f"'longitudeDataItem': '<col>'}}.",
+                        valid_keys=sorted(GEO_SOURCE_KEYS),
+                    )
+                context = geo.get("geographyNameCodeContext")
+                if context is not None and context not in GEO_NAME_CODE_CONTEXTS:
+                    return _err(
+                        "invalid_operation",
+                        i,
+                        f"unknown geographyNameCodeContext '{context}'.",
+                        valid_values=sorted(GEO_NAME_CODE_CONTEXTS),
+                    )
+                coordinates = geo.get("geographyCoordinates")
+                if coordinates is not None:
+                    if context is not None:
+                        return _err(
+                            "invalid_operation",
+                            i,
+                            "geographyDataSource takes geographyNameCodeContext OR "
+                            "geographyCoordinates, not both.",
+                        )
+                    if not isinstance(coordinates, dict) or not (
+                        coordinates.get("latitudeDataItem") and coordinates.get("longitudeDataItem")
+                    ):
+                        return _err(
+                            "invalid_operation",
+                            i,
+                            "'geographyCoordinates' requires 'latitudeDataItem' and "
+                            "'longitudeDataItem' (column names or labels).",
+                        )
+    return None
+
+
+def _require_keys(
+    val: Any, i: int, op: str, keys: tuple[str, ...], nested: dict[str, tuple[str, ...]] | None = None
+) -> dict[str, Any] | None:
+    if not isinstance(val, dict):
+        return _err("invalid_operation", i, f"'{op}' must be an object.")
+    for k in keys:
+        if k not in val:
+            return _err("invalid_operation", i, f"'{op}' requires '{k}'.")
+    for parent, children in (nested or {}).items():
+        block = val.get(parent)
+        if not isinstance(block, dict):
+            return _err("invalid_operation", i, f"'{op}.{parent}' must be an object.")
+        for c in children:
+            if c not in block:
+                return _err("invalid_operation", i, f"'{op}.{parent}' requires '{c}'.")
+    return None
+
+
+def _single_type(container: Any, i: int, op: str) -> tuple[str, Any] | dict[str, Any]:
+    """Extract the single ``{<type>: spec}`` pair, or an error dict."""
+    if not isinstance(container, dict) or len(container) != 1:
+        return _err(
+            "invalid_operation", i, f"'{op}.object' must name exactly one object type, e.g. {{'barChart': {{...}}}}."
+        )
+    (type_key,) = container
+    return type_key, container[type_key]
+
+
+def _resolve_type(type_key: str, i: int, *, for_update: bool) -> dict[str, Any] | None:
+    """Return an error dict if *type_key* can't be added/updated, else None."""
+    obj = REPORT_OBJECT_TYPES.get(type_key)
+    if obj is None:
+        if type_key in NOT_ADDABLE:
+            alt = NOT_ADDABLE[type_key]
+            return _err(
+                "not_addable",
+                i,
+                f"'{type_key}' is a VA UI object with no report-API support. Use '{alt}'.",
+                object_type=type_key,
+                nearest=alt,
+            )
+        return _err(
+            "unknown_object_type",
+            i,
+            f"unknown object type '{type_key}'.",
+            object_type=type_key,
+            did_you_mean=difflib.get_close_matches(type_key, REPORT_OBJECT_TYPES, n=3, cutoff=0.5),
+        )
+    if for_update and not obj.updatable:
+        return _err(
+            "not_updatable", i, f"'{type_key}' cannot be updated via the API (it is add-only).", object_type=type_key
+        )
+    if not for_update and not obj.addable:
+        return _err(
+            "not_addable", i, f"'{type_key}' cannot be added via the API (it is update-only).", object_type=type_key
+        )
+    return None
+
+
+# VA enforces additionalProperties:false on every object spec: an unknown key
+# (including a caller-supplied 'name') fails the whole atomic batch with an HTTP
+# 400 — catch it pre-flight instead. standardContainer is stricter still: it
+# accepts NO properties at add time, not even 'options'.
+_OBJECT_SPEC_ALLOWED_KEYS = frozenset({"dataSource", "dataRoles", "options"})
+
+
+def _validate_object_spec_keys(type_key: str, spec: Any, i: int) -> dict[str, Any] | None:
+    if not isinstance(spec, dict):
+        return None  # shape errors are reported by _validate_roles
+    if type_key == "standardContainer":
+        if spec:
+            return _err(
+                "invalid_object_spec",
+                i,
+                "standardContainer accepts no properties at add time (VA rejects even 'options'); "
+                "add it bare ({}) and set its title via a follow-up updateObject using the name "
+                "the apply returns.",
+                object_type=type_key,
+            )
+        return None
+    extras = sorted(set(spec) - _OBJECT_SPEC_ALLOWED_KEYS)
+    if extras:
+        if "name" in extras:
+            return _err(
+                "invalid_object_spec",
+                i,
+                "objects are auto-named by VA — 'name' is not allowed at add time; use the name "
+                "the apply result returns (or get_report_outline) to reference the object later.",
+                object_type=type_key,
+                unknown_keys=extras,
+            )
+        return _err(
+            "invalid_object_spec",
+            i,
+            f"'{type_key}' does not accept {extras}; allowed keys: "
+            f"{sorted(_OBJECT_SPEC_ALLOWED_KEYS)}.",
+            object_type=type_key,
+            unknown_keys=extras,
+        )
+    return None
+
+
+def _validate_add_object(val: Any, i: int) -> dict[str, Any] | None:
+    if not isinstance(val, dict):
+        return _err("invalid_operation", i, "'addObject' must be an object.")
+    has_object = "object" in val
+    has_report_object = "reportObject" in val
+    if has_object and has_report_object:
+        return _err("invalid_operation", i, "'addObject' takes object OR reportObject, not both.")
+    if not has_object and not has_report_object:
+        return _err("invalid_operation", i, "'addObject' requires 'object' or 'reportObject'.")
+    if has_report_object:
+        # Adding a pre-existing object by reference — the object itself needs
+        # no validation, but its placement still does.
+        return _validate_placement(val.get("placement"), i)
+
+    extracted = _single_type(val["object"], i, "addObject")
+    if isinstance(extracted, dict):
+        return extracted
+    type_key, spec = extracted
+    resolved = _resolve_type(type_key, i, for_update=False)
+    if resolved is not None:
+        return resolved
+    keys_err = _validate_object_spec_keys(type_key, spec, i)
+    if keys_err is not None:
+        return keys_err
+    roles_err = _validate_roles(REPORT_OBJECT_TYPES[type_key], spec, i)
+    if roles_err is not None:
+        return roles_err
+    placement_err = _validate_placement(val.get("placement"), i)
+    if placement_err is not None:
+        return placement_err
+    return _validate_header_placement(type_key, val.get("placement"), i)
+
+
+def _validate_header_placement(type_key: str, placement: Any, i: int) -> dict[str, Any] | None:
+    """Page/report headers accept ONLY control objects — enforce it pre-flight.
+
+    VA rejects anything else with "Only control objects are supported in the
+    page header" and rolls back the whole atomic batch.
+    """
+    if not isinstance(placement, dict):
+        return None
+    for variant in ("page", "report"):
+        inner = placement.get(variant)
+        if isinstance(inner, dict) and inner.get("context") == "header":
+            obj = REPORT_OBJECT_TYPES.get(type_key)
+            if obj is not None and obj.category != "Controls":
+                return _err(
+                    "invalid_placement",
+                    i,
+                    f"the {variant} header accepts ONLY control objects (dropdownList, buttonBar, "
+                    f"slider, ...); '{type_key}' ({obj.category}) belongs in the body — a title is "
+                    "a text object placed with context 'body', position 'start'.",
+                    object_type=type_key,
+                )
+    return None
+
+
+def _validate_placement(placement: Any, i: int) -> dict[str, Any] | None:
+    """Validate an addObject ``placement`` block, or None if valid/absent."""
+    if placement is None:
+        return None
+    if not isinstance(placement, dict) or len(placement) != 1:
+        return _err(
+            "invalid_placement",
+            i,
+            f"placement must name exactly one of {list(PLACEMENT_VARIANTS)}.",
+            valid_variants=list(PLACEMENT_VARIANTS),
+        )
+    (variant,) = placement
+    if variant not in PLACEMENT_VARIANTS:
+        return _err(
+            "invalid_placement",
+            i,
+            f"unknown placement variant '{variant}'.",
+            valid_variants=list(PLACEMENT_VARIANTS),
+        )
+    inner = placement[variant]
+    if not isinstance(inner, dict):
+        return _err("invalid_placement", i, f"placement.{variant} must be an object.")
+    extras = sorted(set(inner) - _PLACEMENT_ALLOWED_KEYS[variant])
+    if extras:
+        return _err(
+            "invalid_placement",
+            i,
+            f"placement.{variant} does not accept {extras}; allowed keys: "
+            f"{sorted(_PLACEMENT_ALLOWED_KEYS[variant])}.",
+            unknown_keys=extras,
+        )
+    if variant in _PLACEMENT_TARGET_REQUIRED and not inner.get("target"):
+        return _err(
+            "invalid_placement",
+            i,
+            f"placement.{variant} requires 'target' (the name of the {variant} to place against).",
+        )
+    for field_name, allowed in _PLACEMENT_ENUMS.get(variant, {}).items():
+        value = inner.get(field_name)
+        if value is not None and value not in allowed:
+            return _err(
+                "invalid_placement",
+                i,
+                f"placement.{variant}.{field_name} must be one of {sorted(allowed)}; got '{value}'.",
+                valid_values=sorted(allowed),
+            )
+    if variant == "report":
+        page_name = inner.get("pageName")
+        if page_name is not None and (not isinstance(page_name, str) or not page_name.strip()):
+            return _err("invalid_placement", i, "placement.report.pageName must be a non-empty string.")
+        page_position = inner.get("pagePosition")
+        if page_position is not None and (
+            isinstance(page_position, bool) or not isinstance(page_position, (int, float))
+        ):
+            return _err(
+                "invalid_placement",
+                i,
+                "placement.report.pagePosition must be a NUMBER (0 puts the new page first) — "
+                "unlike addPage.pagePosition, which is a string.",
+            )
+    return None
+
+
+def _validate_update_object(val: Any, i: int) -> dict[str, Any] | None:
+    if not isinstance(val, dict) or "object" not in val:
+        return _err("invalid_operation", i, "'updateObject' requires 'object'.")
+    extracted = _single_type(val["object"], i, "updateObject")
+    if isinstance(extracted, dict):
+        return extracted
+    type_key, spec = extracted
+    resolved = _resolve_type(type_key, i, for_update=True)
+    if resolved is not None:
+        return resolved
+    if not isinstance(spec, dict) or not spec.get("name"):
+        return _err(
+            "invalid_operation",
+            i,
+            f"'updateObject.object.{type_key}' requires 'name' (the existing object's name or label).",
+        )
+    extras = sorted(set(spec) - {"name", "options"})
+    if extras:
+        return _err(
+            "invalid_object_spec",
+            i,
+            f"'updateObject.object.{type_key}' does not accept {extras} — updates can change only "
+            "'options' (placement and dataRoles are write-once; there is no move/re-role).",
+            object_type=type_key,
+            unknown_keys=extras,
+        )
+    return None
+
+
+def _validate_roles(obj: VaObject, spec: Any, i: int) -> dict[str, Any] | None:
+    if not isinstance(spec, dict):
+        return _err("invalid_operation", i, f"'{obj.schema_key}' must be an object.")
+    roles = spec.get("dataRoles")
+    if roles is None:
+        return None
+    if not isinstance(roles, dict):
+        return _err(
+            "invalid_roles",
+            i,
+            f"'{obj.schema_key}.dataRoles' must be an object of role -> column.",
+            object_type=obj.schema_key,
+            valid_roles=list(obj.role_names),
+        )
+    by_name = {r.name: r for r in obj.roles}
+    for name, value in roles.items():
+        spec_role = by_name.get(name)
+        if spec_role is None:
+            return _err(
+                "invalid_roles",
+                i,
+                f"'{name}' is not a role of {obj.schema_key}.",
+                object_type=obj.schema_key,
+                valid_roles=list(obj.role_names),
+            )
+        if not spec_role.multi and isinstance(value, list):
+            return _err(
+                "invalid_roles",
+                i,
+                f"role '{name}' on {obj.schema_key} takes a single column, not a list.",
+                object_type=obj.schema_key,
+            )
+    return None
+
+
+def warn_operations(operations: list[dict[str, Any]]) -> list[str]:
+    """Return non-blocking warnings for render risks the API accepts silently.
+
+    The OpenAPI spec marks every data role optional, so these are advisory: an
+    object can pass validation (and the VA PUT) yet render blank without its
+    usual roles, and multiple content-bearing texts can collapse onto one
+    element on affected Viya builds.
+    """
+    warnings: list[str] = []
+    if not isinstance(operations, list):
+        return warnings
+    content_texts = 0
+    page_stacked: dict[str, int] = {}
+    for op in operations:
+        if not isinstance(op, dict):
+            continue
+        add = op.get("addObject")
+        if not isinstance(add, dict) or "object" not in add:
+            continue
+        placement = add.get("placement")
+        if isinstance(placement, dict):
+            page = placement.get("page")
+            report = placement.get("report")
+            if isinstance(page, dict) and page.get("context") != "header":
+                target = str(page.get("target"))
+                page_stacked[target] = page_stacked.get(target, 0) + 1
+            elif isinstance(report, dict) and report.get("pageName"):
+                target = str(report["pageName"])
+                page_stacked[target] = page_stacked.get(target, 0) + 1
+        container = add["object"]
+        if not isinstance(container, dict) or len(container) != 1:
+            continue
+        (type_key,) = container
+        spec = container[type_key]
+        if type_key == "text" and isinstance(spec, dict):
+            options = spec.get("options")
+            if isinstance(options, dict) and options.get("content"):
+                content_texts += 1
+        obj = REPORT_OBJECT_TYPES.get(type_key)
+        if obj is None:
+            continue
+        provided = set()
+        if isinstance(spec, dict) and isinstance(spec.get("dataRoles"), dict):
+            provided = set(spec["dataRoles"])
+        missing = [r for r in obj.commonly_required if r not in provided]
+        if missing:
+            warnings.append(f"{type_key} usually needs role(s) {missing}; none provided — it may render empty.")
+        for group in obj.render_required:
+            if not any(role in provided for role in group):
+                warnings.append(
+                    f"{type_key} renders EMPTY without one of {list(group)} — the API does not "
+                    f"auto-apply Frequency the way the VA UI does; add a measure (a count/flag "
+                    f"column works)."
+                )
+    if content_texts >= 2:
+        warnings.append(
+            f"This batch creates {content_texts} content-bearing text objects; some Viya builds "
+            f"misroute text options.content onto the report's FIRST text element (add and update "
+            f"alike). Prefer one content-bearing text per report — e.g. title at most one page — "
+            f"and check the result's text_content_warning / get_report_outline after applying."
+        )
+    for target, count in page_stacked.items():
+        if count >= 4:
+            warnings.append(
+                f"{count} objects are page-placed onto '{target}' — the page body auto-flows "
+                f"VERTICALLY, so they will render as one tall stack. Put KPI tiles side by side "
+                f"in a standardContainer and arrange charts in rows with relativeToObject "
+                f"left/right (see describe_report_objects layout_recipes)."
+            )
+    return warnings
+
+
+# --- request shaping ------------------------------------------------------
+
+
+@dataclass
+class CreateReportRequest:
+    """A normalised ``create_report`` invocation."""
+
+    name: str
+    folder: str | None = None
+    on_conflict: str = "rename"
+    operations: list[dict[str, Any]] | None = field(default=None)
+
+
+def validate_create(req: CreateReportRequest) -> dict[str, Any] | None:
+    """Validate a create request (name, conflict policy, any inline operations)."""
+    if not req.name or not str(req.name).strip():
+        return {"status": "invalid_request", "message": "create_report requires a non-empty name."}
+    if req.on_conflict not in CONFLICT_VALUES:
+        return {
+            "status": "invalid_request",
+            "message": f"on_conflict must be one of {sorted(CONFLICT_VALUES)}.",
+            "on_conflict": req.on_conflict,
+        }
+    if req.operations:
+        return validate_operations(req.operations)
+    return None
+
+
+def build_create_body(req: CreateReportRequest) -> dict[str, Any]:
+    """Build the POST /visualAnalytics/reports request body."""
+    body: dict[str, Any] = {"resultReportName": req.name, "resultNameConflict": req.on_conflict}
+    if req.folder:
+        body["resultFolder"] = req.folder
+    if req.operations:
+        body["operations"] = req.operations
+    return body
+
+
+def summarize_created(operations: list[dict[str, Any]], response: dict[str, Any]) -> dict[str, Any]:
+    """Summarise what an operations batch created, from the request (+ response).
+
+    Reads the requested pages/objects/data sources from *operations* so the
+    result is deterministic regardless of the PUT response shape, then merges
+    the per-operation response entries **by index** — the VA response
+    ``operations`` array is a strict 1:1 mapping of the request array (failed
+    entries keep their slot). Each entry carries ``name`` (the handle placement
+    targets and updateObject consume, e.g. ``ve15``), ``label`` (the display
+    label ``export_report`` consumes, e.g. ``Text 2``), and ``status``.
+    """
+    pages: list[dict[str, Any]] = []
+    objects: list[dict[str, Any]] = []
+    data_sources: list[dict[str, Any]] = []
+    slots: list[dict[str, Any] | None] = []
+    for op in operations or []:
+        record: dict[str, Any] | None = None
+        if isinstance(op, dict):
+            if "addPage" in op:
+                page = op["addPage"] if isinstance(op["addPage"], dict) else {}
+                # The response name is the internal section name (vi*); the
+                # label is the requested pageName — what page placement targets.
+                record = {"label": page.get("pageName")}
+                pages.append(record)
+            elif "addData" in op and isinstance(op["addData"], dict):
+                add = op["addData"]
+                cas = add.get("cas", {}) if isinstance(add.get("cas"), dict) else {}
+                record = {"name": add.get("name") or cas.get("table")}
+                data_sources.append(record)
+            elif "addObject" in op and isinstance(op["addObject"], dict):
+                container = op["addObject"].get("object")
+                if isinstance(container, dict) and len(container) == 1:
+                    (type_key,) = container
+                    record = {
+                        "type": type_key,
+                        "page": _placement_page(op["addObject"].get("placement")),
+                        "placement": op["addObject"].get("placement"),
+                    }
+                    objects.append(record)
+        slots.append(record)
+    _merge_response_results(slots, response)
+    return {"pages": pages, "objects": objects, "dataSources": data_sources}
+
+
+def _placement_page(placement: Any) -> str | None:
+    if not isinstance(placement, dict):
+        return None
+    page = placement.get("page")
+    if isinstance(page, dict):
+        return page.get("target")
+    report = placement.get("report")
+    if isinstance(report, dict):
+        return report.get("pageName")
+    return None
+
+
+def _merge_response_results(slots: list[dict[str, Any] | None], response: dict[str, Any]) -> None:
+    """Merge per-operation response entries onto the request records by index."""
+    if not isinstance(response, dict):
+        return
+    results = response.get("operations") or response.get("operationResponses")
+    if not isinstance(results, list):
+        return
+    # Index-aligned 1:1 with the request array; strict=False tolerates a
+    # response the server truncated.
+    for record, entry in zip(slots, results, strict=False):
+        if record is None or not isinstance(entry, dict):
+            continue
+        for key in ("name", "label", "status"):
+            # Request-provided values win, but a pre-seeded None (e.g. an
+            # unnamed addPage's label) must not block the response value.
+            if entry.get(key) is not None and record.get(key) is None:
+                record[key] = entry[key]
+        if entry.get("messages"):
+            record["messages"] = entry["messages"]
+
+
+def parse_failure(response_text: str) -> dict[str, Any]:
+    """Extract structured per-operation failure details from a VA error body.
+
+    A rejected batch echoes the ``operations`` array with the failing entry at
+    its request index carrying ``status: Failed/Invalid`` plus ``messages``;
+    top-level ``messages`` name the failing index. Returns ``{}`` when the body
+    is not parseable JSON in that shape.
+    """
+    try:
+        data = json.loads(response_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, Any] = {}
+    results = data.get("operations") or data.get("operationResponses")
+    if isinstance(results, list):
+        failed = [
+            {"op_index": i, "status": entry.get("status"), "messages": entry.get("messages")}
+            for i, entry in enumerate(results)
+            if isinstance(entry, dict) and entry.get("status") not in (None, "Success")
+        ]
+        if failed:
+            out["failed_operations"] = failed
+            out["failed_operation_index"] = failed[0]["op_index"]
+    if isinstance(data.get("messages"), list):
+        out["viya_messages"] = data["messages"]
+    return out
+
+
+# --- execution ------------------------------------------------------------
+
+
+def viewer_url(report_id: Any) -> str | None:
+    """A ready-to-open VA viewer deep link — the deliverable of every build."""
+    if not report_id:
+        return None
+    return f"{VIYA_ENDPOINT}/SASVisualAnalytics/?reportUri=/reports/reports/{report_id}"
+
+
+def _expected_text_pairs(
+    operations: list[dict[str, Any]], created_objects: list[dict[str, Any]]
+) -> list[tuple[str, str]]:
+    """(created ve-name, intended content) for each content-bearing text op.
+
+    Paired op-by-op: every text op consumes one created text record (matching
+    summarize_created's selection), whether or not it carries content — two
+    independently filtered lists would shift against each other whenever a
+    content-less text precedes a content-bearing one, producing false
+    misroute warnings.
+    """
+    text_records = iter([o for o in created_objects if o.get("type") == "text"])
+    pairs: list[tuple[str, str]] = []
+    for op in operations or []:
+        if not isinstance(op, dict) or not isinstance(op.get("addObject"), dict):
+            continue
+        container = op["addObject"].get("object")
+        if not isinstance(container, dict) or len(container) != 1 or "text" not in container:
+            continue
+        record = next(text_records, None)
+        if record is None:
+            break
+        spec = container["text"]
+        options = spec.get("options") if isinstance(spec, dict) else None
+        content = options.get("content") if isinstance(options, dict) else None
+        if isinstance(content, str) and record.get("name"):
+            pairs.append((record["name"], content))
+    return pairs
+
+
+async def check_text_contents(
+    report_id: Any,
+    operations: list[dict[str, Any]],
+    created_objects: list[dict[str, Any]],
+    client: httpx.AsyncClient,
+) -> str | None:
+    """Best-effort post-apply check that text contents landed on their elements.
+
+    Some Viya builds misroute text ``options.content`` onto the report's FIRST
+    text element (on add AND update), silently shipping wrong titles. One cheap
+    content GET catches it; returns a warning string on mismatch, else None.
+    Never raises.
+    """
+    try:
+        pairs = _expected_text_pairs(operations, created_objects)
+        if not pairs or not report_id:
+            return None
+        resp = await client.get(
+            f"{VIYA_ENDPOINT}{CONTENT_PATH.format(report_id=report_id)}",
+            headers={"Accept": CONTENT_ACCEPT},
+        )
+        if resp.status_code >= 400:
+            return None
+        outline = reduce_content_outline(_response_json_dict(resp))
+        actual = {
+            obj["name"]: obj.get("text")
+            for page in outline.get("pages", [])
+            for obj in page.get("objects", [])
+            if obj.get("name")
+        }
+        mismatched = [
+            f"'{content}' was meant for {name}, which holds {actual.get(name)!r}"
+            for name, content in pairs
+            if (actual.get(name) or "").strip() != content.strip()
+        ]
+        if mismatched:
+            return (
+                "Text content check FAILED — this Viya build misroutes text options.content onto "
+                "the report's first text element: " + "; ".join(mismatched) + ". Keep one "
+                "content-bearing text per report (title at most one page), or set contents via "
+                "the report content endpoint."
+            )
+        return None
+    except Exception:  # noqa: BLE001 - verification must never break the apply
+        return None
+
+
+def _response_json_dict(resp: httpx.Response) -> dict[str, Any]:
+    """The response body as a dict — {} for empty, non-JSON, or non-object bodies."""
+    if not resp.content:
+        return {}
+    try:
+        data = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _verify_hint(report_id: Any, created: dict[str, Any]) -> str | None:
+    """A next-step suggestion so authoring agents close the see-what-you-built loop."""
+    if not created.get("pages") and not created.get("objects"):
+        return None
+    labels = [p.get("label") or p.get("name") for p in created.get("pages", [])]
+    page = next((label for label in labels if label), "<page label>")
+    return (
+        f"To see the result: export_report('{report_id}', 'png', report_objects=['{page}'], "
+        "image_size='1200px,800px') — export page-by-page (whole-report png can render blank); "
+        "get_report_outline returns the structure with the names/labels to target in follow-ups."
+    )
+
+
+async def execute_create(req: CreateReportRequest, client: httpx.AsyncClient) -> dict[str, Any]:
+    """POST a create request and return ``{status, id, name}`` (or a failure dict)."""
+    body = build_create_body(req)
+    resp = await client.post(
+        f"{VIYA_ENDPOINT}{CREATE_PATH}",
+        content=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    if resp.status_code >= 400:
+        return {
+            "status": "create_failed",
+            "name": req.name,
+            "http_status": resp.status_code,
+            "message": (
+                f"Viya rejected the report creation (HTTP {resp.status_code}). A name "
+                f"conflict policy of '{req.on_conflict}' with an existing name can cause this. "
+                f"Viya said: {resp.text[:400] or '(no response body)'}"
+            ),
+            **parse_failure(resp.text),
+        }
+    data = _response_json_dict(resp)
+    report_id = data.get("resultReportId") or data.get("id")
+    result: dict[str, Any] = {
+        "status": "created",
+        "id": report_id,
+        "name": data.get("resultReportName") or req.name,
+    }
+    url = viewer_url(report_id)
+    if url:
+        result["open_url"] = url
+    if req.operations:
+        created = summarize_created(req.operations, data)
+        result["created"] = created
+        if created.get("pages"):
+            result["note"] = (
+                'VA prepends an empty default "Page 1" before pages added at creation, so '
+                "whole-report exports can render blank — verify page-by-page."
+            )
+        hint = _verify_hint(report_id, created)
+        if hint:
+            result["verify_hint"] = hint
+        text_warning = await check_text_contents(report_id, req.operations, created.get("objects", []), client)
+        if text_warning:
+            result["text_content_warning"] = text_warning
+    return result
+
+
+async def _read_etag(report_id: str, client: httpx.AsyncClient) -> str:
+    resp = await client.get(
+        f"{VIYA_ENDPOINT}{ETAG_PATH.format(report_id=report_id)}",
+        headers={"Accept": "application/json"},
+    )
+    resp.raise_for_status()
+    return resp.headers.get("etag", "")
+
+
+async def execute_operations(
+    report_id: str,
+    operations: list[dict[str, Any]],
+    client: httpx.AsyncClient,
+    response_format: str = "concise",
+    retries: int = 1,
+    result_report_name: str | None = None,
+    result_folder: str | None = None,
+    result_name_conflict: str = "rename",
+) -> dict[str, Any]:
+    """Apply a *validated* operations array with the ETag round-trip + 412 retry.
+
+    Reads the report's current ETag, PUTs the operations with ``If-Match``, and
+    on a 412 (a concurrent edit moved the ETag) transparently re-reads and
+    retries once. HTTP >= 400 is surfaced as a structured ``apply_failed`` dict
+    (with the per-operation failure details parsed out of the VA body) rather
+    than raised; a missing report as ``not_found``.
+
+    Passing ``result_report_name`` and/or ``result_folder`` switches the PUT to
+    *save-as* mode: the operations are applied to a NEW report (HTTP 201) and
+    the source report is left untouched — atomic template instantiation.
+    """
+    body: dict[str, Any] = {"operations": operations}
+    save_as = bool(result_report_name or result_folder)
+    if save_as:
+        if result_report_name:
+            body["resultReportName"] = result_report_name
+        if result_folder:
+            body["resultFolder"] = result_folder
+        body["resultNameConflict"] = result_name_conflict
+    payload = json.dumps(body).encode()
+    url = f"{VIYA_ENDPOINT}{OPERATIONS_PATH.format(report_id=report_id)}"
+    attempt = 0
+    while True:
+        try:
+            etag = await _read_etag(report_id, client)
+        except httpx.HTTPStatusError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return {"status": "not_found", "report_id": report_id, "message": f"No report with id '{report_id}'."}
+            raise
+        resp = await client.put(
+            url,
+            content=payload,
+            headers={
+                "If-Match": etag,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+        if resp.status_code == 412 and attempt < retries:
+            attempt += 1
+            continue
+        break
+
+    if resp.status_code >= 400:
+        return {
+            "status": "apply_failed",
+            "report_id": report_id,
+            "http_status": resp.status_code,
+            "message": (
+                f"Viya rejected the operations (HTTP {resp.status_code}). The whole batch is "
+                f"atomic, so the report is unchanged. See failed_operations for the failing "
+                f"index and Viya's reasons; fix those operations and resend the batch. "
+                f"Viya said: {resp.text[:400] or '(no response body)'}"
+            ),
+            **parse_failure(resp.text),
+        }
+
+    data = _response_json_dict(resp)
+    created = summarize_created(operations, data)
+    result: dict[str, Any] = {
+        "status": "applied",
+        "report_id": report_id,
+        "created": created,
+    }
+    verify_target: Any = report_id
+    if save_as:
+        result["saved_as"] = {
+            "id": data.get("resultReportId"),
+            "name": data.get("resultReportName") or result_report_name,
+        }
+        result["message"] = "Save-as: operations were applied to a NEW report; the source report is unchanged."
+        verify_target = result["saved_as"]["id"] or report_id
+        saved_url = viewer_url(result["saved_as"]["id"])
+        if saved_url:
+            result["saved_as"]["open_url"] = saved_url
+    url = viewer_url(verify_target)
+    if url:
+        result["open_url"] = url
+    hint = _verify_hint(verify_target, created)
+    if hint:
+        result["verify_hint"] = hint
+    text_warning = await check_text_contents(verify_target, operations, created.get("objects", []), client)
+    if text_warning:
+        result["text_content_warning"] = text_warning
+    if response_format == "detailed":
+        result["response"] = data
+    return result
+
+
+# --- report outline (read-back) --------------------------------------------
+
+
+def reduce_content_outline(content: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a BIRD report-content document to ``pages -> objects`` handles.
+
+    Returns exactly what the authoring tools consume: per page the internal
+    section name (``vi*``) and its label, and per object the visual-element
+    name (``ve*`` — the relativeToObject/container/updateObject target), its
+    label (the ``export_report`` handle), its type, and any text content.
+    """
+    elements: dict[str, dict[str, Any]] = {}
+    for element in content.get("visualElements") or []:
+        if isinstance(element, dict) and element.get("name"):
+            elements[element["name"]] = element
+    pages: list[dict[str, Any]] = []
+    view = content.get("view")
+    sections = view.get("sections") if isinstance(view, dict) else None
+    for section in sections or []:
+        if not isinstance(section, dict):
+            continue
+        page: dict[str, Any] = {"name": section.get("name"), "label": section.get("label"), "objects": []}
+        seen: set[str] = set()
+        queue: list[tuple[str, str | None]] = []
+        # Walk the whole section (header band + body) so header controls
+        # appear in the outline too.
+        _collect_refs(section, queue)
+        while queue:
+            ref, parent = queue.pop(0)
+            if ref in seen:
+                continue
+            seen.add(ref)
+            obj: dict[str, Any] = {"name": ref}
+            element = elements.get(ref)
+            if isinstance(element, dict):
+                obj["type"] = element.get("@element")
+                obj["label"] = element.get("labelAttribute")
+                text = _text_content(element)
+                if text:
+                    obj["text"] = text
+                # Containers hold their children in their own element entry.
+                _collect_refs(element, queue, parent=ref)
+            if parent:
+                obj["container"] = parent
+            page["objects"].append(obj)
+        pages.append(page)
+    return {"pages": pages}
+
+
+def _collect_refs(node: Any, out: list[tuple[str, str | None]], parent: str | None = None) -> None:
+    """Collect (ref, enclosing-container-ref) pairs from a layout tree, in order.
+
+    Children of an implicit layout container (VA auto-creates one for geometric
+    relativeToObject placements) are nested INSIDE the Container entry of the
+    section body — the walk must descend through every entry, not just the top
+    ``containedElementList`` — and carrying the enclosing ref lets the outline
+    show which container each object sits in.
+    """
+    if isinstance(node, dict):
+        ref = node.get("ref") if node.get("@element") in ("Visual", "Container") else None
+        if ref:
+            out.append((ref, parent))
+        for value in node.values():
+            _collect_refs(value, out, parent=ref or parent)
+    elif isinstance(node, list):
+        for value in node:
+            _collect_refs(value, out, parent=parent)
+
+
+def _text_content(element: dict[str, Any]) -> str | None:
+    """Join the TextString fragments of a Text element's paragraphList."""
+    texts: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            text = node.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(element.get("paragraphList"))
+    return " ".join(texts) if texts else None
+
+
+async def execute_outline(report_id: str, client: httpx.AsyncClient) -> dict[str, Any]:
+    """GET the stored report definition and return the compact page/object outline."""
+    resp = await client.get(
+        f"{VIYA_ENDPOINT}{CONTENT_PATH.format(report_id=report_id)}",
+        headers={"Accept": CONTENT_ACCEPT},
+    )
+    if resp.status_code == 404:
+        return {"status": "not_found", "report_id": report_id, "message": f"No report with id '{report_id}'."}
+    if resp.status_code >= 400:
+        return {
+            "status": "outline_failed",
+            "report_id": report_id,
+            "http_status": resp.status_code,
+            "message": (
+                f"Viya rejected the content read (HTTP {resp.status_code}). "
+                f"Viya said: {resp.text[:400] or '(no response body)'}"
+            ),
+        }
+    try:
+        data = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        return {"status": "outline_failed", "report_id": report_id, "message": "content endpoint returned non-JSON."}
+    outline = reduce_content_outline(data if isinstance(data, dict) else {})
+    result = {
+        "status": "ok",
+        "report_id": report_id,
+        **outline,
+        "hint": (
+            "Object 'name' (ve*) is the handle for relativeToObject/container placement and "
+            "updateObject; 'label' is what export_report report_objects takes; a page's 'label' "
+            "is the page-placement target; 'container' names the enclosing container element."
+        ),
+    }
+    url = viewer_url(report_id)
+    if url:
+        result["open_url"] = url
+    return result
+
+
+def validate_copy(name: str | None, on_conflict: str) -> dict[str, Any] | None:
+    """Validate a copy request (optional new name, conflict policy)."""
+    if name is not None and not str(name).strip():
+        return {"status": "invalid_request", "message": "copy_report name, if given, must be non-empty."}
+    if on_conflict not in CONFLICT_VALUES:
+        return {
+            "status": "invalid_request",
+            "message": f"on_conflict must be one of {sorted(CONFLICT_VALUES)}.",
+            "on_conflict": on_conflict,
+        }
+    return None
+
+
+def build_copy_body(name: str | None, folder: str | None, on_conflict: str) -> dict[str, Any]:
+    """Build the PUT /visualAnalytics/reports/{id}/copy request body."""
+    body: dict[str, Any] = {"resultNameConflict": on_conflict}
+    if name:
+        body["resultReportName"] = name
+    if folder:
+        body["resultFolder"] = folder
+    return body
+
+
+async def execute_copy(
+    report_id: str,
+    name: str | None,
+    folder: str | None,
+    on_conflict: str,
+    client: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Copy a report and return ``{status, id, name, source_report_id}``.
+
+    The copy endpoint mints a new report, so no ETag/If-Match is needed. HTTP
+    errors surface as structured ``not_found`` / ``copy_failed`` dicts.
+    """
+    body = build_copy_body(name, folder, on_conflict)
+    resp = await client.put(
+        f"{VIYA_ENDPOINT}{COPY_PATH.format(report_id=report_id)}",
+        content=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    if resp.status_code == 404:
+        return {"status": "not_found", "report_id": report_id,
+                "message": f"No report with id '{report_id}' to copy."}
+    if resp.status_code >= 400:
+        return {
+            "status": "copy_failed",
+            "source_report_id": report_id,
+            "http_status": resp.status_code,
+            "message": (
+                f"Viya rejected the copy (HTTP {resp.status_code}). A name conflict policy "
+                f"of '{on_conflict}' with an existing name can cause this. "
+                f"Viya said: {resp.text[:400] or '(no response body)'}"
+            ),
+        }
+    data = _response_json_dict(resp)
+    copy_id = data.get("resultReportId") or data.get("id")
+    result = {
+        "status": "copied",
+        "source_report_id": report_id,
+        "id": copy_id,
+        "name": data.get("resultReportName") or name,
+    }
+    url = viewer_url(copy_id)
+    if url:
+        result["open_url"] = url
+    return result
+
+
+async def execute_delete(report_id: str, client: httpx.AsyncClient) -> dict[str, Any]:
+    """Delete a report and its content, returning a structured result."""
+    resp = await client.delete(f"{VIYA_ENDPOINT}{DELETE_PATH.format(report_id=report_id)}")
+    if resp.status_code == 404:
+        return {"status": "not_found", "report_id": report_id,
+                "message": f"No report with id '{report_id}'."}
+    if resp.status_code >= 400:
+        return {
+            "status": "delete_failed",
+            "report_id": report_id,
+            "http_status": resp.status_code,
+            "message": (
+                f"Viya rejected the delete (HTTP {resp.status_code}). "
+                f"Viya said: {resp.text[:400] or '(no response body)'}"
+            ),
+        }
+    return {"status": "deleted", "report_id": report_id}

--- a/src/sas_mcp_server/helpers/report_authoring_helpers.py
+++ b/src/sas_mcp_server/helpers/report_authoring_helpers.py
@@ -13,10 +13,11 @@ report or PUT an existing one with an ordered ``operations`` array, and the
 service applies every operation atomically (all succeed or nothing persists).
 Rather than one tool per chart type, the authoring tools pass that native array
 straight through — so a new VA object type needs no new tool — and this module
-supplies the *validation* and *discovery* that make the generic surface safe:
+supplies the *validation* and *discovery* that make the generic surface safe.
+The frozen configuration these functions consult (the object registry, the
+operation catalog, placement and validation vocabularies) lives in
+``report_authoring_registry.py``; this module holds only the functions:
 
-* :data:`REPORT_OBJECT_TYPES` — one frozen registry of every API-addable object
-  and its data roles, the single source of truth consumed by all three tools.
 * :func:`validate_operations` — structured, pre-flight checks (known object
   type, addable/updatable gating, data-role names + arity) returning an
   actionable error dict *before* any HTTP call, so the LLM self-corrects.
@@ -40,1098 +41,49 @@ from __future__ import annotations
 import contextlib
 import difflib
 import json
-import re
 from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
 
 from sas_mcp_server.config import VIYA_ENDPOINT
-
-# --- endpoints ------------------------------------------------------------
-
-CREATE_PATH = "/visualAnalytics/reports"
-OPERATIONS_PATH = "/visualAnalytics/reports/{report_id}"
-COPY_PATH = "/visualAnalytics/reports/{report_id}/copy"
-DELETE_PATH = "/visualAnalytics/reports/{report_id}"
-# The current ETag comes from the Reports service view of the report, not the
-# Visual Analytics operations endpoint (mirrors the SAS sample notebooks).
-ETAG_PATH = "/reports/reports/{report_id}"
-# The stored report definition (BIRD document) — the only read-back path for a
-# report's page/object structure. Requires the vnd Accept type (plain
-# application/json is answered with 415).
-CONTENT_PATH = "/reports/reports/{report_id}/content"
-CONTENT_ACCEPT = "application/vnd.sas.report.content+json"
-
-CONFLICT_VALUES = frozenset({"abort", "rename", "replace"})
-
-# The eight report operations the API accepts in an operations array. Meta keys
-# may sit alongside the single operation key on an element.
-OPERATION_KEYS = frozenset(
-    {
-        "addData",
-        "updateData",
-        "changeData",
-        "applyDataView",
-        "addPage",
-        "addObject",
-        "updateObject",
-        "setParameterValue",
-    }
+from sas_mcp_server.helpers.report_authoring_registry import (
+    AGGREGATIONS,
+    ALIASES,
+    API_LIMITS,
+    CATEGORIES,
+    CLASSIFICATIONS,
+    CONFLICT_VALUES,
+    CONTENT_ACCEPT,
+    CONTENT_PATH,
+    COPY_PATH,
+    CREATE_PATH,
+    DELETE_PATH,
+    ETAG_PATH,
+    GEO_NAME_CODE_CONTEXTS,
+    GEO_SOURCE_KEYS,
+    INTENT_MAP,
+    LAYOUT_RECIPES,
+    META_OP_KEYS,
+    NORMALIZED_NOT_ADDABLE,
+    NORMALIZED_TYPES,
+    NOT_ADDABLE,
+    OBJECT_NOTES,
+    OBJECT_SPEC_ALLOWED_KEYS,
+    OBJECTS,
+    OPERATION_KEYS,
+    OPERATIONS,
+    OPERATIONS_PATH,
+    PLACEMENT_ALLOWED_KEYS,
+    PLACEMENT_ENUMS,
+    PLACEMENT_GUIDE,
+    PLACEMENT_TARGET_REQUIRED,
+    PLACEMENT_VARIANTS,
+    REPORT_OBJECT_TYPES,
+    SAS_FORMAT_RE,
+    VaObject,
+    normalize_key,
 )
-_META_OP_KEYS = frozenset({"operationId", "includeObjectInResponse"})
-
-# How an addObject may be placed. Each variant carries a target and/or a
-# context/position from a fixed enum. VA has no absolute width/height/x/y in the
-# request — objects are auto-sized — so layout is built from placement (relative
-# positioning + containers + page assignment), not geometry.
-# NOTE: the live report-context enum is snake_case "new_page" (the published
-# OpenAPI spec says "newPage", but current Viya rejects that spelling with a
-# 400); normalize_operations translates "newPage" for callers that follow the
-# spec. Page/report "header" bands accept ONLY control objects — never text.
-PLACEMENT_VARIANTS: tuple[str, ...] = ("page", "relativeToObject", "container", "report")
-_PLACEMENT_TARGET_REQUIRED = frozenset({"page", "relativeToObject", "container"})
-_PLACEMENT_ENUMS: dict[str, dict[str, frozenset[str]]] = {
-    "page": {"context": frozenset({"header", "body"}), "position": frozenset({"start", "end"})},
-    "relativeToObject": {"position": frozenset({"before", "after", "left", "right", "top", "bottom"})},
-    "container": {"position": frozenset({"start", "end"})},
-    "report": {"context": frozenset({"new_page", "header"}), "position": frozenset({"start", "end"})},
-}
-# VA enforces additionalProperties:false, so unknown placement keys fail the
-# whole atomic batch server-side — reject them pre-flight instead.
-_PLACEMENT_ALLOWED_KEYS: dict[str, frozenset[str]] = {
-    "page": frozenset({"target", "context", "position"}),
-    "relativeToObject": frozenset({"target", "position"}),
-    "container": frozenset({"target", "position"}),
-    "report": frozenset({"context", "position", "pageName", "pagePosition"}),
-}
-
-# The placement vocabulary and layout recipes surfaced by describe() so an agent
-# can build structured pages rather than a single auto-flow stack.
-PLACEMENT_GUIDE: tuple[dict[str, Any], ...] = (
-    {
-        "variant": "page",
-        "shape": {"page": {"target": "<pageName>", "context": "header | body", "position": "start | end"}},
-        "purpose": (
-            "Put the object on a page (defaults: body/end). context 'header' is the control band "
-            "across the top — it accepts ONLY control objects (dropdownList, buttonBar, ...), never "
-            "text or visuals; a title text belongs in the body with position 'start'."
-        ),
-    },
-    {
-        "variant": "relativeToObject",
-        "shape": {"relativeToObject": {"target": "<objectName>", "position": "left|right|top|bottom|before|after"}},
-        "purpose": (
-            "Anchor next to an EXISTING object by name — build columns, rows, and grids. "
-            "left/right/top/bottom are geometric (VA auto-wraps both objects in a layout container "
-            "when the direction crosses the parent's flow); before/after insert in flow order. The "
-            "target must already exist when the operation applies — same-batch forward references fail."
-        ),
-    },
-    {
-        "variant": "container",
-        "shape": {"container": {"target": "<containerName>", "position": "start | end"}},
-        "purpose": "Place inside a standardContainer added earlier, to group objects together.",
-    },
-    {
-        "variant": "report",
-        "shape": {
-            "report": {
-                "context": "new_page | header",
-                "position": "start | end",
-                "pageName": "<name for the new page>",
-                "pagePosition": 0,
-            }
-        },
-        "purpose": (
-            "Place at the report level. context 'new_page' creates a page as it places the object; "
-            "give it a pageName (becomes the page label, targetable by later ops in the SAME batch) "
-            "and an optional numeric pagePosition (0 = first — a NUMBER here, unlike the string "
-            "addPage.pagePosition). context 'header' is the report-wide control band (controls only)."
-        ),
-    },
-)
-
-LAYOUT_RECIPES: tuple[str, ...] = (
-    "Default page skeleton — the page body auto-flows VERTICALLY, so N page-placed objects render "
-    "as one tall ugly stack. Structure every page instead: KPI tiles side by side in a "
-    "standardContainer at the top, then each chart row built with relativeToObject left/right. "
-    "Page placement alone is only right for a page's FIRST object per row.",
-    'Page title: give addPage a "title", e.g. {"addPage": {"pageName": "Overview", "title": "Sales '
-    'Overview"}} — it expands into a text band at the TOP OF THE PAGE BODY. Page and report headers '
-    "accept only control objects, so titles never go in a header.",
-    'Chart titles: pass {"options": {"object": {"title": "Revenue by Region"}}} inside the object '
-    "spec at add time (every addable type except standardContainer — title a container via a "
-    "follow-up updateObject using its returned name). Untitled charts fall back to auto-labels "
-    'like "Frequency of Origin".',
-    "One-batch multi-page report: create each page with its first object via placement "
-    '{"report": {"context": "new_page", "pageName": "Trends", "pagePosition": 1}}, then target that '
-    'pageName from later operations in the SAME batch with {"page": {"target": "Trends"}}. Page '
-    "names are caller-chosen; object names are not.",
-    "Two columns: add chart A in one call, read its returned object name, then add chart B with "
-    '{"relativeToObject": {"target": "<A\'s name>", "position": "right"}}. Targets must already '
-    "exist — a same-batch forward reference fails the whole atomic batch. before/after insert in "
-    "flow order; left/right/top/bottom are geometric side-by-side.",
-    "2x2 grid: place obj2 right of obj1, obj3 bottom of obj1, obj4 right of obj3 — chaining the "
-    "object names each apply_report_operations call returns.",
-    "Grouped strip (e.g. a KPI row of keyValue tiles): add a standardContainer (bare {} — it "
-    "accepts no options at add time), then in a follow-up apply add each tile with placement "
-    '{"container": {"target": "<container\'s returned name>"}}.',
-    "Placement and dataRoles are WRITE-ONCE: updateObject changes only options (title, etc.) and "
-    "there is no move/resize/remove operation — get placement right at add time, or rebuild via "
-    "save-as/copy.",
-    'Creating a report with inline operations leaves VA\'s empty default "Page 1" as the first '
-    "page, so whole-report exports can render blank — verify page-by-page with "
-    "export_report(..., report_objects=['<page label>']) and inspect structure with "
-    "get_report_outline.",
-)
-
-
-# --- object registry ------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class RoleSpec:
-    """A single data role a VA object accepts.
-
-    ``multi`` marks an array-valued role (e.g. ``measures``, ``columns``,
-    ``variables``) versus a single-column role (e.g. ``category``, ``xAxis``).
-    """
-
-    name: str
-    multi: bool = False
-
-
-@dataclass(frozen=True)
-class VaObject:
-    """One VA report object and the data roles it exposes.
-
-    ``commonly_required`` is a curated heuristic from the SAS ``vaobj``
-    documentation (the OpenAPI spec marks *every* role optional), used only for
-    non-blocking warnings — never to reject a payload. ``purpose`` is a one-line
-    picking hint surfaced by describe() so an agent can choose the right object
-    for an analytical intent instead of defaulting to barChart for everything.
-    """
-
-    schema_key: str
-    category: str
-    addable: bool
-    updatable: bool
-    roles: tuple[RoleSpec, ...]
-    commonly_required: tuple[str, ...] = ()
-    purpose: str = ""
-    # Role groups where at least ONE member must be filled or the object is
-    # accepted by VA but RENDERS EMPTY ("required roles not assigned") — the
-    # API does not auto-apply Frequency the way the VA UI does. Live-observed.
-    render_required: tuple[tuple[str, ...], ...] = ()
-
-    @property
-    def role_names(self) -> tuple[str, ...]:
-        return tuple(r.name for r in self.roles)
-
-
-# Registry generated from the SAS Visual Analytics v8 OpenAPI spec (every object
-# in the ``addObjectRequest`` union) and role semantics from the ``vaobj`` docs.
-# Adding or retiring an object when VA changes is a one-line edit here that
-# describe, validation, and the example builder all pick up automatically.
-_R = RoleSpec
-_O = VaObject
-_OBJECTS: tuple[VaObject, ...] = (
-    _O(
-        "crosstab",
-        "Tables",
-        True,
-        True,
-        (_R("rows", multi=True), _R("columns", multi=True), _R("measures", multi=True)),
-        (),
-        purpose="Pivot table — measures at row x column category intersections.",
-    ),
-    _O(
-        "listTable",
-        "Tables",
-        True,
-        True,
-        (_R("columns", multi=True),),
-        ("columns",),
-        purpose="Detail rows, spreadsheet-style — one row per record.",
-    ),
-    _O(
-        "buttonBar",
-        "Controls",
-        True,
-        True,
-        (_R("category"), _R("measure")),
-        (),
-        purpose="Row of buttons picking one category value (prompt control; not auto-wired to filter).",
-    ),
-    _O(
-        "dropdownList",
-        "Controls",
-        True,
-        True,
-        (_R("category"), _R("measure")),
-        (),
-        purpose="Compact dropdown picking a category value (prompt control; not auto-wired to filter).",
-    ),
-    _O(
-        "list",
-        "Controls",
-        True,
-        True,
-        (_R("category"), _R("measure")),
-        (),
-        purpose="Scrollable multi-select list of category values (prompt control).",
-    ),
-    _O(
-        "slider",
-        "Controls",
-        True,
-        True,
-        (_R("measure"),),
-        (),
-        purpose="Numeric range slider (prompt control).",
-    ),
-    _O(
-        "textInput",
-        "Controls",
-        True,
-        True,
-        (_R("category"), _R("measure")),
-        (),
-        purpose="Free-text search box (prompt control).",
-    ),
-    _O(
-        "standardContainer",
-        "Containers",
-        True,
-        True,
-        (),
-        (),
-        purpose="Groups objects into one auto-arranged block — the KPI-row / panel building block.",
-    ),
-    _O(
-        "dataDrivenContent",
-        "Content",
-        True,
-        True,
-        (_R("variables", multi=True),),
-        (),
-        purpose="Embeds a custom third-party visualization fed by report data (its URL is NOT settable here).",
-    ),
-    _O(
-        "image",
-        "Content",
-        True,
-        True,
-        (),
-        (),
-        purpose="Static image from a URL or a Viya folder — logos and branding.",
-    ),
-    _O(
-        "text",
-        "Content",
-        True,
-        True,
-        (),
-        (),
-        purpose="Static narrative text — title bands, section intros, footnotes.",
-    ),
-    _O(
-        "geoBubble",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geography"), _R("size"), _R("color")),
-        ("geography",),
-        purpose="Map with bubbles sized/colored by measures at locations.",
-    ),
-    _O(
-        "geoCluster",
-        "Geo Maps",
-        True,
-        False,
-        (_R("geography"), _R("size"), _R("color")),
-        ("geography",),
-        purpose="Map clustering dense point locations.",
-    ),
-    _O(
-        "geoContour",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geography"), _R("color")),
-        ("geography",),
-        purpose="Map with density contours over locations.",
-    ),
-    _O(
-        "geoCoordinate",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geography"), _R("size"), _R("color")),
-        ("geography",),
-        purpose="Map plotting individual coordinate points.",
-    ),
-    _O(
-        "geoLine",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geography"), _R("width"), _R("color"), _R("pattern")),
-        ("geography",),
-        purpose="Map drawing lines/routes between geo points.",
-    ),
-    _O(
-        "geoLineCoordinate",
-        "Geo Maps",
-        True,
-        True,
-        (
-            _R("geographyLine"),
-            _R("widthLine"),
-            _R("colorLine"),
-            _R("patternLine"),
-            _R("geographyScatter"),
-            _R("sizeScatter"),
-            _R("colorScatter"),
-        ),
-        (),
-        purpose="Map combining a line layer with a coordinate-point layer.",
-    ),
-    _O(
-        "geoNetwork",
-        "Geo Maps",
-        True,
-        True,
-        (_R("source"), _R("target"), _R("size"), _R("color"), _R("dataLabel")),
-        (),
-        purpose="Map of source-to-target links (flows) between locations.",
-    ),
-    _O(
-        "geoPie",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geography"), _R("size"), _R("response"), _R("group")),
-        ("geography",),
-        purpose="Map with pie markers at locations.",
-    ),
-    _O(
-        "geoRegion",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geography"), _R("color")),
-        ("geography",),
-        purpose="Choropleth — regions filled by a measure.",
-    ),
-    _O(
-        "geoRegionCoordinate",
-        "Geo Maps",
-        True,
-        True,
-        (_R("geographyRegion"), _R("colorRegion"), _R("geographyScatter"), _R("sizeScatter"), _R("colorScatter")),
-        (),
-        purpose="Choropleth plus a coordinate-point overlay.",
-    ),
-    _O(
-        "automatedExplanation",
-        "Analytics",
-        True,
-        True,
-        (_R("response"), _R("underlyingFactors", multi=True)),
-        (),
-        purpose="Auto-generated narrative explaining what drives a measure.",
-    ),
-    _O(
-        "forecasting",
-        "Analytics",
-        True,
-        True,
-        (_R("timeAxis"), _R("measures", multi=True), _R("underlyingFactors", multi=True)),
-        ("timeAxis",),
-        purpose="Time-series forecast with confidence bands.",
-    ),
-    _O(
-        "networkAnalysis",
-        "Analytics",
-        True,
-        True,
-        (_R("source"), _R("target"), _R("size"), _R("color"), _R("linkWidth"), _R("linkColor")),
-        (),
-        purpose="Node-link network diagram of relationships.",
-    ),
-    _O(
-        "pathAnalysis",
-        "Analytics",
-        True,
-        True,
-        (_R("event"), _R("sequenceOrder"), _R("transactionId"), _R("weight")),
-        (),
-        purpose="Sankey-style flow of event sequences (journeys, funnels).",
-    ),
-    _O(
-        "cluster",
-        "Statistics",
-        True,
-        True,
-        (_R("variables", multi=True),),
-        (),
-        purpose="Cluster analysis grouping observations across variables.",
-    ),
-    _O(
-        "linearRegression",
-        "Statistics",
-        False,
-        True,
-        (_R("response"), _R("continuousEffects", multi=True), _R("classificationEffects", multi=True)),
-        (),
-        purpose="Linear regression fit summary (update-only via the API).",
-    ),
-    _O(
-        "logisticRegression",
-        "Statistics",
-        True,
-        False,
-        (_R("response"), _R("continuousEffects", multi=True)),
-        (),
-        purpose="Logistic regression fit summary.",
-    ),
-    _O(
-        "nonparametricLogisticRegression",
-        "Statistics",
-        True,
-        True,
-        (_R("response"), _R("splineEffects", multi=True)),
-        (),
-        purpose="Spline-based (GAM-like) logistic regression.",
-    ),
-    _O(
-        "bayesianNetwork",
-        "Machine Learning",
-        True,
-        True,
-        (_R("response"), _R("predictors", multi=True)),
-        (),
-        purpose="Bayesian network model of a response and predictors.",
-    ),
-    _O(
-        "factorizationMachine",
-        "Machine Learning",
-        True,
-        True,
-        (_R("response"), _R("predictors", multi=True)),
-        (),
-        purpose="Factorization machine model (sparse interactions).",
-    ),
-    _O(
-        "forest",
-        "Machine Learning",
-        True,
-        True,
-        (_R("response"), _R("predictors", multi=True)),
-        (),
-        purpose="Random-forest model assessment.",
-    ),
-    _O(
-        "gradientBoosting",
-        "Machine Learning",
-        True,
-        True,
-        (_R("response"), _R("predictors", multi=True)),
-        (),
-        purpose="Gradient-boosting model assessment (nearest to a decision tree).",
-    ),
-    _O(
-        "neuralNetwork",
-        "Machine Learning",
-        True,
-        True,
-        (_R("response"), _R("predictors", multi=True)),
-        (),
-        purpose="Neural network model assessment.",
-    ),
-    _O(
-        "supportVectorMachine",
-        "Machine Learning",
-        True,
-        True,
-        (_R("response"), _R("predictors", multi=True)),
-        (),
-        purpose="Support vector machine model assessment.",
-    ),
-    _O(
-        "barChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measures", multi=True), _R("frequency")),
-        ("category",),
-        purpose="Bars comparing measures across categories — the general workhorse.",
-        render_required=(("measures", "frequency"),),
-    ),
-    _O(
-        "boxPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measures", multi=True)),
-        ("measures",),
-        purpose="Distribution quartiles and outliers per category.",
-    ),
-    _O(
-        "bubbleChangePlot",
-        "Graphs",
-        True,
-        True,
-        (_R("xStart"), _R("xEnd"), _R("yStart"), _R("yEnd"), _R("sizeStart"), _R("sizeEnd"), _R("group")),
-        (),
-        purpose="Bubbles showing movement between a start and an end state.",
-    ),
-    _O(
-        "bubblePlot",
-        "Graphs",
-        True,
-        True,
-        (_R("xAxis"), _R("yAxis"), _R("size"), _R("group")),
-        ("xAxis", "yAxis", "size"),
-        purpose="Scatter with a third measure encoded as bubble size.",
-    ),
-    _O(
-        "butterflyChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measureBar"), _R("measureBar2")),
-        (),
-        purpose="Two measures diverging left/right from a shared category axis.",
-    ),
-    _O(
-        "comparativeTimeSeriesPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("timeAxis"), _R("measureTimeSeries1"), _R("measureTimeSeries2")),
-        (),
-        purpose="Two stacked time-series panels over the same time axis.",
-    ),
-    _O(
-        "correlationMatrix",
-        "Graphs",
-        True,
-        True,
-        (_R("measures", multi=True),),
-        ("measures",),
-        purpose="Heat-colored pairwise correlations between measures.",
-    ),
-    _O(
-        "dotPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measure")),
-        ("category",),
-        purpose="Dots marking a measure per category — lighter than bars.",
-    ),
-    _O(
-        "dualAxisBarChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measureBar"), _R("measureBar2")),
-        (),
-        purpose="Bars for two measures on independent Y axes.",
-    ),
-    _O(
-        "dualAxisBarLineChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measureBar"), _R("measureLine")),
-        (),
-        purpose="Bars plus a line on independent Y axes — volume vs rate.",
-    ),
-    _O(
-        "dualAxisLineChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measureLine"), _R("measureLine2")),
-        (),
-        purpose="Two lines on independent Y axes.",
-    ),
-    _O(
-        "dualAxisTimeSeriesPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("timeAxis"), _R("measureLine"), _R("measureLine2")),
-        (),
-        purpose="Two time series on independent Y axes.",
-    ),
-    _O(
-        "gauge",
-        "Graphs",
-        True,
-        True,
-        (_R("measure"), _R("target"), _R("group")),
-        ("measure",),
-        purpose="KPI dial of a measure against a target.",
-    ),
-    _O(
-        "heatMap",
-        "Graphs",
-        True,
-        True,
-        (_R("axisItems", multi=True), _R("color")),
-        ("axisItems",),
-        purpose="Grid cells colored by a measure.",
-    ),
-    _O(
-        "histogram",
-        "Graphs",
-        True,
-        True,
-        (_R("measure"), _R("frequency")),
-        ("measure",),
-        purpose="Distribution of a single measure.",
-    ),
-    _O(
-        "keyValue",
-        "Graphs",
-        True,
-        True,
-        (_R("measure"), _R("latticeCategory")),
-        ("measure",),
-        purpose="Big-number KPI tile — one headline value.",
-    ),
-    _O(
-        "lineChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measures", multi=True), _R("frequency")),
-        ("category",),
-        purpose="Lines across ordered categories — trends over a non-date axis.",
-        render_required=(("measures", "frequency"),),
-    ),
-    _O(
-        "needlePlot",
-        "Graphs",
-        True,
-        True,
-        (_R("xAxis"), _R("yAxis"), _R("group")),
-        (),
-        purpose="Vertical needles from a baseline — sparse event values.",
-    ),
-    _O(
-        "numericSeriesPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("xAxis"), _R("yAxis"), _R("group")),
-        (),
-        purpose="Line over a numeric (non-date) X axis.",
-    ),
-    _O(
-        "parallelCoordinatePlot",
-        "Graphs",
-        True,
-        True,
-        (_R("variables", multi=True),),
-        (),
-        purpose="Profile lines across many variables at once.",
-    ),
-    _O(
-        "pieChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measures", multi=True), _R("frequency")),
-        ("category",),
-        purpose="Part-to-whole share per category (keep to a few slices).",
-        render_required=(("measures", "frequency"),),
-    ),
-    _O(
-        "scatterPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("measures", multi=True), _R("color")),
-        ("measures",),
-        purpose="Point cloud relating two or more measures.",
-    ),
-    _O(
-        "scheduleChart",
-        "Graphs",
-        True,
-        True,
-        (_R("task"), _R("start"), _R("finish"), _R("group")),
-        (),
-        purpose="Gantt-style bars of tasks over start/finish times.",
-    ),
-    _O(
-        "stepPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("xAxis"), _R("yAxis"), _R("group")),
-        (),
-        purpose="Stepped line — values holding constant between changes.",
-    ),
-    _O(
-        "targetedBarChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measure"), _R("target")),
-        (),
-        purpose="Bars with target markers — actual vs goal.",
-    ),
-    _O(
-        "timeSeriesPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("timeAxis"), _R("measure"), _R("group")),
-        ("timeAxis",),
-        purpose="Trend of a measure over a date/time axis.",
-    ),
-    _O(
-        "treeMap",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("measure")),
-        ("category",),
-        purpose="Nested rectangles sized by a measure — hierarchical part-to-whole.",
-    ),
-    _O(
-        "vectorPlot",
-        "Graphs",
-        True,
-        True,
-        (_R("xAxis"), _R("yAxis"), _R("xOrigin"), _R("yOrigin"), _R("color")),
-        (),
-        purpose="Arrows from origin to point — direction and magnitude of change.",
-    ),
-    _O(
-        "waterfallChart",
-        "Graphs",
-        True,
-        True,
-        (_R("category"), _R("response")),
-        (),
-        purpose="Cumulative running total across categories.",
-    ),
-    _O(
-        "wordCloud",
-        "Graphs",
-        True,
-        True,
-        (_R("word"), _R("size"), _R("color")),
-        (),
-        purpose="Words sized by frequency or a measure.",
-        render_required=(("size",),),
-    ),
-)
-del _R, _O
-
-REPORT_OBJECT_TYPES: dict[str, VaObject] = {o.schema_key: o for o in _OBJECTS}
-
-# Objects that appear in the VA UI but have NO schema in the report API. Mapping
-# each to the nearest addable alternative lets the tools redirect an agent
-# instead of letting it fail with an opaque VA error.
-NOT_ADDABLE: dict[str, str] = {
-    "textTopics": "wordCloud",
-    "decisionTree": "gradientBoosting",
-    "generalizedAdditiveModel": "nonparametricLogisticRegression",
-    "generalizedLinearModel": "logisticRegression",
-}
-
-CATEGORIES: tuple[str, ...] = (
-    "Tables",
-    "Controls",
-    "Containers",
-    "Content",
-    "Graphs",
-    "Geo Maps",
-    "Analytics",
-    "Statistics",
-    "Machine Learning",
-)
-
-# Colloquial names an agent is likely to try, mapped to real schema keys —
-# consulted before difflib so describe('kpi') lands on keyValue instead of
-# nothing (difflib alone scores kpi->keyValue below its cutoff).
-ALIASES: dict[str, str] = {
-    "kpi": "keyValue",
-    "tile": "keyValue",
-    "bignumber": "keyValue",
-    "indicator": "keyValue",
-    "map": "geoRegion",
-    "choropleth": "geoRegion",
-    "table": "listTable",
-    "datatable": "listTable",
-    "pivot": "crosstab",
-    "pivottable": "crosstab",
-    "filter": "dropdownList",
-    "dropdown": "dropdownList",
-    "donut": "pieChart",
-    "gantt": "scheduleChart",
-    "sankey": "pathAnalysis",
-    "trend": "timeSeriesPlot",
-    "sparkline": "timeSeriesPlot",
-    "container": "standardContainer",
-    "textbox": "text",
-    "label": "text",
-    "logo": "image",
-    "funnel": "pathAnalysis",
-}
-
-def _normalize_key(value: str) -> str:
-    """Case/spacing-insensitive lookup form: 'Decision Tree' -> 'decisiontree'."""
-    return value.strip().lower().replace(" ", "").replace("-", "").replace("_", "")
-
-
-_NORMALIZED_TYPES: dict[str, str] = {_normalize_key(k): k for k in REPORT_OBJECT_TYPES}
-_NORMALIZED_NOT_ADDABLE: dict[str, str] = {_normalize_key(k): k for k in NOT_ADDABLE}
-
-
-# Analytical intent -> the object types that serve it, surfaced in the describe
-# index so an agent picks variety deliberately instead of barChart-for-everything.
-INTENT_MAP: dict[str, list[str]] = {
-    "single KPI number": ["keyValue", "gauge"],
-    "KPI row of tiles": ["standardContainer", "keyValue"],
-    "trend over time": ["timeSeriesPlot", "lineChart"],
-    "compare categories": ["barChart", "dotPlot"],
-    "actual vs target": ["targetedBarChart", "gauge"],
-    "part-to-whole": ["pieChart", "treeMap"],
-    "distribution": ["histogram", "boxPlot"],
-    "relationship between measures": ["scatterPlot", "bubblePlot", "heatMap"],
-    "geographic distribution": ["geoRegion", "geoBubble"],
-    "detail rows": ["listTable"],
-    "pivot / cross-tab": ["crosstab"],
-    "filter control": ["dropdownList", "buttonBar", "slider"],
-    "narrative text / title band": ["text"],
-    "logo / branding": ["image"],
-    "forecast": ["forecasting"],
-    "what drives a measure": ["automatedExplanation"],
-    "flows / sequences": ["pathAnalysis", "networkAnalysis"],
-}
-
-# Honest boundaries of the operations API, surfaced by describe() so an agent
-# does not burn round-trips hunting for capabilities that do not exist.
-API_LIMITS: tuple[str, ...] = (
-    "Controls are added UNWIRED: no operation creates filters, actions, or links between objects "
-    "— interactive wiring needs the VA UI (or raw report-content editing).",
-    "setParameterValue only sets EXISTING report parameters; parameters cannot be created here.",
-    "Calculated items, hierarchies, and custom sorts cannot be created via operations — save a "
-    "data view once in the VA UI, then import it with applyDataView.",
-    "No theme/page-numbering/footer operation exists; retheming lives in the SAS Report "
-    "Transforms API.",
-    "Placement and dataRoles are write-once: updateObject changes only options, and there is no "
-    "move/resize/remove operation (delete_report or save-as/copy and rebuild instead).",
-    "Objects are auto-named and auto-sized: no width/height/x/y anywhere, and VA rejects a "
-    "caller-supplied object 'name' at add time — chain layouts on the names each apply returns.",
-    "Page and report headers accept ONLY control objects — titles are text objects placed at the "
-    "top of the page body.",
-)
-
-# dataItems vocabularies from the VA v8 OpenAPI spec (dataItemProperties),
-# validated pre-flight because VA rejects unknown values with a whole-batch 400.
-AGGREGATIONS: frozenset[str] = frozenset(
-    {
-        "sum",
-        "average",
-        "min",
-        "max",
-        "count",
-        "median",
-        "variance",
-        "numberMissing",
-        "standardDeviation",
-        "standardError",
-        "firstQuartile",
-        "thirdQuartile",
-        "skewness",
-        "kurtosis",
-        "coefficientOfVariation",
-        "correctedSumOfSquares",
-        "uncorrectedSumOfSquares",
-        "tStatistic",
-        "pValue",
-    }
-)
-CLASSIFICATIONS: frozenset[str] = frozenset({"category", "measure", "geography"})
-# The geographyDataSource union from the spec: named-region contexts OR raw
-# lat/long coordinates (geographyCoordinates) — exactly one of the two.
-GEO_SOURCE_KEYS: frozenset[str] = frozenset(
-    {
-        "geographyNameCodeContext",
-        "geographyCountryRegion",
-        "geographyDataProvider",
-        "geographyCoordinates",
-    }
-)
-# Named SAS format: optional $, leading letter, optional width, dot, optional
-# decimals (DOLLAR12.2, COMMA10., PERCENT8.1, DATE9., $CHAR20.). VA rejects
-# bare numeric w.d forms like "8.1" — and the whole atomic batch with them.
-_SAS_FORMAT_RE = re.compile(r"^\$?[A-Za-z][A-Za-z0-9_]*\.\d*$")
-GEO_NAME_CODE_CONTEXTS: frozenset[str] = frozenset(
-    {
-        "CountryRegionNames",
-        "CountryRegionISO2LetterCodes",
-        "CountryRegionISO3LetterCodes",
-        "CountryRegionISONumericCodes",
-        "CountryRegionSASMapIdValues",
-        "SubdivisionNames",
-        "SubdivisionSASMapIdValues",
-        "USStateNames",
-        "USStateAbbreviations",
-        "USZipCodes",
-    }
-)
-
-# The eight operations, with a worked example each, for describe(operation=...)
-# and the tool docstrings. The index lists key+purpose; the full entry (example,
-# notes) is returned by describe_report_objects(operation='addData') etc.
-OPERATIONS: tuple[dict[str, Any], ...] = (
-    {
-        "key": "addData",
-        "purpose": (
-            "Bind a CAS table as a data source; dataItems is where reports get polish — "
-            "readable labels, formats, aggregations, geography."
-        ),
-        "required": ["cas.{server, library, table}"],
-        "example": {
-            "addData": {
-                "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"},
-                "dataItems": [
-                    {
-                        "dataItem": "Revenue",
-                        "properties": {"name": "Revenue (USD)", "format": "DOLLAR12.2", "aggregation": "average"},
-                    },
-                    {
-                        "dataItem": "State",
-                        "properties": {
-                            "classification": "geography",
-                            "geographyDataSource": {"geographyNameCodeContext": "USStateNames"},
-                        },
-                    },
-                ],
-            }
-        },
-        "notes": [
-            "addObject.dataSource references the addData 'name', defaulting to cas.table.",
-            "After a rename, dataRoles must use the NEW name (e.g. 'Revenue (USD)').",
-            f"aggregation: one of {sorted(AGGREGATIONS)}.",
-            "format must be a NAMED SAS format (DOLLAR12.2, PERCENT8.1, COMMA10., DATE9.) — "
-            "bare numeric forms like '8.1' are rejected.",
-            "classification: category | measure | geography — geography classification is the "
-            "precondition for every Geo Map object.",
-            f"geographyNameCodeContext: one of {sorted(GEO_NAME_CODE_CONTEXTS)}.",
-            "Raw lat/long point data: {'classification': 'geography', 'geographyDataSource': "
-            "{'geographyCoordinates': {'latitudeDataItem': 'LATITUDE', 'longitudeDataItem': "
-            "'LONGITUDE'}}} — coordinates OR a name-code context, never both.",
-        ],
-    },
-    {
-        "key": "addPage",
-        "purpose": (
-            "Add a page; a 'title' becomes a text band at the top of the page body; reference the "
-            "page by pageName when placing objects."
-        ),
-        "required": [],
-        "example": {"addPage": {"pageName": "Overview", "title": "Sales Overview", "pagePosition": "0"}},
-        "notes": [
-            "pagePosition is a STRING here ('0' = first) — unlike the numeric "
-            "report-placement pagePosition.",
-            "The title text lands in the page body (page headers accept only controls).",
-        ],
-    },
-    {
-        "key": "addObject",
-        "purpose": "Add a visual/control/content object, titled and placed.",
-        "required": ["object.<type>  (or reportObject)"],
-        "example": {
-            "addObject": {
-                "object": {
-                    "barChart": {
-                        "dataSource": "SALES",
-                        "dataRoles": {"category": "Region", "measures": ["Revenue (USD)"]},
-                        "options": {"object": {"title": "Revenue by Region"}},
-                    }
-                },
-                "placement": {"page": {"target": "Overview"}},
-            }
-        },
-        "notes": [
-            "Allowed object-spec keys: dataSource, dataRoles, options (VA rejects anything else, "
-            "including a caller-supplied 'name').",
-            "options.object.title/alternativeText work at add time on every type except "
-            "standardContainer.",
-        ],
-    },
-    {
-        "key": "updateObject",
-        "purpose": "Change an existing object's options (title, etc.) — never its placement or data roles.",
-        "required": ["object.<type>.name"],
-        "example": {
-            "updateObject": {
-                "object": {"barChart": {"name": "ve15", "options": {"object": {"title": "MSRP by Region"}}}}
-            }
-        },
-        "notes": ["'name' is the object name (ve*) or label returned by a previous apply or get_report_outline."],
-    },
-    {
-        "key": "setParameterValue",
-        "purpose": "Set an EXISTING report parameter's value (parameters cannot be created here).",
-        "required": ["name", "value"],
-        "example": {"setParameterValue": {"name": "originFilter", "value": "Asia"}},
-    },
-    {
-        "key": "updateData",
-        "purpose": "Update an existing data source's items in place.",
-        "required": ["data"],
-        "example": {"updateData": {"data": {"name": "SALES"}}},
-    },
-    {
-        "key": "changeData",
-        "purpose": "Swap a data source for a different CAS table (copy-and-replace).",
-        "required": ["originalData", "replacementData"],
-        "example": {
-            "changeData": {
-                "originalData": {"cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"}},
-                "replacementData": {
-                    "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES_2025"}
-                },
-            }
-        },
-    },
-    {
-        "key": "applyDataView",
-        "purpose": (
-            "Import a data view saved in the VA UI — the sanctioned route to calculated items, "
-            "hierarchies, and custom sorts."
-        ),
-        "required": ["targetData", "dataView"],
-        "example": {
-            "applyDataView": {
-                "dataItemConflictResolution": "createDuplicate",
-                "targetData": {"name": "SALES"},
-                "dataView": {"name": "SALES View 1"},
-            }
-        },
-        "notes": [
-            "dataItemConflictResolution: abort (default) | createDuplicate | replaceExisting | "
-            "keepExisting | dataMapping.",
-            "dataView takes {'name': ...} or {'uri': ...}; there is no API to create or list data "
-            "views — save one in the VA UI first.",
-        ],
-    },
-)
-
 
 # --- discovery ------------------------------------------------------------
 
@@ -1199,7 +151,7 @@ def describe(
             "addable": o.addable,
             "updatable": o.updatable,
         }
-        for o in _OBJECTS
+        for o in OBJECTS
         if category is None or o.category == category
     ]
     result: dict[str, Any] = {
@@ -1235,63 +187,12 @@ def _describe_operation(operation: str) -> dict[str, Any]:
     }
 
 
-# Extra guidance for objects whose real-world contract probing showed to be
-# surprising; merged into the describe() detail.
-_OBJECT_NOTES: dict[str, dict[str, str]] = {
-    "text": {
-        "content_note": (
-            "Set the text via options.content (a plain string — no markup). Caveat: some Viya "
-            "builds misroute options.content to the report's FIRST text object on both add and "
-            "update, so keep one content-bearing text per report, or write additional texts via "
-            "the report content endpoint (PUT /reports/reports/{id}/content)."
-        ),
-    },
-    "image": {
-        "options_note": (
-            "options is a oneOf directly under it (no wrapper): {'url': 'https://.../logo.png'} "
-            "for a web image, OR {'imageName': 'logo.png', 'imageFolder': '/folders/folders/"
-            "{folderId}'} for a repository image (imageFolder is the folders-service URI, not a "
-            "display path). URL extension must look like an image (.png/.jpg); reachability is "
-            "NOT checked at add time, repository existence IS."
-        ),
-    },
-    "standardContainer": {
-        "options_note": (
-            "Accepts NO properties at add time — VA rejects even 'options'. Add it bare ({}), "
-            "then title it via a follow-up updateObject using the name the apply returned. "
-            "Containers auto-arrange their children; there is no layout/direction knob."
-        ),
-    },
-    "dataDrivenContent": {
-        "options_note": (
-            "The content URL is NOT settable via the operations API — a dataDrivenContent added "
-            "here renders empty until the URL is set in the VA UI."
-        ),
-    },
-    "histogram": {
-        "data_note": (
-            "A dataItem carrying a preset aggregation breaks histogram binning (the rendered "
-            "object shows 'missing data item'). Point the histogram's measure at the raw, "
-            "unaggregated column — or use a boxPlot for aggregated comparisons."
-        ),
-    },
-    "keyValue": {
-        "title_note": (
-            "Skip options.object.title on KPI tiles — the tile already renders its measure's "
-            "label prominently, so a title duplicates it. Give the measure a good display name "
-            "via addData dataItems (e.g. 'Avg Loan (USD)') instead, and place tiles side by side "
-            "in a standardContainer, never stacked on the page."
-        ),
-    },
-}
-
-
 def _describe_one(object_type: str) -> dict[str, Any]:
     resolved_from: str | None = None
-    normalized = _normalize_key(object_type)
+    normalized = normalize_key(object_type)
     obj = REPORT_OBJECT_TYPES.get(object_type)
     if obj is None:
-        target = _NORMALIZED_TYPES.get(normalized) or ALIASES.get(normalized)
+        target = NORMALIZED_TYPES.get(normalized) or ALIASES.get(normalized)
         if target:
             resolved_from = object_type
             obj = REPORT_OBJECT_TYPES[target]
@@ -1324,7 +225,7 @@ def _describe_one(object_type: str) -> dict[str, Any]:
             detail["note"] = f"'{obj.schema_key}' can be updated (updateObject) but not added via the API."
         if obj.schema_key == "standardContainer":
             detail["common_options"] = {
-                "note": _OBJECT_NOTES["standardContainer"]["options_note"],
+                "note": OBJECT_NOTES["standardContainer"]["options_note"],
             }
         else:
             detail["common_options"] = {
@@ -1334,7 +235,7 @@ def _describe_one(object_type: str) -> dict[str, Any]:
                     "relying on VA's auto-labels."
                 ),
             }
-        detail.update(_OBJECT_NOTES.get(obj.schema_key, {}))
+        detail.update(OBJECT_NOTES.get(obj.schema_key, {}))
         if obj.render_required:
             detail["render_required"] = [list(group) for group in obj.render_required]
         if obj.category == "Geo Maps":
@@ -1348,7 +249,7 @@ def _describe_one(object_type: str) -> dict[str, Any]:
             )
         return detail
 
-    not_addable_key = object_type if object_type in NOT_ADDABLE else _NORMALIZED_NOT_ADDABLE.get(normalized)
+    not_addable_key = object_type if object_type in NOT_ADDABLE else NORMALIZED_NOT_ADDABLE.get(normalized)
     if not_addable_key:
         alt = NOT_ADDABLE[not_addable_key]
         return {
@@ -1511,7 +412,7 @@ def _validate_one(op: Any, i: int) -> dict[str, Any] | None:
         return _err("invalid_operation", i, "each operation must be an object.")
     keys = [k for k in op if k in OPERATION_KEYS]
     if not keys:
-        unknown = [k for k in op if k not in _META_OP_KEYS]
+        unknown = [k for k in op if k not in META_OP_KEYS]
         return _err(
             "invalid_operation",
             i,
@@ -1520,13 +421,13 @@ def _validate_one(op: Any, i: int) -> dict[str, Any] | None:
         )
     if len(keys) > 1:
         return _err("invalid_operation", i, f"exactly one operation per array element; got {sorted(keys)}.")
-    stray = [k for k in op if k not in OPERATION_KEYS and k not in _META_OP_KEYS]
+    stray = [k for k in op if k not in OPERATION_KEYS and k not in META_OP_KEYS]
     if stray:
         return _err(
             "invalid_operation",
             i,
             f"unknown key(s) {sorted(stray)} alongside '{keys[0]}' — VA rejects unrecognised "
-            f"properties; allowed meta keys: {sorted(_META_OP_KEYS)}.",
+            f"properties; allowed meta keys: {sorted(META_OP_KEYS)}.",
             unknown_keys=sorted(stray),
         )
     key = keys[0]
@@ -1618,7 +519,7 @@ def _validate_data_items(val: Any, i: int, op: str) -> dict[str, Any] | None:
                 valid_values=sorted(AGGREGATIONS),
             )
         fmt = props.get("format")
-        if fmt is not None and (not isinstance(fmt, str) or not _SAS_FORMAT_RE.match(fmt)):
+        if fmt is not None and (not isinstance(fmt, str) or not SAS_FORMAT_RE.match(fmt)):
             return _err(
                 "invalid_operation",
                 i,
@@ -1748,13 +649,6 @@ def _resolve_type(type_key: str, i: int, *, for_update: bool) -> dict[str, Any] 
     return None
 
 
-# VA enforces additionalProperties:false on every object spec: an unknown key
-# (including a caller-supplied 'name') fails the whole atomic batch with an HTTP
-# 400 — catch it pre-flight instead. standardContainer is stricter still: it
-# accepts NO properties at add time, not even 'options'.
-_OBJECT_SPEC_ALLOWED_KEYS = frozenset({"dataSource", "dataRoles", "options"})
-
-
 def _validate_object_spec_keys(type_key: str, spec: Any, i: int) -> dict[str, Any] | None:
     if not isinstance(spec, dict):
         return None  # shape errors are reported by _validate_roles
@@ -1769,7 +663,7 @@ def _validate_object_spec_keys(type_key: str, spec: Any, i: int) -> dict[str, An
                 object_type=type_key,
             )
         return None
-    extras = sorted(set(spec) - _OBJECT_SPEC_ALLOWED_KEYS)
+    extras = sorted(set(spec) - OBJECT_SPEC_ALLOWED_KEYS)
     if extras:
         if "name" in extras:
             return _err(
@@ -1784,7 +678,7 @@ def _validate_object_spec_keys(type_key: str, spec: Any, i: int) -> dict[str, An
             "invalid_object_spec",
             i,
             f"'{type_key}' does not accept {extras}; allowed keys: "
-            f"{sorted(_OBJECT_SPEC_ALLOWED_KEYS)}.",
+            f"{sorted(OBJECT_SPEC_ALLOWED_KEYS)}.",
             object_type=type_key,
             unknown_keys=extras,
         )
@@ -1870,22 +764,22 @@ def _validate_placement(placement: Any, i: int) -> dict[str, Any] | None:
     inner = placement[variant]
     if not isinstance(inner, dict):
         return _err("invalid_placement", i, f"placement.{variant} must be an object.")
-    extras = sorted(set(inner) - _PLACEMENT_ALLOWED_KEYS[variant])
+    extras = sorted(set(inner) - PLACEMENT_ALLOWED_KEYS[variant])
     if extras:
         return _err(
             "invalid_placement",
             i,
             f"placement.{variant} does not accept {extras}; allowed keys: "
-            f"{sorted(_PLACEMENT_ALLOWED_KEYS[variant])}.",
+            f"{sorted(PLACEMENT_ALLOWED_KEYS[variant])}.",
             unknown_keys=extras,
         )
-    if variant in _PLACEMENT_TARGET_REQUIRED and not inner.get("target"):
+    if variant in PLACEMENT_TARGET_REQUIRED and not inner.get("target"):
         return _err(
             "invalid_placement",
             i,
             f"placement.{variant} requires 'target' (the name of the {variant} to place against).",
         )
-    for field_name, allowed in _PLACEMENT_ENUMS.get(variant, {}).items():
+    for field_name, allowed in PLACEMENT_ENUMS.get(variant, {}).items():
         value = inner.get(field_name)
         if value is not None and value not in allowed:
             return _err(

--- a/src/sas_mcp_server/helpers/report_authoring_registry.py
+++ b/src/sas_mcp_server/helpers/report_authoring_registry.py
@@ -1,0 +1,1175 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static configuration for the Visual Analytics report-authoring tools.
+
+The frozen data that drives ``report_authoring_helpers.py``, kept apart from
+the functions so the catalog can be read and maintained on its own:
+
+* the endpoint paths for the create / operations / copy / delete / content
+  calls (the ETag read deliberately targets the Reports service while the
+  operations PUT targets Visual Analytics — the two-path handshake the SAS
+  sample notebooks use);
+* :data:`REPORT_OBJECT_TYPES` — the registry of every API-addable object and
+  its data roles, generated from the VA v8 OpenAPI spec (every object in the
+  ``addObjectRequest`` union) with role semantics from the ``vaobj`` docs; the
+  single source of truth consumed by discovery, validation, and the example
+  builder. Adding or retiring an object when VA changes is a one-line edit to
+  :data:`OBJECTS` that the tools pick up automatically;
+* the operation catalog (:data:`OPERATIONS`), placement vocabulary
+  (:data:`PLACEMENT_GUIDE`), layout recipes, alias / intent maps, and the
+  API's honest limits — the material ``describe_report_objects`` surfaces;
+* the validation vocabularies (aggregations, classifications, geography
+  contexts, the SAS format shape, allowed placement/object-spec keys) checked
+  pre-flight because VA rejects unknown values with a whole-batch 400.
+
+Data only — anything that executes lives in ``report_authoring_helpers.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# --- endpoints ------------------------------------------------------------
+
+CREATE_PATH = "/visualAnalytics/reports"
+OPERATIONS_PATH = "/visualAnalytics/reports/{report_id}"
+COPY_PATH = "/visualAnalytics/reports/{report_id}/copy"
+DELETE_PATH = "/visualAnalytics/reports/{report_id}"
+# The current ETag comes from the Reports service view of the report, not the
+# Visual Analytics operations endpoint (mirrors the SAS sample notebooks).
+ETAG_PATH = "/reports/reports/{report_id}"
+# The stored report definition (BIRD document) — the only read-back path for a
+# report's page/object structure. Requires the vnd Accept type (plain
+# application/json is answered with 415).
+CONTENT_PATH = "/reports/reports/{report_id}/content"
+CONTENT_ACCEPT = "application/vnd.sas.report.content+json"
+
+CONFLICT_VALUES = frozenset({"abort", "rename", "replace"})
+
+# The eight report operations the API accepts in an operations array. Meta keys
+# may sit alongside the single operation key on an element.
+OPERATION_KEYS = frozenset(
+    {
+        "addData",
+        "updateData",
+        "changeData",
+        "applyDataView",
+        "addPage",
+        "addObject",
+        "updateObject",
+        "setParameterValue",
+    }
+)
+META_OP_KEYS = frozenset({"operationId", "includeObjectInResponse"})
+
+# How an addObject may be placed. Each variant carries a target and/or a
+# context/position from a fixed enum. VA has no absolute width/height/x/y in the
+# request — objects are auto-sized — so layout is built from placement (relative
+# positioning + containers + page assignment), not geometry.
+# NOTE: the live report-context enum is snake_case "new_page" (the published
+# OpenAPI spec says "newPage", but current Viya rejects that spelling with a
+# 400); normalize_operations translates "newPage" for callers that follow the
+# spec. Page/report "header" bands accept ONLY control objects — never text.
+PLACEMENT_VARIANTS: tuple[str, ...] = ("page", "relativeToObject", "container", "report")
+PLACEMENT_TARGET_REQUIRED = frozenset({"page", "relativeToObject", "container"})
+PLACEMENT_ENUMS: dict[str, dict[str, frozenset[str]]] = {
+    "page": {"context": frozenset({"header", "body"}), "position": frozenset({"start", "end"})},
+    "relativeToObject": {"position": frozenset({"before", "after", "left", "right", "top", "bottom"})},
+    "container": {"position": frozenset({"start", "end"})},
+    "report": {"context": frozenset({"new_page", "header"}), "position": frozenset({"start", "end"})},
+}
+# VA enforces additionalProperties:false, so unknown placement keys fail the
+# whole atomic batch server-side — reject them pre-flight instead.
+PLACEMENT_ALLOWED_KEYS: dict[str, frozenset[str]] = {
+    "page": frozenset({"target", "context", "position"}),
+    "relativeToObject": frozenset({"target", "position"}),
+    "container": frozenset({"target", "position"}),
+    "report": frozenset({"context", "position", "pageName", "pagePosition"}),
+}
+
+# The placement vocabulary and layout recipes surfaced by describe() so an agent
+# can build structured pages rather than a single auto-flow stack.
+PLACEMENT_GUIDE: tuple[dict[str, Any], ...] = (
+    {
+        "variant": "page",
+        "shape": {"page": {"target": "<pageName>", "context": "header | body", "position": "start | end"}},
+        "purpose": (
+            "Put the object on a page (defaults: body/end). context 'header' is the control band "
+            "across the top — it accepts ONLY control objects (dropdownList, buttonBar, ...), never "
+            "text or visuals; a title text belongs in the body with position 'start'."
+        ),
+    },
+    {
+        "variant": "relativeToObject",
+        "shape": {"relativeToObject": {"target": "<objectName>", "position": "left|right|top|bottom|before|after"}},
+        "purpose": (
+            "Anchor next to an EXISTING object by name — build columns, rows, and grids. "
+            "left/right/top/bottom are geometric (VA auto-wraps both objects in a layout container "
+            "when the direction crosses the parent's flow); before/after insert in flow order. The "
+            "target must already exist when the operation applies — same-batch forward references fail."
+        ),
+    },
+    {
+        "variant": "container",
+        "shape": {"container": {"target": "<containerName>", "position": "start | end"}},
+        "purpose": "Place inside a standardContainer added earlier, to group objects together.",
+    },
+    {
+        "variant": "report",
+        "shape": {
+            "report": {
+                "context": "new_page | header",
+                "position": "start | end",
+                "pageName": "<name for the new page>",
+                "pagePosition": 0,
+            }
+        },
+        "purpose": (
+            "Place at the report level. context 'new_page' creates a page as it places the object; "
+            "give it a pageName (becomes the page label, targetable by later ops in the SAME batch) "
+            "and an optional numeric pagePosition (0 = first — a NUMBER here, unlike the string "
+            "addPage.pagePosition). context 'header' is the report-wide control band (controls only)."
+        ),
+    },
+)
+
+LAYOUT_RECIPES: tuple[str, ...] = (
+    "Default page skeleton — the page body auto-flows VERTICALLY, so N page-placed objects render "
+    "as one tall ugly stack. Structure every page instead: KPI tiles side by side in a "
+    "standardContainer at the top, then each chart row built with relativeToObject left/right. "
+    "Page placement alone is only right for a page's FIRST object per row.",
+    'Page title: give addPage a "title", e.g. {"addPage": {"pageName": "Overview", "title": "Sales '
+    'Overview"}} — it expands into a text band at the TOP OF THE PAGE BODY. Page and report headers '
+    "accept only control objects, so titles never go in a header.",
+    'Chart titles: pass {"options": {"object": {"title": "Revenue by Region"}}} inside the object '
+    "spec at add time (every addable type except standardContainer — title a container via a "
+    "follow-up updateObject using its returned name). Untitled charts fall back to auto-labels "
+    'like "Frequency of Origin".',
+    "One-batch multi-page report: create each page with its first object via placement "
+    '{"report": {"context": "new_page", "pageName": "Trends", "pagePosition": 1}}, then target that '
+    'pageName from later operations in the SAME batch with {"page": {"target": "Trends"}}. Page '
+    "names are caller-chosen; object names are not.",
+    "Two columns: add chart A in one call, read its returned object name, then add chart B with "
+    '{"relativeToObject": {"target": "<A\'s name>", "position": "right"}}. Targets must already '
+    "exist — a same-batch forward reference fails the whole atomic batch. before/after insert in "
+    "flow order; left/right/top/bottom are geometric side-by-side.",
+    "2x2 grid: place obj2 right of obj1, obj3 bottom of obj1, obj4 right of obj3 — chaining the "
+    "object names each apply_report_operations call returns.",
+    "Grouped strip (e.g. a KPI row of keyValue tiles): add a standardContainer (bare {} — it "
+    "accepts no options at add time), then in a follow-up apply add each tile with placement "
+    '{"container": {"target": "<container\'s returned name>"}}.',
+    "Placement and dataRoles are WRITE-ONCE: updateObject changes only options (title, etc.) and "
+    "there is no move/resize/remove operation — get placement right at add time, or rebuild via "
+    "save-as/copy.",
+    'Creating a report with inline operations leaves VA\'s empty default "Page 1" as the first '
+    "page, so whole-report exports can render blank — verify page-by-page with "
+    "export_report(..., report_objects=['<page label>']) and inspect structure with "
+    "get_report_outline.",
+)
+
+
+# --- object registry ------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoleSpec:
+    """A single data role a VA object accepts.
+
+    ``multi`` marks an array-valued role (e.g. ``measures``, ``columns``,
+    ``variables``) versus a single-column role (e.g. ``category``, ``xAxis``).
+    """
+
+    name: str
+    multi: bool = False
+
+
+@dataclass(frozen=True)
+class VaObject:
+    """One VA report object and the data roles it exposes.
+
+    ``commonly_required`` is a curated heuristic from the SAS ``vaobj``
+    documentation (the OpenAPI spec marks *every* role optional), used only for
+    non-blocking warnings — never to reject a payload. ``purpose`` is a one-line
+    picking hint surfaced by describe() so an agent can choose the right object
+    for an analytical intent instead of defaulting to barChart for everything.
+    """
+
+    schema_key: str
+    category: str
+    addable: bool
+    updatable: bool
+    roles: tuple[RoleSpec, ...]
+    commonly_required: tuple[str, ...] = ()
+    purpose: str = ""
+    # Role groups where at least ONE member must be filled or the object is
+    # accepted by VA but RENDERS EMPTY ("required roles not assigned") — the
+    # API does not auto-apply Frequency the way the VA UI does. Live-observed.
+    render_required: tuple[tuple[str, ...], ...] = ()
+
+    @property
+    def role_names(self) -> tuple[str, ...]:
+        return tuple(r.name for r in self.roles)
+
+
+# Registry generated from the SAS Visual Analytics v8 OpenAPI spec (every object
+# in the ``addObjectRequest`` union) and role semantics from the ``vaobj`` docs.
+# Adding or retiring an object when VA changes is a one-line edit here that
+# describe, validation, and the example builder all pick up automatically.
+_R = RoleSpec
+_O = VaObject
+OBJECTS: tuple[VaObject, ...] = (
+    _O(
+        "crosstab",
+        "Tables",
+        True,
+        True,
+        (_R("rows", multi=True), _R("columns", multi=True), _R("measures", multi=True)),
+        (),
+        purpose="Pivot table — measures at row x column category intersections.",
+    ),
+    _O(
+        "listTable",
+        "Tables",
+        True,
+        True,
+        (_R("columns", multi=True),),
+        ("columns",),
+        purpose="Detail rows, spreadsheet-style — one row per record.",
+    ),
+    _O(
+        "buttonBar",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Row of buttons picking one category value (prompt control; not auto-wired to filter).",
+    ),
+    _O(
+        "dropdownList",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Compact dropdown picking a category value (prompt control; not auto-wired to filter).",
+    ),
+    _O(
+        "list",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Scrollable multi-select list of category values (prompt control).",
+    ),
+    _O(
+        "slider",
+        "Controls",
+        True,
+        True,
+        (_R("measure"),),
+        (),
+        purpose="Numeric range slider (prompt control).",
+    ),
+    _O(
+        "textInput",
+        "Controls",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        (),
+        purpose="Free-text search box (prompt control).",
+    ),
+    _O(
+        "standardContainer",
+        "Containers",
+        True,
+        True,
+        (),
+        (),
+        purpose="Groups objects into one auto-arranged block — the KPI-row / panel building block.",
+    ),
+    _O(
+        "dataDrivenContent",
+        "Content",
+        True,
+        True,
+        (_R("variables", multi=True),),
+        (),
+        purpose="Embeds a custom third-party visualization fed by report data (its URL is NOT settable here).",
+    ),
+    _O(
+        "image",
+        "Content",
+        True,
+        True,
+        (),
+        (),
+        purpose="Static image from a URL or a Viya folder — logos and branding.",
+    ),
+    _O(
+        "text",
+        "Content",
+        True,
+        True,
+        (),
+        (),
+        purpose="Static narrative text — title bands, section intros, footnotes.",
+    ),
+    _O(
+        "geoBubble",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("size"), _R("color")),
+        ("geography",),
+        purpose="Map with bubbles sized/colored by measures at locations.",
+    ),
+    _O(
+        "geoCluster",
+        "Geo Maps",
+        True,
+        False,
+        (_R("geography"), _R("size"), _R("color")),
+        ("geography",),
+        purpose="Map clustering dense point locations.",
+    ),
+    _O(
+        "geoContour",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("color")),
+        ("geography",),
+        purpose="Map with density contours over locations.",
+    ),
+    _O(
+        "geoCoordinate",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("size"), _R("color")),
+        ("geography",),
+        purpose="Map plotting individual coordinate points.",
+    ),
+    _O(
+        "geoLine",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("width"), _R("color"), _R("pattern")),
+        ("geography",),
+        purpose="Map drawing lines/routes between geo points.",
+    ),
+    _O(
+        "geoLineCoordinate",
+        "Geo Maps",
+        True,
+        True,
+        (
+            _R("geographyLine"),
+            _R("widthLine"),
+            _R("colorLine"),
+            _R("patternLine"),
+            _R("geographyScatter"),
+            _R("sizeScatter"),
+            _R("colorScatter"),
+        ),
+        (),
+        purpose="Map combining a line layer with a coordinate-point layer.",
+    ),
+    _O(
+        "geoNetwork",
+        "Geo Maps",
+        True,
+        True,
+        (_R("source"), _R("target"), _R("size"), _R("color"), _R("dataLabel")),
+        (),
+        purpose="Map of source-to-target links (flows) between locations.",
+    ),
+    _O(
+        "geoPie",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("size"), _R("response"), _R("group")),
+        ("geography",),
+        purpose="Map with pie markers at locations.",
+    ),
+    _O(
+        "geoRegion",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geography"), _R("color")),
+        ("geography",),
+        purpose="Choropleth — regions filled by a measure.",
+    ),
+    _O(
+        "geoRegionCoordinate",
+        "Geo Maps",
+        True,
+        True,
+        (_R("geographyRegion"), _R("colorRegion"), _R("geographyScatter"), _R("sizeScatter"), _R("colorScatter")),
+        (),
+        purpose="Choropleth plus a coordinate-point overlay.",
+    ),
+    _O(
+        "automatedExplanation",
+        "Analytics",
+        True,
+        True,
+        (_R("response"), _R("underlyingFactors", multi=True)),
+        (),
+        purpose="Auto-generated narrative explaining what drives a measure.",
+    ),
+    _O(
+        "forecasting",
+        "Analytics",
+        True,
+        True,
+        (_R("timeAxis"), _R("measures", multi=True), _R("underlyingFactors", multi=True)),
+        ("timeAxis",),
+        purpose="Time-series forecast with confidence bands.",
+    ),
+    _O(
+        "networkAnalysis",
+        "Analytics",
+        True,
+        True,
+        (_R("source"), _R("target"), _R("size"), _R("color"), _R("linkWidth"), _R("linkColor")),
+        (),
+        purpose="Node-link network diagram of relationships.",
+    ),
+    _O(
+        "pathAnalysis",
+        "Analytics",
+        True,
+        True,
+        (_R("event"), _R("sequenceOrder"), _R("transactionId"), _R("weight")),
+        (),
+        purpose="Sankey-style flow of event sequences (journeys, funnels).",
+    ),
+    _O(
+        "cluster",
+        "Statistics",
+        True,
+        True,
+        (_R("variables", multi=True),),
+        (),
+        purpose="Cluster analysis grouping observations across variables.",
+    ),
+    _O(
+        "linearRegression",
+        "Statistics",
+        False,
+        True,
+        (_R("response"), _R("continuousEffects", multi=True), _R("classificationEffects", multi=True)),
+        (),
+        purpose="Linear regression fit summary (update-only via the API).",
+    ),
+    _O(
+        "logisticRegression",
+        "Statistics",
+        True,
+        False,
+        (_R("response"), _R("continuousEffects", multi=True)),
+        (),
+        purpose="Logistic regression fit summary.",
+    ),
+    _O(
+        "nonparametricLogisticRegression",
+        "Statistics",
+        True,
+        True,
+        (_R("response"), _R("splineEffects", multi=True)),
+        (),
+        purpose="Spline-based (GAM-like) logistic regression.",
+    ),
+    _O(
+        "bayesianNetwork",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Bayesian network model of a response and predictors.",
+    ),
+    _O(
+        "factorizationMachine",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Factorization machine model (sparse interactions).",
+    ),
+    _O(
+        "forest",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Random-forest model assessment.",
+    ),
+    _O(
+        "gradientBoosting",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Gradient-boosting model assessment (nearest to a decision tree).",
+    ),
+    _O(
+        "neuralNetwork",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Neural network model assessment.",
+    ),
+    _O(
+        "supportVectorMachine",
+        "Machine Learning",
+        True,
+        True,
+        (_R("response"), _R("predictors", multi=True)),
+        (),
+        purpose="Support vector machine model assessment.",
+    ),
+    _O(
+        "barChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True), _R("frequency")),
+        ("category",),
+        purpose="Bars comparing measures across categories — the general workhorse.",
+        render_required=(("measures", "frequency"),),
+    ),
+    _O(
+        "boxPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True)),
+        ("measures",),
+        purpose="Distribution quartiles and outliers per category.",
+    ),
+    _O(
+        "bubbleChangePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xStart"), _R("xEnd"), _R("yStart"), _R("yEnd"), _R("sizeStart"), _R("sizeEnd"), _R("group")),
+        (),
+        purpose="Bubbles showing movement between a start and an end state.",
+    ),
+    _O(
+        "bubblePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("size"), _R("group")),
+        ("xAxis", "yAxis", "size"),
+        purpose="Scatter with a third measure encoded as bubble size.",
+    ),
+    _O(
+        "butterflyChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureBar"), _R("measureBar2")),
+        (),
+        purpose="Two measures diverging left/right from a shared category axis.",
+    ),
+    _O(
+        "comparativeTimeSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("timeAxis"), _R("measureTimeSeries1"), _R("measureTimeSeries2")),
+        (),
+        purpose="Two stacked time-series panels over the same time axis.",
+    ),
+    _O(
+        "correlationMatrix",
+        "Graphs",
+        True,
+        True,
+        (_R("measures", multi=True),),
+        ("measures",),
+        purpose="Heat-colored pairwise correlations between measures.",
+    ),
+    _O(
+        "dotPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        ("category",),
+        purpose="Dots marking a measure per category — lighter than bars.",
+    ),
+    _O(
+        "dualAxisBarChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureBar"), _R("measureBar2")),
+        (),
+        purpose="Bars for two measures on independent Y axes.",
+    ),
+    _O(
+        "dualAxisBarLineChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureBar"), _R("measureLine")),
+        (),
+        purpose="Bars plus a line on independent Y axes — volume vs rate.",
+    ),
+    _O(
+        "dualAxisLineChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measureLine"), _R("measureLine2")),
+        (),
+        purpose="Two lines on independent Y axes.",
+    ),
+    _O(
+        "dualAxisTimeSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("timeAxis"), _R("measureLine"), _R("measureLine2")),
+        (),
+        purpose="Two time series on independent Y axes.",
+    ),
+    _O(
+        "gauge",
+        "Graphs",
+        True,
+        True,
+        (_R("measure"), _R("target"), _R("group")),
+        ("measure",),
+        purpose="KPI dial of a measure against a target.",
+    ),
+    _O(
+        "heatMap",
+        "Graphs",
+        True,
+        True,
+        (_R("axisItems", multi=True), _R("color")),
+        ("axisItems",),
+        purpose="Grid cells colored by a measure.",
+    ),
+    _O(
+        "histogram",
+        "Graphs",
+        True,
+        True,
+        (_R("measure"), _R("frequency")),
+        ("measure",),
+        purpose="Distribution of a single measure.",
+    ),
+    _O(
+        "keyValue",
+        "Graphs",
+        True,
+        True,
+        (_R("measure"), _R("latticeCategory")),
+        ("measure",),
+        purpose="Big-number KPI tile — one headline value.",
+    ),
+    _O(
+        "lineChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True), _R("frequency")),
+        ("category",),
+        purpose="Lines across ordered categories — trends over a non-date axis.",
+        render_required=(("measures", "frequency"),),
+    ),
+    _O(
+        "needlePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("group")),
+        (),
+        purpose="Vertical needles from a baseline — sparse event values.",
+    ),
+    _O(
+        "numericSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("group")),
+        (),
+        purpose="Line over a numeric (non-date) X axis.",
+    ),
+    _O(
+        "parallelCoordinatePlot",
+        "Graphs",
+        True,
+        True,
+        (_R("variables", multi=True),),
+        (),
+        purpose="Profile lines across many variables at once.",
+    ),
+    _O(
+        "pieChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measures", multi=True), _R("frequency")),
+        ("category",),
+        purpose="Part-to-whole share per category (keep to a few slices).",
+        render_required=(("measures", "frequency"),),
+    ),
+    _O(
+        "scatterPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("measures", multi=True), _R("color")),
+        ("measures",),
+        purpose="Point cloud relating two or more measures.",
+    ),
+    _O(
+        "scheduleChart",
+        "Graphs",
+        True,
+        True,
+        (_R("task"), _R("start"), _R("finish"), _R("group")),
+        (),
+        purpose="Gantt-style bars of tasks over start/finish times.",
+    ),
+    _O(
+        "stepPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("group")),
+        (),
+        purpose="Stepped line — values holding constant between changes.",
+    ),
+    _O(
+        "targetedBarChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measure"), _R("target")),
+        (),
+        purpose="Bars with target markers — actual vs goal.",
+    ),
+    _O(
+        "timeSeriesPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("timeAxis"), _R("measure"), _R("group")),
+        ("timeAxis",),
+        purpose="Trend of a measure over a date/time axis.",
+    ),
+    _O(
+        "treeMap",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("measure")),
+        ("category",),
+        purpose="Nested rectangles sized by a measure — hierarchical part-to-whole.",
+    ),
+    _O(
+        "vectorPlot",
+        "Graphs",
+        True,
+        True,
+        (_R("xAxis"), _R("yAxis"), _R("xOrigin"), _R("yOrigin"), _R("color")),
+        (),
+        purpose="Arrows from origin to point — direction and magnitude of change.",
+    ),
+    _O(
+        "waterfallChart",
+        "Graphs",
+        True,
+        True,
+        (_R("category"), _R("response")),
+        (),
+        purpose="Cumulative running total across categories.",
+    ),
+    _O(
+        "wordCloud",
+        "Graphs",
+        True,
+        True,
+        (_R("word"), _R("size"), _R("color")),
+        (),
+        purpose="Words sized by frequency or a measure.",
+        render_required=(("size",),),
+    ),
+)
+del _R, _O
+
+REPORT_OBJECT_TYPES: dict[str, VaObject] = {o.schema_key: o for o in OBJECTS}
+
+# Objects that appear in the VA UI but have NO schema in the report API. Mapping
+# each to the nearest addable alternative lets the tools redirect an agent
+# instead of letting it fail with an opaque VA error.
+NOT_ADDABLE: dict[str, str] = {
+    "textTopics": "wordCloud",
+    "decisionTree": "gradientBoosting",
+    "generalizedAdditiveModel": "nonparametricLogisticRegression",
+    "generalizedLinearModel": "logisticRegression",
+}
+
+CATEGORIES: tuple[str, ...] = (
+    "Tables",
+    "Controls",
+    "Containers",
+    "Content",
+    "Graphs",
+    "Geo Maps",
+    "Analytics",
+    "Statistics",
+    "Machine Learning",
+)
+
+# Colloquial names an agent is likely to try, mapped to real schema keys —
+# consulted before difflib so describe('kpi') lands on keyValue instead of
+# nothing (difflib alone scores kpi->keyValue below its cutoff).
+ALIASES: dict[str, str] = {
+    "kpi": "keyValue",
+    "tile": "keyValue",
+    "bignumber": "keyValue",
+    "indicator": "keyValue",
+    "map": "geoRegion",
+    "choropleth": "geoRegion",
+    "table": "listTable",
+    "datatable": "listTable",
+    "pivot": "crosstab",
+    "pivottable": "crosstab",
+    "filter": "dropdownList",
+    "dropdown": "dropdownList",
+    "donut": "pieChart",
+    "gantt": "scheduleChart",
+    "sankey": "pathAnalysis",
+    "trend": "timeSeriesPlot",
+    "sparkline": "timeSeriesPlot",
+    "container": "standardContainer",
+    "textbox": "text",
+    "label": "text",
+    "logo": "image",
+    "funnel": "pathAnalysis",
+}
+
+def normalize_key(value: str) -> str:
+    """Case/spacing-insensitive lookup form: 'Decision Tree' -> 'decisiontree'."""
+    return value.strip().lower().replace(" ", "").replace("-", "").replace("_", "")
+
+
+NORMALIZED_TYPES: dict[str, str] = {normalize_key(k): k for k in REPORT_OBJECT_TYPES}
+NORMALIZED_NOT_ADDABLE: dict[str, str] = {normalize_key(k): k for k in NOT_ADDABLE}
+
+
+# Analytical intent -> the object types that serve it, surfaced in the describe
+# index so an agent picks variety deliberately instead of barChart-for-everything.
+INTENT_MAP: dict[str, list[str]] = {
+    "single KPI number": ["keyValue", "gauge"],
+    "KPI row of tiles": ["standardContainer", "keyValue"],
+    "trend over time": ["timeSeriesPlot", "lineChart"],
+    "compare categories": ["barChart", "dotPlot"],
+    "actual vs target": ["targetedBarChart", "gauge"],
+    "part-to-whole": ["pieChart", "treeMap"],
+    "distribution": ["histogram", "boxPlot"],
+    "relationship between measures": ["scatterPlot", "bubblePlot", "heatMap"],
+    "geographic distribution": ["geoRegion", "geoBubble"],
+    "detail rows": ["listTable"],
+    "pivot / cross-tab": ["crosstab"],
+    "filter control": ["dropdownList", "buttonBar", "slider"],
+    "narrative text / title band": ["text"],
+    "logo / branding": ["image"],
+    "forecast": ["forecasting"],
+    "what drives a measure": ["automatedExplanation"],
+    "flows / sequences": ["pathAnalysis", "networkAnalysis"],
+}
+
+# Honest boundaries of the operations API, surfaced by describe() so an agent
+# does not burn round-trips hunting for capabilities that do not exist.
+API_LIMITS: tuple[str, ...] = (
+    "Controls are added UNWIRED: no operation creates filters, actions, or links between objects "
+    "— interactive wiring needs the VA UI (or raw report-content editing).",
+    "setParameterValue only sets EXISTING report parameters; parameters cannot be created here.",
+    "Calculated items, hierarchies, and custom sorts cannot be created via operations — save a "
+    "data view once in the VA UI, then import it with applyDataView.",
+    "No theme/page-numbering/footer operation exists; retheming lives in the SAS Report "
+    "Transforms API.",
+    "Placement and dataRoles are write-once: updateObject changes only options, and there is no "
+    "move/resize/remove operation (delete_report or save-as/copy and rebuild instead).",
+    "Objects are auto-named and auto-sized: no width/height/x/y anywhere, and VA rejects a "
+    "caller-supplied object 'name' at add time — chain layouts on the names each apply returns.",
+    "Page and report headers accept ONLY control objects — titles are text objects placed at the "
+    "top of the page body.",
+)
+
+# dataItems vocabularies from the VA v8 OpenAPI spec (dataItemProperties),
+# validated pre-flight because VA rejects unknown values with a whole-batch 400.
+AGGREGATIONS: frozenset[str] = frozenset(
+    {
+        "sum",
+        "average",
+        "min",
+        "max",
+        "count",
+        "median",
+        "variance",
+        "numberMissing",
+        "standardDeviation",
+        "standardError",
+        "firstQuartile",
+        "thirdQuartile",
+        "skewness",
+        "kurtosis",
+        "coefficientOfVariation",
+        "correctedSumOfSquares",
+        "uncorrectedSumOfSquares",
+        "tStatistic",
+        "pValue",
+    }
+)
+CLASSIFICATIONS: frozenset[str] = frozenset({"category", "measure", "geography"})
+# The geographyDataSource union from the spec: named-region contexts OR raw
+# lat/long coordinates (geographyCoordinates) — exactly one of the two.
+GEO_SOURCE_KEYS: frozenset[str] = frozenset(
+    {
+        "geographyNameCodeContext",
+        "geographyCountryRegion",
+        "geographyDataProvider",
+        "geographyCoordinates",
+    }
+)
+# Named SAS format: optional $, leading letter, optional width, dot, optional
+# decimals (DOLLAR12.2, COMMA10., PERCENT8.1, DATE9., $CHAR20.). VA rejects
+# bare numeric w.d forms like "8.1" — and the whole atomic batch with them.
+SAS_FORMAT_RE = re.compile(r"^\$?[A-Za-z][A-Za-z0-9_]*\.\d*$")
+GEO_NAME_CODE_CONTEXTS: frozenset[str] = frozenset(
+    {
+        "CountryRegionNames",
+        "CountryRegionISO2LetterCodes",
+        "CountryRegionISO3LetterCodes",
+        "CountryRegionISONumericCodes",
+        "CountryRegionSASMapIdValues",
+        "SubdivisionNames",
+        "SubdivisionSASMapIdValues",
+        "USStateNames",
+        "USStateAbbreviations",
+        "USZipCodes",
+    }
+)
+
+# The eight operations, with a worked example each, for describe(operation=...)
+# and the tool docstrings. The index lists key+purpose; the full entry (example,
+# notes) is returned by describe_report_objects(operation='addData') etc.
+OPERATIONS: tuple[dict[str, Any], ...] = (
+    {
+        "key": "addData",
+        "purpose": (
+            "Bind a CAS table as a data source; dataItems is where reports get polish — "
+            "readable labels, formats, aggregations, geography."
+        ),
+        "required": ["cas.{server, library, table}"],
+        "example": {
+            "addData": {
+                "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"},
+                "dataItems": [
+                    {
+                        "dataItem": "Revenue",
+                        "properties": {"name": "Revenue (USD)", "format": "DOLLAR12.2", "aggregation": "average"},
+                    },
+                    {
+                        "dataItem": "State",
+                        "properties": {
+                            "classification": "geography",
+                            "geographyDataSource": {"geographyNameCodeContext": "USStateNames"},
+                        },
+                    },
+                ],
+            }
+        },
+        "notes": [
+            "addObject.dataSource references the addData 'name', defaulting to cas.table.",
+            "After a rename, dataRoles must use the NEW name (e.g. 'Revenue (USD)').",
+            f"aggregation: one of {sorted(AGGREGATIONS)}.",
+            "format must be a NAMED SAS format (DOLLAR12.2, PERCENT8.1, COMMA10., DATE9.) — "
+            "bare numeric forms like '8.1' are rejected.",
+            "classification: category | measure | geography — geography classification is the "
+            "precondition for every Geo Map object.",
+            f"geographyNameCodeContext: one of {sorted(GEO_NAME_CODE_CONTEXTS)}.",
+            "Raw lat/long point data: {'classification': 'geography', 'geographyDataSource': "
+            "{'geographyCoordinates': {'latitudeDataItem': 'LATITUDE', 'longitudeDataItem': "
+            "'LONGITUDE'}}} — coordinates OR a name-code context, never both.",
+        ],
+    },
+    {
+        "key": "addPage",
+        "purpose": (
+            "Add a page; a 'title' becomes a text band at the top of the page body; reference the "
+            "page by pageName when placing objects."
+        ),
+        "required": [],
+        "example": {"addPage": {"pageName": "Overview", "title": "Sales Overview", "pagePosition": "0"}},
+        "notes": [
+            "pagePosition is a STRING here ('0' = first) — unlike the numeric "
+            "report-placement pagePosition.",
+            "The title text lands in the page body (page headers accept only controls).",
+        ],
+    },
+    {
+        "key": "addObject",
+        "purpose": "Add a visual/control/content object, titled and placed.",
+        "required": ["object.<type>  (or reportObject)"],
+        "example": {
+            "addObject": {
+                "object": {
+                    "barChart": {
+                        "dataSource": "SALES",
+                        "dataRoles": {"category": "Region", "measures": ["Revenue (USD)"]},
+                        "options": {"object": {"title": "Revenue by Region"}},
+                    }
+                },
+                "placement": {"page": {"target": "Overview"}},
+            }
+        },
+        "notes": [
+            "Allowed object-spec keys: dataSource, dataRoles, options (VA rejects anything else, "
+            "including a caller-supplied 'name').",
+            "options.object.title/alternativeText work at add time on every type except "
+            "standardContainer.",
+        ],
+    },
+    {
+        "key": "updateObject",
+        "purpose": "Change an existing object's options (title, etc.) — never its placement or data roles.",
+        "required": ["object.<type>.name"],
+        "example": {
+            "updateObject": {
+                "object": {"barChart": {"name": "ve15", "options": {"object": {"title": "MSRP by Region"}}}}
+            }
+        },
+        "notes": ["'name' is the object name (ve*) or label returned by a previous apply or get_report_outline."],
+    },
+    {
+        "key": "setParameterValue",
+        "purpose": "Set an EXISTING report parameter's value (parameters cannot be created here).",
+        "required": ["name", "value"],
+        "example": {"setParameterValue": {"name": "originFilter", "value": "Asia"}},
+    },
+    {
+        "key": "updateData",
+        "purpose": "Update an existing data source's items in place.",
+        "required": ["data"],
+        "example": {"updateData": {"data": {"name": "SALES"}}},
+    },
+    {
+        "key": "changeData",
+        "purpose": "Swap a data source for a different CAS table (copy-and-replace).",
+        "required": ["originalData", "replacementData"],
+        "example": {
+            "changeData": {
+                "originalData": {"cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"}},
+                "replacementData": {
+                    "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES_2025"}
+                },
+            }
+        },
+    },
+    {
+        "key": "applyDataView",
+        "purpose": (
+            "Import a data view saved in the VA UI — the sanctioned route to calculated items, "
+            "hierarchies, and custom sorts."
+        ),
+        "required": ["targetData", "dataView"],
+        "example": {
+            "applyDataView": {
+                "dataItemConflictResolution": "createDuplicate",
+                "targetData": {"name": "SALES"},
+                "dataView": {"name": "SALES View 1"},
+            }
+        },
+        "notes": [
+            "dataItemConflictResolution: abort (default) | createDuplicate | replaceExisting | "
+            "keepExisting | dataMapping.",
+            "dataView takes {'name': ...} or {'uri': ...}; there is no API to create or list data "
+            "views — save one in the VA UI first.",
+        ],
+    },
+)
+
+
+# VA enforces additionalProperties:false on every object spec: an unknown key
+# (including a caller-supplied 'name') fails the whole atomic batch with an HTTP
+# 400 — catch it pre-flight instead. standardContainer is stricter still: it
+# accepts NO properties at add time, not even 'options'.
+OBJECT_SPEC_ALLOWED_KEYS = frozenset({"dataSource", "dataRoles", "options"})
+
+
+# Extra guidance for objects whose real-world contract probing showed to be
+# surprising; merged into the describe() detail.
+OBJECT_NOTES: dict[str, dict[str, str]] = {
+    "text": {
+        "content_note": (
+            "Set the text via options.content (a plain string — no markup). Caveat: some Viya "
+            "builds misroute options.content to the report's FIRST text object on both add and "
+            "update, so keep one content-bearing text per report, or write additional texts via "
+            "the report content endpoint (PUT /reports/reports/{id}/content)."
+        ),
+    },
+    "image": {
+        "options_note": (
+            "options is a oneOf directly under it (no wrapper): {'url': 'https://.../logo.png'} "
+            "for a web image, OR {'imageName': 'logo.png', 'imageFolder': '/folders/folders/"
+            "{folderId}'} for a repository image (imageFolder is the folders-service URI, not a "
+            "display path). URL extension must look like an image (.png/.jpg); reachability is "
+            "NOT checked at add time, repository existence IS."
+        ),
+    },
+    "standardContainer": {
+        "options_note": (
+            "Accepts NO properties at add time — VA rejects even 'options'. Add it bare ({}), "
+            "then title it via a follow-up updateObject using the name the apply returned. "
+            "Containers auto-arrange their children; there is no layout/direction knob."
+        ),
+    },
+    "dataDrivenContent": {
+        "options_note": (
+            "The content URL is NOT settable via the operations API — a dataDrivenContent added "
+            "here renders empty until the URL is set in the VA UI."
+        ),
+    },
+    "histogram": {
+        "data_note": (
+            "A dataItem carrying a preset aggregation breaks histogram binning (the rendered "
+            "object shows 'missing data item'). Point the histogram's measure at the raw, "
+            "unaggregated column — or use a boxPlot for aggregated comparisons."
+        ),
+    },
+    "keyValue": {
+        "title_note": (
+            "Skip options.object.title on KPI tiles — the tile already renders its measure's "
+            "label prominently, so a title duplicates it. Give the measure a good display name "
+            "via addData dataItems (e.g. 'Avg Loan (USD)') instead, and place tiles side by side "
+            "in a standardContainer, never stacked on the page."
+        ),
+    },
+}

--- a/src/sas_mcp_server/prompts.py
+++ b/src/sas_mcp_server/prompts.py
@@ -134,3 +134,43 @@ def register_prompts(mcp: FastMCP) -> None:
             f"- Appropriate summary statistics\n"
             f"- Proper ODS open/close statements"
         ))]
+
+    @mcp.prompt()
+    def build_va_dashboard(table: str,
+                           audience: str | None = None,
+                           focus: str | None = None) -> list[Message]:
+        """Build a polished multi-page Visual Analytics dashboard from a CAS table,
+        using the report-authoring tools (discover → shape → structure → polish → verify)."""
+        audience_line = f"\nAudience: {audience} — match depth and terminology to them." if audience else ""
+        focus_line = f"\nFocus / key questions: {focus}." if focus else ""
+        return [Message(role="user", content=(
+            f"Build a polished SAS Visual Analytics dashboard from the CAS table {table}, "
+            f"using the report-authoring tools (describe_report_objects, create_report, "
+            f"apply_report_operations, get_report_outline, export_report).{audience_line}{focus_line}\n\n"
+            f"Work through these stages in order:\n\n"
+            f"1. DISCOVER — get_castable_columns on {table}; classify each column (measure, "
+            f"category, date, geography); pick 3-5 headline KPIs; sketch a page plan "
+            f"(overview -> detail -> data) BEFORE creating anything. Use "
+            f"describe_report_objects()'s intent_map to pick a deliberate chart variety.\n\n"
+            f"2. SHAPE THE DATA — in addData, use dataItems to rename every used column to a "
+            f"human label, apply formats (DOLLAR/PERCENT/COMMA), set the right aggregation "
+            f"(average for rates and prices — never sum a ratio), and classify geography "
+            f"columns. See describe_report_objects(operation='addData'). After a rename, "
+            f"dataRoles must use the NEW label.\n\n"
+            f"3. STRUCTURE — build the skeleton in ONE atomic create_report: pages with titles "
+            f"(addPage.title renders as a text band at the top of the page body — page headers "
+            f"accept only controls), a KPI row (standardContainer + keyValue tiles), and the "
+            f"main visuals. Then chain apply_report_operations calls for side-by-side layout "
+            f"via relativeToObject, targeting the object names each result returns (same-batch "
+            f"forward references fail; placement is write-once). The page body auto-flows "
+            f"VERTICALLY — objects that are merely page-placed render as one tall stack, so "
+            f"tiles go side by side in the container and charts pair up left/right.\n\n"
+            f"4. POLISH — give every visual a meaningful options.object.title at add time, "
+            f"EXCEPT keyValue tiles (they render their measure's label prominently — name the "
+            f"measure well in dataItems instead); 3-7 objects per page; pie charts only for "
+            f"five or fewer slices; detail rows in a listTable on their own page.\n\n"
+            f"5. VERIFY — after each structural change, get_report_outline for the structure "
+            f"and export_report (png, one page label at a time — whole-report png can render "
+            f"blank) to LOOK at the result; iterate until the overview page answers the key "
+            f"questions in five seconds."
+        ))]

--- a/src/sas_mcp_server/tools/_common.py
+++ b/src/sas_mcp_server/tools/_common.py
@@ -13,14 +13,88 @@ is the single shared dependency of the tiers — no tier imports another, so any
 subset of tiers can be registered on its own.
 """
 
+import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from typing import Any
 
 import httpx
 from fastmcp import Context
 
 from ..viya_client import logger, make_client
 from ..viya_utils import get_cached_session
+
+# --- tolerant input coercion -------------------------------------------------
+# Some MCP clients (observed live: Claude Cowork) serialize optional list/dict
+# parameters as JSON-ENCODED STRINGS ('[{"addData": ...}]' instead of the
+# array), and the model cannot fix that from its side — pydantic rejects the
+# call before the tool body runs. These BeforeValidator coercions absorb the
+# whole failure class server-side without changing the published JSON schema
+# (BeforeValidator does not alter the annotated type's schema).
+
+
+def coerce_json_list(value: Any) -> Any:
+    """Parse a JSON-encoded string into the list it encodes."""
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(
+                "expected a JSON array (got an unparseable string). Pass the value as a "
+                "real array, not a quoted JSON string."
+            ) from exc
+        if not isinstance(parsed, list):
+            # ValueError, not TypeError: pydantic only converts ValueError into
+            # a clean validation error inside a BeforeValidator.
+            raise ValueError("expected a JSON array; the string decodes to a non-array value.")  # noqa: TRY004
+        return parsed
+    return value
+
+
+def coerce_str_or_json_list(value: Any) -> Any:
+    """Like :func:`coerce_json_list`, but a bare string becomes a 1-element list.
+
+    ``report_objects='["Overview"]'`` and ``report_objects='Overview'`` were both
+    observed live; each has exactly one sensible reading. A string that merely
+    LOOKS like JSON but isn't (a label such as ``'[Draft] Overview'``) is a
+    label, and a double-encoded scalar (``'"Overview"'``) unwraps once.
+    """
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except (json.JSONDecodeError, ValueError):
+                return [value]  # a label that happens to start with '['
+            if isinstance(parsed, list):
+                return parsed
+            return [value]
+        if text.startswith('"'):
+            try:
+                parsed = json.loads(text)
+            except (json.JSONDecodeError, ValueError):
+                return [value]
+            if isinstance(parsed, str):
+                return [parsed]
+        return [value]
+    return value
+
+
+def coerce_json_dict(value: Any) -> Any:
+    """Parse a JSON-encoded string into the object it encodes."""
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(
+                "expected a JSON object (got an unparseable string). Pass the value as a "
+                "real object, not a quoted JSON string."
+            ) from exc
+        if not isinstance(parsed, dict):
+            # ValueError, not TypeError: see coerce_json_list.
+            raise ValueError("expected a JSON object; the string decodes to a non-object value.")  # noqa: TRY004
+        return parsed
+    return value
 
 
 def make_session_helpers(get_token: Callable[[Context], Awaitable[str]]):

--- a/src/sas_mcp_server/tools/decisioning.py
+++ b/src/sas_mcp_server/tools/decisioning.py
@@ -6,9 +6,10 @@
 import asyncio
 import json
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from pydantic import BeforeValidator
 
 from ..config import VIYA_ENDPOINT
 from ..viya_client import (
@@ -21,7 +22,11 @@ from ..viya_client import (
     raise_for_viya_status,
     return_items,
 )
-from ._common import make_session_helpers
+from ._common import coerce_json_list, make_session_helpers
+
+# Tolerant alias for list params some MCP clients deliver as JSON-encoded
+# strings (see _common.coerce_json_list). The published schema is unchanged.
+DictListParam = Annotated[list[dict[str, Any]], BeforeValidator(coerce_json_list)]
 
 
 def _build_decision_flow_body(
@@ -63,7 +68,7 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
 
     @mcp.tool()
     async def create_business_ruleset(
-        name: str, signature: list[dict[str, Any]], ctx: Context, description: str | None = None
+        name: str, signature: DictListParam, ctx: Context, description: str | None = None
     ) -> dict[str, Any]:
         """Create a new SAS Business Rules rule set.
 
@@ -84,7 +89,7 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
 
     @mcp.tool()
     async def update_business_ruleset(
-        ruleset_id: str, name: str, signature: list[dict[str, Any]], ctx: Context, description: str | None = None
+        ruleset_id: str, name: str, signature: DictListParam, ctx: Context, description: str | None = None
     ) -> dict[str, Any]:
         """Update an existing SAS Business Rules rule set's name/description/signature.
 
@@ -205,8 +210,8 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         name: str,
         conditional: str,
         rule_fired_tracking_enabled: bool,
-        conditions: list[dict[str, Any]],
-        actions: list[dict[str, Any]],
+        conditions: DictListParam,
+        actions: DictListParam,
         ctx: Context,
     ) -> dict[str, Any]:
         """Create a new rule inside an existing SAS Business Rules rule set.
@@ -252,8 +257,8 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         name: str,
         conditional: str,
         rule_fired_tracking_enabled: bool,
-        conditions: list[dict[str, Any]],
-        actions: list[dict[str, Any]],
+        conditions: DictListParam,
+        actions: DictListParam,
         ctx: Context,
     ) -> dict[str, Any]:
         """Update an existing rule inside a SAS Business Rules rule set.
@@ -320,8 +325,8 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
     @mcp.tool()
     async def create_decision_flow(
         name: str,
-        signature: list[dict[str, Any]],
-        rule_set_steps: list[dict[str, Any]],
+        signature: DictListParam,
+        rule_set_steps: DictListParam,
         ctx: Context,
         description: str | None = None,
     ) -> dict[str, Any]:
@@ -350,8 +355,8 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
     async def update_decision_flow(
         decision_id: str,
         name: str,
-        signature: list[dict[str, Any]],
-        rule_set_steps: list[dict[str, Any]],
+        signature: DictListParam,
+        rule_set_steps: DictListParam,
         ctx: Context,
         description: str | None = None,
     ) -> dict[str, Any]:

--- a/src/sas_mcp_server/tools/discovery.py
+++ b/src/sas_mcp_server/tools/discovery.py
@@ -704,8 +704,12 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         table_name: str,
         ctx: Context,
         limit: int = 200,
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Get column metadata for a CAS table (names, types, labels, formats).
+
+        A missing table returns a structured ``not_found`` with the two usual
+        causes (unloaded source table vs session-scoped table) instead of a raw
+        HTTP error.
 
         Args:
             server_id: CAS server name or ID.
@@ -714,11 +718,30 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
             limit: Maximum columns to return (default 200).
         """
         async with viya_session("get_castable_columns", ctx) as client:
-            items, _ = await get_paged_items(
-                f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}/columns",
-                client,
-                limit=limit,
-            )
+            try:
+                items, _ = await get_paged_items(
+                    f"/casManagement/servers/{server_id}/caslibs/{caslib_name}/tables/{table_name}/columns",
+                    client,
+                    limit=limit,
+                )
+            except httpx.HTTPStatusError as exc:
+                if exc.response is not None and exc.response.status_code == 404:
+                    return {
+                        "status": "not_found",
+                        "server": server_id,
+                        "caslib": caslib_name,
+                        "table": table_name,
+                        "message": (
+                            f"casManagement has no loaded table '{table_name}' in caslib "
+                            f"'{caslib_name}'. Two usual causes: (1) the table exists on disk "
+                            f"but is not loaded into memory — call promote_table_to_memory "
+                            f"(VA addData can also auto-load it); (2) the table was created in "
+                            f"a SAS/CAS session without PROMOTE=YES, so it is session-scoped "
+                            f"and invisible here — re-create it with PROMOTE=YES (e.g. "
+                            f"PROC CASUTIL PROMOTE, or data step with promote=yes)."
+                        ),
+                    }
+                raise
             return return_items(items, ["name", "type", "rawLength", "label", "format"])
 
     @mcp.tool()

--- a/src/sas_mcp_server/tools/reports.py
+++ b/src/sas_mcp_server/tools/reports.py
@@ -4,13 +4,20 @@
 """Tier 3 — Reports & Visualization tools."""
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from pydantic import BeforeValidator
 
-from ..helpers import report_export_helpers
-from ..viya_client import contains_filter, get_json, get_paged_items, return_items
-from ._common import make_session_helpers
+from ..helpers import report_authoring_helpers, report_export_helpers
+from ..viya_client import contains_filter, get_json, get_paged_items, logger, return_items
+from ._common import coerce_json_dict, coerce_json_list, coerce_str_or_json_list, make_session_helpers
+
+# Tolerant aliases for params some MCP clients deliver as JSON-encoded strings
+# (see _common.coerce_json_list). The published schema is unchanged.
+OperationsParam = Annotated[list[dict[str, Any]], BeforeValidator(coerce_json_list)]
+ReportObjectsParam = Annotated[list[str], BeforeValidator(coerce_str_or_json_list)]
+OptionsParam = Annotated[dict[str, Any], BeforeValidator(coerce_json_dict)]
 
 
 def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> None:
@@ -46,9 +53,9 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         report_id: str,
         export_format: str,
         ctx: Context,
-        report_objects: list[str] | None = None,
+        report_objects: ReportObjectsParam | None = None,
         image_size: str | None = None,
-        options: dict[str, Any] | None = None,
+        options: OptionsParam | None = None,
     ):
         """Export a Visual Analytics report (or specific report objects) in any
         format the VA service exposes, via its synchronous export endpoints.
@@ -80,6 +87,14 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         embedded binary file (carrying the right MIME type) for ``package`` /
         ``pdf`` / ``xlsx``. Binary results larger than ``MAX_EXPORT_INLINE_BYTES``
         are refused with guidance rather than streamed through the model context.
+
+        Verifying freshly authored reports: a WHOLE-report ``png`` can render
+        blank (API-created reports keep an empty default "Page 1" first) —
+        export page-by-page instead by passing a page label in
+        ``report_objects``. Text objects 404 on per-object image export; use
+        their page. ``pdf`` with no ``report_objects`` is the reliable
+        whole-report fallback. ``get_report_outline`` lists the page/object
+        labels to pass here.
         """
         req = report_export_helpers.ReportExportRequest(
             report_id=report_id,
@@ -93,3 +108,272 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
             return error
         async with viya_session("export_report", ctx) as client:
             return await report_export_helpers.execute_export(req, client)
+
+    @mcp.tool()
+    async def describe_report_objects(
+        ctx: Context,
+        object_type: str | None = None,
+        category: str | None = None,
+        operation: str | None = None,
+    ) -> dict[str, Any]:
+        """Discover what a Visual Analytics report can contain — operations and objects.
+
+        Call this to learn how to build a report before calling
+        ``apply_report_operations``. It reads a bundled catalog (no network), so
+        it is the cheap way to look up an object's data roles instead of guessing.
+
+        Modes:
+          * No arguments — an index: the eight report operations, every addable
+            object (schema key, one-line purpose, category, addable/updatable),
+            an intent→object map (e.g. "single KPI number" → ``keyValue``), the
+            placement guide, layout recipes, and the API's hard limits.
+          * ``category`` — the index filtered to one category (Tables, Controls,
+            Containers, Content, Graphs, Geo Maps, Analytics, Statistics,
+            Machine Learning).
+          * ``object_type`` — one object's full contract: its data roles (each
+            marked single vs list), the roles it commonly needs, its common
+            options (``options.object.title`` etc.), and a ready-to-send
+            ``addObject`` example. Colloquial names resolve (``"kpi"`` →
+            ``keyValue``); for a VA UI object with no API support (Text Topics,
+            Decision tree, GAM, GLM) it returns the nearest addable alternative;
+            for an unknown key it returns ``did_you_mean``.
+          * ``operation`` — one operation's full shape with a worked example and
+            notes; ``operation="addData"`` documents ``dataItems`` (column
+            renames, SAS formats, aggregations, geography classification — the
+            polish layer most reports need).
+
+        Pair it with ``get_castable_columns`` to see which columns are categories
+        vs measures, then map those columns onto the roles reported here.
+
+        Args:
+            object_type: A schema key (e.g. ``"barChart"``, ``"scatterPlot"``)
+                or colloquial alias for its contract and example.
+            category: Restrict the catalog to one category.
+            operation: An operation key (e.g. ``"addData"``, ``"applyDataView"``)
+                for its full shape, example, and notes.
+        """
+        logger.info("--- TOOL USED: describe_report_objects ---")
+        return report_authoring_helpers.describe(object_type=object_type, category=category, operation=operation)
+
+    @mcp.tool()
+    async def create_report(
+        name: str,
+        ctx: Context,
+        folder: str | None = None,
+        on_conflict: str = "rename",
+        operations: OperationsParam | None = None,
+    ) -> dict[str, Any]:
+        """Create a Visual Analytics report and return its id for further edits.
+
+        Creates an empty report shell, or — if you pass ``operations`` — builds
+        the whole report in one atomic call (bind data, add pages, add objects).
+        Building at creation avoids leaving an empty report behind if a later
+        edit fails. Returns ``{"status": "created", "id": ..., "name": ...}``
+        plus a ``created`` summary whose object names/labels are what follow-up
+        placement and exports target; feed the id to ``apply_report_operations``
+        to keep editing. Note: VA prepends an empty default "Page 1" before any
+        pages your operations add, so verify page-by-page with ``export_report``
+        (see the result's ``verify_hint``) rather than a whole-report export.
+
+        Args:
+            name: Report name (``resultReportName``). Must be unique in the folder
+                unless ``on_conflict`` resolves it.
+            folder: Optional target folder URI (``resultFolder``); omit for the
+                caller's My Folder.
+            on_conflict: Name-conflict policy — ``rename`` (default), ``abort``,
+                or ``replace``.
+            operations: Optional native operations array to apply at creation, in
+                the same shape ``apply_report_operations`` takes. Call
+                ``describe_report_objects`` for the operation and object formats.
+        """
+        ops = report_authoring_helpers.normalize_operations(operations) if operations else None
+        req = report_authoring_helpers.CreateReportRequest(
+            name=name, folder=folder, on_conflict=on_conflict, operations=ops
+        )
+        error = report_authoring_helpers.validate_create(req)
+        if error is not None:
+            return error
+        warnings = report_authoring_helpers.warn_operations(ops) if ops else []
+        async with viya_session("create_report", ctx) as client:
+            result = await report_authoring_helpers.execute_create(req, client)
+        if warnings and result.get("status") == "created":
+            result["warnings"] = warnings
+        return result
+
+    @mcp.tool()
+    async def apply_report_operations(
+        report_id: str,
+        operations: OperationsParam,
+        ctx: Context,
+        dry_run: bool = False,
+        response_format: str = "concise",
+        result_report_name: str | None = None,
+        result_folder: str | None = None,
+        result_name_conflict: str = "rename",
+    ) -> dict[str, Any]:
+        """Apply an ordered batch of operations to a report — the authoring workhorse.
+
+        This is how you add pages, add objects (any of the ~60 VA visual, control,
+        and content types), set parameters, and swap data sources. ``operations``
+        is the native SAS Visual Analytics operations array; the whole batch is
+        applied atomically (all succeed or nothing changes).
+
+        Operation keys (one per array element): ``addData``, ``addPage``,
+        ``addObject``, ``updateObject``, ``setParameterValue``, ``updateData``,
+        ``changeData``, ``applyDataView``. Call ``describe_report_objects`` for
+        each operation's shape (``operation="addData"`` covers formats,
+        aggregations, and geography via ``dataItems``) and each object's data
+        roles, and ``get_castable_columns`` to map columns onto those roles.
+
+        Layout & titles (see ``describe_report_objects`` → ``placement`` /
+        ``layout_recipes`` for details):
+          * Page title — give ``addPage`` a ``title`` (e.g. ``{"addPage":
+            {"pageName": "Overview", "title": "Sales Overview"}}``); it becomes a
+            text band at the top of that page's body. Page/report headers accept
+            ONLY control objects — never text or visuals.
+          * Chart titles — pass ``{"options": {"object": {"title": "..."}}}``
+            inside the object spec at add time (all types except
+            ``standardContainer``, which takes no options at add time).
+          * One-batch multi-page — create pages inline with placement
+            ``{"report": {"context": "new_page", "pageName": "Trends",
+            "pagePosition": 1}}`` (numeric position) and target that pageName
+            from later operations in the same batch.
+          * Grids/columns — ``relativeToObject`` with ``left/right/top/bottom``
+            (geometric) or ``before/after`` (flow order) against an EXISTING
+            object's name; same-batch forward references fail, so chain across
+            calls using the names each result returns. Objects are auto-named
+            and auto-sized; placement and dataRoles are write-once
+            (``updateObject`` changes options only).
+          * Read structure back anytime with ``get_report_outline``; verify
+            visually with ``export_report`` page-by-page (see ``verify_hint``
+            in the result).
+
+        The tool validates every operation against the object catalog before any
+        HTTP call (unknown/typo'd object type, non-addable object, bad data-role
+        names or arity, disallowed object/placement keys) and reports ALL invalid
+        operations at once. It also handles the ETag optimistic-concurrency
+        handshake for you, retrying once transparently on a concurrent edit.
+
+        Args:
+            report_id: Target report id (from ``create_report`` or ``list_reports``).
+            operations: Ordered native operations array. Example element:
+                ``{"addObject": {"object": {"barChart": {"dataSource": "CARS",
+                "dataRoles": {"category": "Origin", "measures": ["MSRP"]},
+                "options": {"object": {"title": "MSRP by Origin"}}}},
+                "placement": {"page": {"target": "Overview"}}}}``.
+            dry_run: Validate and return the normalized payload (plus any
+                soft warnings about missing common roles) without writing anything.
+            response_format: ``concise`` (default) returns the created page/object/
+                data-source names+labels; ``detailed`` also echoes the full VA
+                response.
+            result_report_name: Save-as — apply the operations to a NEW report
+                with this name, leaving the source report untouched (atomic
+                template instantiation; pairs with ``changeData``).
+            result_folder: Save-as target folder URI; omit for My Folder.
+            result_name_conflict: Save-as name-conflict policy — ``rename``
+                (default), ``abort``, or ``replace``.
+        """
+        if result_name_conflict not in report_authoring_helpers.CONFLICT_VALUES:
+            return {
+                "status": "invalid_request",
+                "message": f"result_name_conflict must be one of {sorted(report_authoring_helpers.CONFLICT_VALUES)}.",
+            }
+        for param_name, value in (("result_report_name", result_report_name), ("result_folder", result_folder)):
+            # A blank save-as target would silently fall back to editing the
+            # SOURCE report in place — refuse it instead.
+            if value is not None and not str(value).strip():
+                return {
+                    "status": "invalid_request",
+                    "message": f"{param_name}, if given, must be non-empty (blank would edit the source in place).",
+                }
+        ops = report_authoring_helpers.normalize_operations(operations)
+        error = report_authoring_helpers.validate_operations(ops)
+        if error is not None:
+            return error
+        warnings = report_authoring_helpers.warn_operations(ops)
+        if dry_run:
+            return {"status": "valid", "warnings": warnings, "normalized_operations": ops}
+        async with viya_session("apply_report_operations", ctx) as client:
+            result = await report_authoring_helpers.execute_operations(
+                report_id,
+                ops,
+                client,
+                response_format=response_format,
+                result_report_name=result_report_name,
+                result_folder=result_folder,
+                result_name_conflict=result_name_conflict,
+            )
+        if warnings and result.get("status") == "applied":
+            result["warnings"] = warnings
+        return result
+
+    @mcp.tool()
+    async def get_report_outline(report_id: str, ctx: Context) -> dict[str, Any]:
+        """Read a report's structure: pages → objects with the handles other tools need.
+
+        Reduces the stored report definition to a compact outline —
+        per page its internal name and label, per object its name (``ve*``),
+        label, type, and any text content. Use it to edit an existing report,
+        to recover object names after an apply, or to check what a batch
+        actually produced:
+
+          * object ``name`` → the target for ``relativeToObject``/``container``
+            placement and ``updateObject``;
+          * object ``label`` → what ``export_report`` ``report_objects`` takes;
+          * page ``label`` → the ``page`` placement target.
+
+        Returns ``{"status": "ok", "pages": [...], "hint": ...}`` (or
+        ``not_found`` / ``outline_failed``).
+
+        Args:
+            report_id: The report id to outline.
+        """
+        async with viya_session("get_report_outline", ctx) as client:
+            return await report_authoring_helpers.execute_outline(report_id, client)
+
+    @mcp.tool()
+    async def copy_report(
+        report_id: str,
+        ctx: Context,
+        name: str | None = None,
+        folder: str | None = None,
+        on_conflict: str = "rename",
+    ) -> dict[str, Any]:
+        """Copy a Visual Analytics report to a new report, returning the copy's id.
+
+        Useful for tailoring a report to a new audience or for the copy-and-replace
+        pattern — copy, then ``apply_report_operations`` with a ``changeData`` op to
+        point the copy at a different table. Returns
+        ``{"status": "copied", "id": ..., "name": ..., "source_report_id": ...}``.
+
+        Args:
+            report_id: The source report id to copy.
+            name: Optional name for the copy (``resultReportName``); omit to let
+                Viya name it.
+            folder: Optional target folder URI (``resultFolder``); omit for the
+                caller's My Folder.
+            on_conflict: Name-conflict policy — ``rename`` (default), ``abort``,
+                or ``replace``.
+        """
+        error = report_authoring_helpers.validate_copy(name, on_conflict)
+        if error is not None:
+            return error
+        async with viya_session("copy_report", ctx) as client:
+            return await report_authoring_helpers.execute_copy(
+                report_id, name, folder, on_conflict, client
+            )
+
+    @mcp.tool()
+    async def delete_report(report_id: str, ctx: Context) -> dict[str, Any]:
+        """Delete a Visual Analytics report and its content.
+
+        There is no per-object undo in the report API, so deleting and rebuilding
+        (or copying first) is how you discard an unwanted report. Returns
+        ``{"status": "deleted", "report_id": ...}`` (or ``not_found`` /
+        ``delete_failed``).
+
+        Args:
+            report_id: The report id to delete.
+        """
+        async with viya_session("delete_report", ctx) as client:
+            return await report_authoring_helpers.execute_delete(report_id, client)

--- a/src/sas_mcp_server/tools/reports.py
+++ b/src/sas_mcp_server/tools/reports.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 from fastmcp import Context, FastMCP
 from pydantic import BeforeValidator
 
-from ..helpers import report_authoring_helpers, report_export_helpers
+from ..helpers import report_authoring_helpers, report_authoring_registry, report_export_helpers
 from ..viya_client import contains_filter, get_json, get_paged_items, logger, return_items
 from ._common import coerce_json_dict, coerce_json_list, coerce_str_or_json_list, make_session_helpers
 
@@ -273,10 +273,10 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
             result_name_conflict: Save-as name-conflict policy — ``rename``
                 (default), ``abort``, or ``replace``.
         """
-        if result_name_conflict not in report_authoring_helpers.CONFLICT_VALUES:
+        if result_name_conflict not in report_authoring_registry.CONFLICT_VALUES:
             return {
                 "status": "invalid_request",
-                "message": f"result_name_conflict must be one of {sorted(report_authoring_helpers.CONFLICT_VALUES)}.",
+                "message": f"result_name_conflict must be one of {sorted(report_authoring_registry.CONFLICT_VALUES)}.",
             }
         for param_name, value in (("result_report_name", result_report_name), ("result_folder", result_folder)):
             # A blank save-as target would silently fall back to editing the

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -622,6 +622,150 @@ async def test_report_workflow(integration_mcp_server):
         assert _embedded_file_bytes(package) > 0
 
 
+async def test_report_authoring_workflow(integration_mcp_server):
+    """describe_report_objects → create_report (one atomic build with data
+    polish + page title + titled chart) → apply_report_operations (relative
+    placement chained on returned names, then save-as) → get_report_outline →
+    copy_report → delete_report.
+
+    Uses the ``Public.HMEQ`` sample table (same anchor as the CAS discovery
+    workflow); every report created here — the build, the save-as result, and
+    the copy — is deleted at the end.
+    """
+    report_name = f"MCP Authoring IT {_SUFFIX}"
+    async with Client(integration_mcp_server) as client:
+        # Discovery is a local catalog read — sanity-check the surfaces the
+        # authoring loop depends on.
+        index = (await client.call_tool("describe_report_objects", {})).data
+        assert any(o["schema_key"] == "keyValue" for o in index["objects"])
+        assert "single KPI number" in index["intent_map"]
+        add_data = (await client.call_tool("describe_report_objects", {"operation": "addData"})).data
+        assert "dataItems" in add_data["example"]["addData"]
+
+        servers = (await client.call_tool("list_cas_servers", {})).data
+        assert servers, "No CAS servers found"
+        cas_server = servers[0]["name"]
+
+        extra_ids: list[str] = []
+        created = (
+            await client.call_tool(
+                "create_report",
+                {
+                    "name": report_name,
+                    "operations": [
+                        {
+                            "addData": {
+                                "cas": {"server": cas_server, "library": "Public", "table": "HMEQ"},
+                                "dataItems": [
+                                    {
+                                        "dataItem": "LOAN",
+                                        "properties": {
+                                            "name": "Loan Amount",
+                                            "format": "DOLLAR12.",
+                                            "aggregation": "average",
+                                        },
+                                    }
+                                ],
+                            }
+                        },
+                        {"addPage": {"pageName": "Overview", "title": "HMEQ Overview"}},
+                        {
+                            "addObject": {
+                                "object": {
+                                    "barChart": {
+                                        "dataSource": "HMEQ",
+                                        "dataRoles": {"category": "REASON", "measures": ["Loan Amount"]},
+                                        "options": {"object": {"title": "Average Loan by Reason"}},
+                                    }
+                                },
+                                "placement": {"page": {"target": "Overview"}},
+                            }
+                        },
+                    ],
+                },
+            )
+        ).data
+        if created.get("status") == "create_failed":
+            pytest.skip(f"Report create failed on this Viya (is Public.HMEQ available?): {created.get('message')}")
+        assert created["status"] == "created"
+        report_id = created["id"]
+        try:
+            # The title expands into a body text object appended at the END of
+            # the batch (so caller op indices survive), giving [barChart, text]
+            # — index-aligned names from the response.
+            objects = created["created"]["objects"]
+            assert [o["type"] for o in objects] == ["barChart", "text"]
+            bar_name = objects[0].get("name")
+            assert bar_name, "create response carried no object names"
+
+            # Chain a KPI tile to the right of the bar chart by its returned name.
+            applied = (
+                await client.call_tool(
+                    "apply_report_operations",
+                    {
+                        "report_id": report_id,
+                        "operations": [
+                            {
+                                "addObject": {
+                                    "object": {
+                                        # keyValue tiles get no title — the measure's
+                                        # label renders prominently on the tile.
+                                        "keyValue": {
+                                            "dataSource": "HMEQ",
+                                            "dataRoles": {"measure": "Loan Amount"},
+                                        }
+                                    },
+                                    "placement": {
+                                        "relativeToObject": {"target": bar_name, "position": "right"}
+                                    },
+                                }
+                            }
+                        ],
+                    },
+                )
+            ).data
+            assert applied["status"] == "applied"
+            assert applied["created"]["objects"][0].get("name")
+
+            # Read the structure back: the page and both chained objects.
+            outline = (await client.call_tool("get_report_outline", {"report_id": report_id})).data
+            assert outline["status"] == "ok"
+            overview = next(p for p in outline["pages"] if p["label"] == "Overview")
+            assert any(o["name"] == bar_name for o in overview["objects"])
+
+            # Save-as: apply to a NEW report, leaving the source untouched.
+            saved = (
+                await client.call_tool(
+                    "apply_report_operations",
+                    {
+                        "report_id": report_id,
+                        "operations": [{"addPage": {"pageName": "SaveAsPage"}}],
+                        "result_report_name": f"{report_name} SaveAs",
+                    },
+                )
+            ).data
+            assert saved["status"] == "applied"
+            assert saved["saved_as"]["id"]
+            extra_ids.append(saved["saved_as"]["id"])
+            source_outline = (await client.call_tool("get_report_outline", {"report_id": report_id})).data
+            assert all(p["label"] != "SaveAsPage" for p in source_outline["pages"])
+
+            copied = (
+                await client.call_tool(
+                    "copy_report", {"report_id": report_id, "name": f"{report_name} Copy"}
+                )
+            ).data
+            assert copied["status"] == "copied"
+            assert copied["id"]
+            extra_ids.append(copied["id"])
+        finally:
+            deleted = (await client.call_tool("delete_report", {"report_id": report_id})).data
+            assert deleted["status"] == "deleted"
+            for extra in extra_ids:
+                with contextlib.suppress(Exception):
+                    await client.call_tool("delete_report", {"report_id": extra})
+
+
 # -----------------------------------------------------------------------
 # ML Project Workflow
 # -----------------------------------------------------------------------
@@ -1200,6 +1344,7 @@ PROMPT_RENDER_ARGS = {
     "explain_sas_code": {"sas_code": "proc print data=sashelp.class; run;"},
     "sas_macro_builder": {"macro_name": "loadcsv", "purpose": "Load a CSV into CAS"},
     "generate_report": {"dataset": "SASHELP.CLASS"},
+    "build_va_dashboard": {"table": "Public.HMEQ"},
 }
 
 
@@ -1399,6 +1544,12 @@ TOOL_COVERAGE = {
     "list_reports": "test_report_workflow",
     "get_report": "test_report_workflow",
     "export_report": "test_report_workflow",
+    "describe_report_objects": "test_report_authoring_workflow",
+    "create_report": "test_report_authoring_workflow",
+    "apply_report_operations": "test_report_authoring_workflow",
+    "get_report_outline": "test_report_authoring_workflow",
+    "copy_report": "test_report_authoring_workflow",
+    "delete_report": "test_report_authoring_workflow",
     "submit_batch_job": "test_batch_job_workflow",
     "get_job_status": "test_batch_job_workflow",
     "list_jobs": "test_batch_job_workflow",

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -39,6 +39,7 @@ async def test_all_prompts_registered(prompt_mcp):
         "explain_sas_code",
         "sas_macro_builder",
         "generate_report",
+        "build_va_dashboard",
     }
     prompts = await prompt_mcp.list_prompts()
     registered = {p.name for p in prompts}
@@ -133,3 +134,27 @@ async def test_generate_report(prompt_mcp):
     assert "detailed" in content
     assert "PDF" in content
     assert "WORK.SALES" in content
+
+
+async def test_build_va_dashboard(prompt_mcp):
+    """Test build_va_dashboard prompt."""
+    prompt_fn = await _prompt_fn(prompt_mcp, "build_va_dashboard")
+    messages = prompt_fn(table="Public.HMEQ", audience="executives", focus="loan default risk")
+    content = messages[0].content.text
+    assert "Public.HMEQ" in content
+    assert "executives" in content
+    assert "loan default risk" in content
+    # The method stages and the tools they lean on are all named.
+    for stage in ("DISCOVER", "SHAPE THE DATA", "STRUCTURE", "POLISH", "VERIFY"):
+        assert stage in content
+    for tool in ("create_report", "apply_report_operations", "get_report_outline", "export_report"):
+        assert tool in content
+
+
+async def test_build_va_dashboard_minimal(prompt_mcp):
+    """Optional args omitted — no dangling audience/focus lines."""
+    prompt_fn = await _prompt_fn(prompt_mcp, "build_va_dashboard")
+    content = prompt_fn(table="Public.CARS")[0].content.text
+    assert "Public.CARS" in content
+    assert "Audience:" not in content
+    assert "Focus" not in content.split("\n")[0]

--- a/tests/test_report_authoring_helpers.py
+++ b/tests/test_report_authoring_helpers.py
@@ -1,0 +1,884 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the report_authoring helpers — pure logic, no MCP or network.
+
+Cover the object registry, the pre-flight operation validation, the discovery
+describe(), tolerant normalisation, common-role warnings, and the request
+shaping that back the create_report / apply_report_operations tools.
+"""
+
+from sas_mcp_server.helpers.report_authoring_helpers import (
+    AGGREGATIONS,
+    NOT_ADDABLE,
+    OPERATION_KEYS,
+    REPORT_OBJECT_TYPES,
+    CreateReportRequest,
+    build_copy_body,
+    build_create_body,
+    describe,
+    normalize_operations,
+    parse_failure,
+    reduce_content_outline,
+    summarize_created,
+    validate_copy,
+    validate_create,
+    validate_operations,
+    warn_operations,
+)
+
+
+def _add_object(type_key, data_roles=None, page="P1", data_source="CARS"):
+    obj = {"dataSource": data_source}
+    if data_roles is not None:
+        obj["dataRoles"] = data_roles
+    op = {"addObject": {"object": {type_key: obj}}}
+    if page:
+        op["addObject"]["placement"] = {"page": {"target": page}}
+    return op
+
+
+# --- registry integrity ---------------------------------------------------
+
+
+def test_registry_has_all_addable_objects():
+    # 64 objects reachable via addObject; linearRegression is update-only.
+    addable = [o for o in REPORT_OBJECT_TYPES.values() if o.addable]
+    assert len(addable) == 64
+    assert REPORT_OBJECT_TYPES["linearRegression"].addable is False
+    assert REPORT_OBJECT_TYPES["linearRegression"].updatable is True
+
+
+def test_registry_add_update_asymmetries():
+    assert REPORT_OBJECT_TYPES["geoCluster"].addable is True
+    assert REPORT_OBJECT_TYPES["geoCluster"].updatable is False
+    assert REPORT_OBJECT_TYPES["logisticRegression"].updatable is False
+
+
+def test_not_addable_ui_objects_mapped():
+    assert set(NOT_ADDABLE) == {
+        "textTopics",
+        "decisionTree",
+        "generalizedAdditiveModel",
+        "generalizedLinearModel",
+    }
+    assert NOT_ADDABLE["decisionTree"] == "gradientBoosting"
+
+
+def test_multi_roles_flagged():
+    bar = REPORT_OBJECT_TYPES["barChart"]
+    measures = next(r for r in bar.roles if r.name == "measures")
+    category = next(r for r in bar.roles if r.name == "category")
+    assert measures.multi is True
+    assert category.multi is False
+
+
+# --- describe -------------------------------------------------------------
+
+
+def test_describe_index_lists_operations_and_objects():
+    idx = describe()
+    assert {op["key"] for op in idx["operations"]} == set(OPERATION_KEYS)
+    assert any(o["schema_key"] == "barChart" for o in idx["objects"])
+
+
+def test_describe_category_filter():
+    idx = describe(category="Geo Maps")
+    cats = {o["category"] for o in idx["objects"]}
+    assert cats == {"Geo Maps"}
+
+
+def test_describe_object_detail_has_example_and_roles():
+    detail = describe(object_type="scatterPlot")
+    assert detail["schema_key"] == "scatterPlot"
+    assert detail["commonly_required"] == ["measures"]
+    assert "addObject" in detail["example"]
+
+
+def test_describe_geo_precondition():
+    detail = describe(object_type="geoRegion")
+    assert "precondition" in detail
+
+
+def test_describe_update_only_object_notes_it():
+    detail = describe(object_type="linearRegression")
+    assert detail["addable"] is False
+    assert "note" in detail
+
+
+def test_describe_not_addable_redirects():
+    detail = describe(object_type="decisionTree")
+    assert detail["status"] == "not_addable"
+    assert detail["nearest"] == "gradientBoosting"
+
+
+def test_describe_wrong_case_resolves():
+    detail = describe(object_type="barchart")  # wrong case resolves via normalized lookup
+    assert detail["schema_key"] == "barChart"
+    assert detail["resolved_from_alias"] == "barchart"
+
+
+def test_describe_unknown_suggests():
+    detail = describe(object_type="barChrat")  # typo
+    assert detail["status"] == "unknown_object_type"
+    assert "barChart" in detail["did_you_mean"]
+
+
+def test_describe_not_addable_ui_names_resolve():
+    # The VA UI spellings ("Decision Tree", "Text Topics") must hit the
+    # redirect too, not fall through to unknown_object_type.
+    assert describe(object_type="decision tree")["status"] == "not_addable"
+    assert describe(object_type="Text Topics")["nearest"] == "wordCloud"
+
+
+def test_describe_index_has_purposes_intents_and_limits():
+    idx = describe()
+    key_value = next(o for o in idx["objects"] if o["schema_key"] == "keyValue")
+    assert "KPI" in key_value["purpose"]
+    assert "keyValue" in idx["intent_map"]["single KPI number"]
+    assert any("header" in limit for limit in idx["limits"])
+
+
+def test_describe_alias_resolves_to_object():
+    detail = describe(object_type="kpi")
+    assert detail["schema_key"] == "keyValue"
+    assert detail["resolved_from_alias"] == "kpi"
+
+
+def test_describe_operation_mode_returns_full_entry():
+    entry = describe(operation="addData")
+    assert entry["key"] == "addData"
+    assert "dataItems" in entry["example"]["addData"]
+    assert any("geography" in n for n in entry["notes"])
+    unknown = describe(operation="removeObject")
+    assert unknown["status"] == "unknown_operation"
+    assert "addObject" in unknown["valid_operations"]
+
+
+def test_describe_common_options_and_titled_example():
+    detail = describe(object_type="barChart")
+    assert "title" in detail["common_options"]["shape"]["options"]["object"]
+    example_body = detail["example"]["addObject"]["object"]["barChart"]
+    assert example_body["options"]["object"]["title"]
+
+
+def test_describe_content_object_examples_are_real():
+    text = describe(object_type="text")
+    text_body = text["example"]["addObject"]["object"]["text"]
+    assert "dataSource" not in text_body
+    assert text_body["options"]["content"]
+    assert "content_note" in text
+
+    image = describe(object_type="image")
+    image_body = image["example"]["addObject"]["object"]["image"]
+    assert image_body["options"]["url"].startswith("https://")
+    assert "options_note" in image
+
+    container = describe(object_type="standardContainer")
+    assert container["example"]["addObject"]["object"]["standardContainer"] == {}
+    assert "no properties" in container["common_options"]["note"].lower() or (
+        "no properties" in container["options_note"].lower()
+    )
+
+
+# --- validate_operations --------------------------------------------------
+
+
+def test_validate_rejects_empty():
+    err = validate_operations([])
+    assert err["status"] == "invalid_operation"
+
+
+def test_validate_rejects_unknown_operation_key():
+    err = validate_operations([{"deleteObject": {}}])
+    assert err["status"] == "invalid_operation"
+    assert "deleteObject" in err["unknown_keys"]
+
+
+def test_validate_rejects_two_ops_in_one_element():
+    err = validate_operations([{"addPage": {}, "addData": {"cas": {"library": "L", "table": "T"}}}])
+    assert err["status"] == "invalid_operation"
+
+
+def test_validate_accepts_minimal_valid_batch():
+    ops = [
+        {"addData": {"cas": {"server": "cas-shared-default", "library": "Public", "table": "CARS"}}},
+        {"addPage": {"pageName": "P1"}},
+        _add_object("barChart", {"category": "Origin", "measures": ["MSRP"]}),
+    ]
+    assert validate_operations(ops) is None
+
+
+def test_validate_adddata_requires_server():
+    # Live Viya rejects addData without cas.server even though the published
+    # spec marks it optional — catch it pre-flight with a pointer.
+    err = validate_operations([{"addData": {"cas": {"library": "Public", "table": "CARS"}}}])
+    assert err["status"] == "invalid_operation"
+    assert "cas-shared-default" in err["message"]
+
+
+def test_validate_unknown_object_type():
+    err = validate_operations([_add_object("bubbleplot", {"xAxis": "a"})])
+    assert err["status"] == "unknown_object_type"
+    assert "bubblePlot" in err["did_you_mean"]
+
+
+def test_validate_not_addable_object():
+    err = validate_operations([_add_object("decisionTree")])
+    assert err["status"] == "not_addable"
+    assert err["nearest"] == "gradientBoosting"
+
+
+def test_validate_add_only_object_rejected_for_add():
+    err = validate_operations([_add_object("linearRegression", {"response": "y"})])
+    assert err["status"] == "not_addable"
+
+
+def test_validate_bad_role_name():
+    err = validate_operations([_add_object("scatterPlot", {"category": "Make"})])
+    assert err["status"] == "invalid_roles"
+    assert "measures" in err["valid_roles"]
+
+
+def test_validate_single_role_given_list():
+    err = validate_operations([_add_object("barChart", {"category": ["a", "b"]})])
+    assert err["status"] == "invalid_roles"
+
+
+def test_validate_addobject_requires_object_or_reportobject():
+    err = validate_operations([{"addObject": {}}])
+    assert err["status"] == "invalid_operation"
+
+
+def test_validate_addobject_rejects_both_object_and_reportobject():
+    op = {"addObject": {"object": {"text": {}}, "reportObject": {"name": "x"}}}
+    err = validate_operations([op])
+    assert err["status"] == "invalid_operation"
+
+
+def test_validate_reportobject_passthrough_ok():
+    op = {"addObject": {"reportObject": {"name": "existingObj"}}}
+    assert validate_operations([op]) is None
+
+
+def test_validate_updateobject_needs_updatable_and_name():
+    # geoCluster is add-only.
+    err = validate_operations([{"updateObject": {"object": {"geoCluster": {"name": "g"}}}}])
+    assert err["status"] == "not_updatable"
+    # missing name
+    err2 = validate_operations([{"updateObject": {"object": {"barChart": {}}}}])
+    assert err2["status"] == "invalid_operation"
+    # valid
+    assert validate_operations([{"updateObject": {"object": {"barChart": {"name": "b1"}}}}]) is None
+
+
+def test_validate_adddata_requires_library_and_table():
+    err = validate_operations([{"addData": {"cas": {"library": "Public"}}}])
+    assert err["status"] == "invalid_operation"
+
+
+def test_validate_setparameter_requires_name_value():
+    err = validate_operations([{"setParameterValue": {"name": "p"}}])
+    assert err["status"] == "invalid_operation"
+    assert validate_operations([{"setParameterValue": {"name": "p", "value": "v"}}]) is None
+
+
+def test_validate_changedata_requires_both_sides():
+    err = validate_operations([{"changeData": {"originalData": {"cas": {}}}}])
+    assert err["status"] == "invalid_operation"
+
+
+def test_validate_reports_op_index():
+    ops = [{"addPage": {"pageName": "P"}}, _add_object("nope")]
+    err = validate_operations(ops)
+    assert err["op_index"] == 1
+
+
+def test_validate_collects_all_errors():
+    # The batch is atomic server-side, so all invalid operations are reported
+    # at once instead of one per round-trip.
+    ops = [_add_object("nope"), {"addPage": {"pageName": "P"}}, _add_object("scatterPlot", {"category": "x"})]
+    err = validate_operations(ops)
+    assert err["status"] == "unknown_object_type"  # first error keeps its shape
+    assert err["error_count"] == 2
+    assert [e["op_index"] for e in err["all_errors"]] == [0, 2]
+
+
+def test_validate_rejects_object_name_at_add_time():
+    op = _add_object("barChart", {"category": "Origin"})
+    op["addObject"]["object"]["barChart"]["name"] = "myBar"
+    err = validate_operations([op])
+    assert err["status"] == "invalid_object_spec"
+    assert "auto-named" in err["message"]
+
+
+def test_validate_rejects_unknown_object_spec_key():
+    op = _add_object("barChart", {"category": "Origin"})
+    op["addObject"]["object"]["barChart"]["width"] = 400
+    err = validate_operations([op])
+    assert err["status"] == "invalid_object_spec"
+    assert err["unknown_keys"] == ["width"]
+
+
+def test_validate_standard_container_must_be_bare():
+    # VA rejects ANY property on standardContainer at add time — even options.
+    op = {"addObject": {"object": {"standardContainer": {"options": {"object": {"title": "KPIs"}}}}}}
+    err = validate_operations([op])
+    assert err["status"] == "invalid_object_spec"
+    assert "updateObject" in err["message"]
+    assert validate_operations([{"addObject": {"object": {"standardContainer": {}}}}]) is None
+
+
+def test_validate_object_options_allowed_at_add_time():
+    op = _add_object("barChart", {"category": "Origin"})
+    op["addObject"]["object"]["barChart"]["options"] = {"object": {"title": "MSRP by Origin"}}
+    assert validate_operations([op]) is None
+
+
+def test_validate_updateobject_rejects_placement_and_dataroles():
+    op = {"updateObject": {"object": {"barChart": {"name": "ve15", "dataRoles": {"category": "Origin"}}}}}
+    err = validate_operations([op])
+    assert err["status"] == "invalid_object_spec"
+    assert err["unknown_keys"] == ["dataRoles"]
+
+
+def test_validate_data_items_enums():
+    good = {
+        "addData": {
+            "cas": {"server": "cas-shared-default", "library": "Public", "table": "SALES"},
+            "dataItems": [
+                {"dataItem": "Revenue", "properties": {"name": "Revenue (USD)", "format": "DOLLAR12.2",
+                                                       "aggregation": "average"}},
+                {"dataItem": "State", "properties": {"classification": "geography",
+                                                     "geographyDataSource": {
+                                                         "geographyNameCodeContext": "USStateNames"}}},
+            ],
+        }
+    }
+    assert validate_operations([good]) is None
+    assert "average" in AGGREGATIONS
+
+    bad_agg = {"addData": {"cas": {"server": "s", "library": "L", "table": "T"},
+                           "dataItems": [{"dataItem": "x", "properties": {"aggregation": "mean"}}]}}
+    err = validate_operations([bad_agg])
+    assert err["status"] == "invalid_operation"
+    assert "average" in err["valid_values"]
+
+    orphan_geo = {"addData": {"cas": {"server": "s", "library": "L", "table": "T"},
+                              "dataItems": [{"dataItem": "x", "properties": {
+                                  "geographyDataSource": {"geographyNameCodeContext": "USStateNames"}}}]}}
+    err = validate_operations([orphan_geo])
+    assert "geography" in err["message"]
+
+    bad_context = {"addData": {"cas": {"server": "s", "library": "L", "table": "T"},
+                               "dataItems": [{"dataItem": "x", "properties": {
+                                   "classification": "geography",
+                                   "geographyDataSource": {"geographyNameCodeContext": "USStates"}}}]}}
+    err = validate_operations([bad_context])
+    assert "USStateNames" in err["valid_values"]
+
+
+def _geo_item(geo_source):
+    return {"addData": {"cas": {"server": "s", "library": "L", "table": "T"},
+                        "dataItems": [{"dataItem": "x", "properties": {
+                            "classification": "geography", "geographyDataSource": geo_source}}]}}
+
+
+def test_validate_geography_coordinates():
+    # Raw lat/long point data — the shape the spec calls geographyCoordinates.
+    good = _geo_item({"geographyCoordinates": {"latitudeDataItem": "LAT", "longitudeDataItem": "LON"}})
+    assert validate_operations([good]) is None
+    # The wrong key an agent actually guessed live must fail fast, with the fix.
+    guessed = _geo_item({"customCoordinates": {"latitudeDataItem": "LAT", "longitudeDataItem": "LON"}})
+    err = validate_operations([guessed])
+    assert err["status"] == "invalid_operation"
+    assert "geographyCoordinates" in err["message"]
+    assert "geographyCoordinates" in err["valid_keys"]
+    # coordinates need both columns
+    half = _geo_item({"geographyCoordinates": {"latitudeDataItem": "LAT"}})
+    assert "longitudeDataItem" in validate_operations([half])["message"]
+    # context and coordinates are mutually exclusive
+    both = _geo_item({"geographyNameCodeContext": "USStateNames",
+                      "geographyCoordinates": {"latitudeDataItem": "LAT", "longitudeDataItem": "LON"}})
+    assert "not both" in validate_operations([both])["message"]
+
+
+def test_validate_rejects_bare_numeric_format():
+    # "8.1" passed pre-flight live and killed the whole atomic batch server-side.
+    bad = {"addData": {"cas": {"server": "s", "library": "L", "table": "T"},
+                       "dataItems": [{"dataItem": "x", "properties": {"format": "8.1"}}]}}
+    err = validate_operations([bad])
+    assert err["status"] == "invalid_operation"
+    assert "DOLLAR12.2" in err["message"]
+    for fmt in ("DOLLAR12.2", "COMMA10.", "PERCENT8.1", "DATE9.", "$CHAR20."):
+        good = {"addData": {"cas": {"server": "s", "library": "L", "table": "T"},
+                            "dataItems": [{"dataItem": "x", "properties": {"format": fmt}}]}}
+        assert validate_operations([good]) is None, fmt
+
+
+def test_warn_render_required_roles():
+    # Category-only charts are ACCEPTED but render empty — warn pre-flight.
+    warnings = warn_operations([_add_object("barChart", {"category": "Origin"})])
+    assert any("renders EMPTY" in w for w in warnings)
+    # frequency satisfies the measures group
+    assert warn_operations([_add_object("barChart", {"category": "Origin", "frequency": "N"})]) == []
+    assert warn_operations([_add_object("barChart", {"category": "Origin", "measures": ["MSRP"]})]) == []
+    word_only = {"addObject": {"object": {"wordCloud": {"dataSource": "T", "dataRoles": {"word": "EVENT"}}}}}
+    assert any("renders EMPTY" in w for w in warn_operations([word_only]))
+
+
+def test_warn_multiple_content_texts():
+    text = {"addObject": {"object": {"text": {"options": {"content": "A"}}}}}
+    text2 = {"addObject": {"object": {"text": {"options": {"content": "B"}}}}}
+    warnings = warn_operations([text, text2])
+    assert any("misroute" in w for w in warnings)
+    assert warn_operations([text]) == []
+
+
+def test_warn_page_placed_stack():
+    # N merely page-placed objects auto-flow into one vertical stack — the
+    # single ugliest failure mode observed; warn with the structural fix.
+    stacked = [
+        _add_object("barChart", {"category": "C", "measures": ["M"]}, page="Overview") for _ in range(4)
+    ]
+    warnings = warn_operations(stacked)
+    assert any("VERTICALLY" in w and "standardContainer" in w for w in warnings)
+    # Structured placements (container / relativeToObject) do not count.
+    tiles = [
+        {"addObject": {"object": {"keyValue": {"dataSource": "T", "dataRoles": {"measure": "M"}}},
+                       "placement": {"container": {"target": "c1"}}}}
+        for _ in range(4)
+    ]
+    assert not any("VERTICALLY" in w for w in warn_operations(tiles))
+    # Three on one page is fine.
+    assert not any("VERTICALLY" in w for w in warn_operations(stacked[:3]))
+
+
+def test_expected_text_pairs_skip_contentless_texts():
+    # A content-less text op must consume its created record WITHOUT shifting
+    # the pairing — two independently filtered lists produced false misroute
+    # warnings when an empty text preceded a content-bearing one.
+    from sas_mcp_server.helpers.report_authoring_helpers import _expected_text_pairs
+
+    ops = [
+        {"addObject": {"object": {"text": {"options": {}}}}},
+        {"addObject": {"object": {"text": {"options": {"content": "Intended Title"}}}}},
+    ]
+    created = [{"type": "text", "name": "ve1"}, {"type": "text", "name": "ve2"}]
+    assert _expected_text_pairs(ops, created) == [("ve2", "Intended Title")]
+    # Non-string content is skipped the same way.
+    ops[0]["addObject"]["object"]["text"]["options"]["content"] = 123
+    assert _expected_text_pairs(ops, created) == [("ve2", "Intended Title")]
+
+
+def test_validate_geography_source_must_be_object():
+    err = validate_operations([_geo_item("USStateNames")])
+    assert err["status"] == "invalid_operation"
+    assert "must be an object" in err["message"]
+
+
+def test_describe_key_value_has_no_title_in_example():
+    detail = describe(object_type="keyValue")
+    body = detail["example"]["addObject"]["object"]["keyValue"]
+    assert "options" not in body  # the measure label IS the tile's headline
+    assert "title_note" in detail
+    bar = describe(object_type="barChart")["example"]["addObject"]["object"]["barChart"]
+    assert bar["options"]["object"]["title"]  # other visuals stay titled
+
+
+# --- normalize ------------------------------------------------------------
+
+
+def test_normalize_coerces_pageposition_int_to_str():
+    ops = normalize_operations([{"addPage": {"pageName": "P", "pagePosition": 0}}])
+    assert ops[0]["addPage"]["pagePosition"] == "0"
+
+
+def test_normalize_wraps_scalar_multi_role():
+    ops = normalize_operations([_add_object("barChart", {"category": "Origin", "measures": "MSRP"})])
+    roles = ops[0]["addObject"]["object"]["barChart"]["dataRoles"]
+    assert roles["measures"] == ["MSRP"]
+    assert roles["category"] == "Origin"  # single role left as-is
+
+
+def test_normalize_does_not_mutate_input():
+    original = [{"addPage": {"pageName": "P", "pagePosition": 3}}]
+    normalize_operations(original)
+    assert original[0]["addPage"]["pagePosition"] == 3
+
+
+# --- page titles ----------------------------------------------------------
+
+
+def test_page_title_expands_to_body_text_band():
+    # VA rejects text in page headers ("Only control objects are supported in
+    # the page header"), so the title must land at the top of the page body.
+    ops = normalize_operations([{"addPage": {"pageName": "Overview", "title": "Sales Overview"}}])
+    assert len(ops) == 2
+    assert "title" not in ops[0]["addPage"]  # stripped from the page op
+    assert ops[0]["addPage"]["pageName"] == "Overview"
+    text = ops[1]["addObject"]
+    assert text["object"]["text"]["options"]["content"] == "Sales Overview"
+    assert text["placement"]["page"] == {"target": "Overview", "context": "body", "position": "start"}
+
+
+def test_page_title_survives_when_no_pagename_then_fails_validation():
+    ops = normalize_operations([{"addPage": {"title": "Orphan"}}])
+    assert len(ops) == 1  # not expanded — no page to target
+    err = validate_operations(ops)
+    assert err["status"] == "invalid_operation"
+    assert "pageName" in err["message"]
+
+
+def test_page_title_batch_is_valid_end_to_end():
+    ops = normalize_operations(
+        [
+            {"addPage": {"pageName": "Overview", "title": "Sales Overview"}},
+            _add_object("barChart", {"category": "Origin", "measures": ["MSRP"]}, page="Overview"),
+        ]
+    )
+    assert validate_operations(ops) is None
+    assert len(ops) == 3  # addPage + barChart + synthesized title text
+
+
+def test_page_title_expansion_preserves_caller_indices():
+    # Synthesized title ops go at the END so op_index in errors (and VA's
+    # failed-at-index messages) keep matching the caller's operations array.
+    ops = normalize_operations(
+        [
+            {"addPage": {"pageName": "A", "title": "T"}},
+            _add_object("nope"),
+        ]
+    )
+    assert ops[2]["addObject"]["object"]["text"]["options"]["content"] == "T"
+    err = validate_operations(ops)
+    assert err["op_index"] == 1  # the caller's failing element, unshifted
+
+
+def test_falsy_page_title_is_stripped_not_expanded():
+    # An empty title must not leak the tool-only 'title' key to VA (which
+    # rejects unknown properties), and must not create an empty text band.
+    ops = normalize_operations([{"addPage": {"pageName": "P", "title": ""}}])
+    assert len(ops) == 1
+    assert "title" not in ops[0]["addPage"]
+    assert validate_operations(ops) is None
+
+
+def test_bool_pageposition_rejected_not_stringified():
+    ops = normalize_operations([{"addPage": {"pageName": "P", "pagePosition": True}}])
+    assert ops[0]["addPage"]["pagePosition"] is True  # bool must not become "True"
+    assert validate_operations(ops)["status"] == "invalid_operation"
+
+
+# --- placement ------------------------------------------------------------
+
+
+def _placed(placement):
+    op = _add_object("barChart", {"category": "Origin"}, page=None)
+    op["addObject"]["placement"] = placement
+    return op
+
+
+def test_placement_relative_positions_valid():
+    for pos in ("left", "right", "top", "bottom", "before", "after"):
+        op = _placed({"relativeToObject": {"target": "bar1", "position": pos}})
+        assert validate_operations([op]) is None, pos
+
+
+def test_placement_container_and_report_valid():
+    assert validate_operations([_placed({"container": {"target": "c1", "position": "end"}})]) is None
+    assert validate_operations([_placed({"report": {"context": "new_page"}})]) is None
+
+
+def test_placement_header_is_controls_only():
+    # VA: "Only control objects are supported in the page header" — enforce it
+    # pre-flight for both the page and report header bands.
+    control = {
+        "addObject": {
+            "object": {"dropdownList": {"dataSource": "CARS", "dataRoles": {"category": "Origin"}}},
+            "placement": {"page": {"target": "P", "context": "header"}},
+        }
+    }
+    assert validate_operations([control]) is None
+    err = validate_operations([_placed({"page": {"target": "P", "context": "header"}})])
+    assert err["status"] == "invalid_placement"
+    assert "control objects" in err["message"]
+    err2 = validate_operations([_placed({"report": {"context": "header"}})])
+    assert err2["status"] == "invalid_placement"
+
+
+def test_placement_report_new_page_with_name_and_position():
+    ok = _placed({"report": {"context": "new_page", "pageName": "Trends", "pagePosition": 0}})
+    assert validate_operations([ok]) is None
+    # pagePosition is a NUMBER in report placement (string only on addPage).
+    bad_pos = _placed({"report": {"context": "new_page", "pagePosition": "0"}})
+    err = validate_operations([bad_pos])
+    assert err["status"] == "invalid_placement"
+    assert "NUMBER" in err["message"]
+    bad_name = _placed({"report": {"context": "new_page", "pageName": "  "}})
+    assert validate_operations([bad_name])["status"] == "invalid_placement"
+
+
+def test_normalize_translates_report_placement_spellings():
+    # The published spec says "newPage" but the live enum is snake_case; a
+    # digit-string pagePosition is coerced to the number the API expects.
+    op = _placed({"report": {"context": "newPage", "pagePosition": "1"}})
+    ops = normalize_operations([op])
+    report = ops[0]["addObject"]["placement"]["report"]
+    assert report["context"] == "new_page"
+    assert report["pagePosition"] == 1
+    assert validate_operations(ops) is None
+
+
+def test_placement_unknown_inner_key_rejected():
+    err = validate_operations([_placed({"page": {"target": "P", "size": "50%"}})])
+    assert err["status"] == "invalid_placement"
+    assert err["unknown_keys"] == ["size"]
+
+
+def test_normalize_malformed_report_pageposition_no_crash():
+    # normalize must never raise; the typed validation message handles it.
+    op = _placed({"report": {"context": "new_page", "pagePosition": "--1"}})
+    ops = normalize_operations([op])
+    assert ops[0]["addObject"]["placement"]["report"]["pagePosition"] == "--1"
+    assert validate_operations(ops)["status"] == "invalid_placement"
+
+
+def test_validate_rejects_stray_sibling_keys():
+    err = validate_operations([{"addPage": {"pageName": "P"}, "comment": "x"}])
+    assert err["status"] == "invalid_operation"
+    assert err["unknown_keys"] == ["comment"]
+    # The documented meta keys stay allowed.
+    assert validate_operations([{"addPage": {"pageName": "P"}, "operationId": "op1"}]) is None
+
+
+def test_validate_reportobject_placement_checked():
+    op = {"addObject": {"reportObject": {"name": "x"}, "placement": {"grid": {}}}}
+    assert validate_operations([op])["status"] == "invalid_placement"
+
+
+def test_validate_updatedata_requires_data():
+    assert validate_operations([{"updateData": {}}])["status"] == "invalid_operation"
+    assert validate_operations([{"updateData": {"data": {"name": "CARS"}}}]) is None
+
+
+def test_placement_unknown_variant():
+    err = validate_operations([_placed({"grid": {"row": 1}})])
+    assert err["status"] == "invalid_placement"
+    assert "page" in err["valid_variants"]
+
+
+def test_placement_missing_target():
+    err = validate_operations([_placed({"relativeToObject": {"position": "right"}})])
+    assert err["status"] == "invalid_placement"
+    assert "target" in err["message"]
+
+
+def test_placement_bad_position_enum():
+    err = validate_operations([_placed({"relativeToObject": {"target": "bar1", "position": "below"}})])
+    assert err["status"] == "invalid_placement"
+    assert "bottom" in err["valid_values"]
+
+
+def test_placement_two_variants_rejected():
+    err = validate_operations([_placed({"page": {"target": "P"}, "container": {"target": "c"}})])
+    assert err["status"] == "invalid_placement"
+
+
+def test_describe_index_exposes_placement_and_recipes():
+    idx = describe()
+    variants = {p["variant"] for p in idx["placement"]}
+    assert variants == {"page", "relativeToObject", "container", "report"}
+    assert any("title" in r for r in idx["layout_recipes"])
+
+
+# --- warnings -------------------------------------------------------------
+
+
+def test_warn_missing_common_role():
+    warnings = warn_operations([_add_object("keyValue", {"latticeCategory": "Origin"})])
+    assert warnings and "measure" in warnings[0]
+
+
+def test_no_warning_when_common_roles_present():
+    warnings = warn_operations([_add_object("keyValue", {"measure": "MSRP"})])
+    assert warnings == []
+
+
+# --- create request shaping ----------------------------------------------
+
+
+def test_validate_create_rejects_blank_name():
+    assert validate_create(CreateReportRequest(name="  "))["status"] == "invalid_request"
+
+
+def test_validate_create_rejects_bad_conflict():
+    err = validate_create(CreateReportRequest(name="R", on_conflict="merge"))
+    assert err["status"] == "invalid_request"
+
+
+def test_validate_create_checks_inline_operations():
+    err = validate_create(CreateReportRequest(name="R", operations=[_add_object("decisionTree")]))
+    assert err["status"] == "not_addable"
+
+
+def test_build_create_body_defaults_and_folder():
+    body = build_create_body(CreateReportRequest(name="Cars", folder="/f/abc"))
+    assert body["resultReportName"] == "Cars"
+    assert body["resultNameConflict"] == "rename"
+    assert body["resultFolder"] == "/f/abc"
+    assert "operations" not in body
+
+
+# --- copy request shaping -------------------------------------------------
+
+
+def test_validate_copy():
+    assert validate_copy("Copy", "rename") is None
+    assert validate_copy(None, "abort") is None  # name optional for a copy
+    assert validate_copy("  ", "rename")["status"] == "invalid_request"
+    assert validate_copy("Copy", "merge")["status"] == "invalid_request"
+
+
+def test_build_copy_body_omits_unset():
+    assert build_copy_body(None, None, "abort") == {"resultNameConflict": "abort"}
+    body = build_copy_body("New", "/f/x", "rename")
+    assert body == {"resultNameConflict": "rename", "resultReportName": "New", "resultFolder": "/f/x"}
+
+
+# --- summarize ------------------------------------------------------------
+
+
+def test_summarize_created_reads_operations():
+    ops = [
+        {"addData": {"cas": {"library": "Public", "table": "CARS"}}},
+        {"addPage": {"pageName": "Overview"}},
+        _add_object("barChart", {"category": "Origin", "measures": ["MSRP"]}, page="Overview"),
+    ]
+    summary = summarize_created(ops, {})
+    assert summary["pages"][0]["label"] == "Overview"
+    assert summary["dataSources"] == [{"name": "CARS"}]
+    assert summary["objects"][0]["type"] == "barChart"
+    assert summary["objects"][0]["page"] == "Overview"
+
+
+def test_summarize_merges_response_names():
+    ops = [_add_object("barChart", {"category": "Origin"}, page="P")]
+    response = {"operationResponses": [{"name": "bar1"}]}
+    summary = summarize_created(ops, response)
+    assert summary["objects"][0]["name"] == "bar1"
+
+
+def test_summarize_merges_by_index_in_mixed_batches():
+    # The VA response `operations` array is 1:1 index-aligned with the request;
+    # a page/data name must never be attributed to an object (the old zip bug).
+    ops = [
+        {"addData": {"cas": {"library": "Public", "table": "CARS"}}},
+        {"addPage": {"pageName": "Overview"}},
+        _add_object("barChart", {"category": "Origin"}, page="Overview"),
+    ]
+    response = {
+        "operations": [
+            {"name": "ds7", "status": "Success"},
+            {"name": "vi70", "label": "Overview", "status": "Success"},
+            {"name": "ve15", "label": "Bar - Origin 1", "status": "Success"},
+        ]
+    }
+    summary = summarize_created(ops, response)
+    assert summary["objects"][0]["name"] == "ve15"
+    assert summary["objects"][0]["label"] == "Bar - Origin 1"
+    assert summary["pages"][0]["name"] == "vi70"
+    assert summary["pages"][0]["label"] == "Overview"
+    # The requested data-source handle (what addObject.dataSource references)
+    # is preserved rather than replaced by the internal ds* name.
+    assert summary["dataSources"][0]["name"] == "CARS"
+
+
+def test_summarize_keeps_report_placement_page():
+    op = {
+        "addObject": {
+            "object": {"text": {"options": {"content": "hi"}}},
+            "placement": {"report": {"context": "new_page", "pageName": "Trends"}},
+        }
+    }
+    summary = summarize_created([op], {})
+    assert summary["objects"][0]["page"] == "Trends"
+    assert summary["objects"][0]["placement"]["report"]["pageName"] == "Trends"
+
+
+def test_summarize_fills_unnamed_page_from_response():
+    # A pre-seeded None (unnamed addPage) must not block the response label —
+    # the verify hint depends on a real, export-usable label.
+    summary = summarize_created(
+        [{"addPage": {}}], {"operations": [{"name": "vi6", "label": "Page 2", "status": "Success"}]}
+    )
+    assert summary["pages"][0]["label"] == "Page 2"
+    assert summary["pages"][0]["name"] == "vi6"
+
+
+def test_parse_failure_extracts_failing_index():
+    body = (
+        '{"operations": [{"name": "vi7", "label": "P", "status": "Success"},'
+        '{"status": "Failed", "messages": ["The target was not found in the report: veX",'
+        '"Unable to add the object to the report"]}],'
+        '"status": "Failed", "messages": ["Operation addObject failed at index 1"]}'
+    )
+    parsed = parse_failure(body)
+    assert parsed["failed_operation_index"] == 1
+    assert parsed["failed_operations"][0]["messages"][0].startswith("The target was not found")
+    assert parsed["viya_messages"] == ["Operation addObject failed at index 1"]
+    assert parse_failure("not json") == {}
+
+
+# --- outline reduction ------------------------------------------------------
+
+
+def test_reduce_content_outline_pages_objects_and_text():
+    content = {
+        "visualElements": [
+            {"@element": "Text", "name": "ve9", "labelAttribute": "Text 1",
+             "paragraphList": [{"@element": "P", "elements": [
+                 {"@element": "Span", "elements": [{"@element": "TextString", "text": "Sales Overview"}]}]}]},
+            {"@element": "Graph", "name": "ve15", "labelAttribute": "Bar - Origin 1"},
+            {"@element": "VisualContainer", "name": "ve20", "labelAttribute": "Standard container 1",
+             "layout": {"containedElementList": [{"@element": "Visual", "ref": "ve21"}]}},
+            {"@element": "Graph", "name": "ve21", "labelAttribute": "Key value 1"},
+            {"@element": "DropDown", "name": "ve30", "labelAttribute": "Drop-down list 1"},
+        ],
+        "view": {
+            "sections": [
+                {
+                    "name": "vi7",
+                    "label": "Overview",
+                    "header": {"containedElementList": [{"@element": "Visual", "ref": "ve30"}]},
+                    "body": {"containedElementList": [
+                        {"@element": "Visual", "ref": "ve9"},
+                        {"@element": "Visual", "ref": "ve15"},
+                        {"@element": "Container", "ref": "ve20"},
+                    ]},
+                },
+                {"name": "vi30", "label": "Empty"},
+            ]
+        },
+    }
+    outline = reduce_content_outline(content)
+    page = outline["pages"][0]
+    assert (page["name"], page["label"]) == ("vi7", "Overview")
+    names = [o["name"] for o in page["objects"]]
+    # Header controls and container children are both included, in order.
+    assert names == ["ve30", "ve9", "ve15", "ve20", "ve21"]
+    text = page["objects"][1]
+    assert text["type"] == "Text"
+    assert text["text"] == "Sales Overview"
+    assert page["objects"][2]["label"] == "Bar - Origin 1"
+    # Container membership is exposed so layout is verifiable without a render.
+    kv = next(o for o in page["objects"] if o["name"] == "ve21")
+    assert kv["container"] == "ve20"
+    assert "container" not in page["objects"][0]  # header control sits at top level
+    assert outline["pages"][1] == {"name": "vi30", "label": "Empty", "objects": []}
+
+
+def test_reduce_content_outline_tolerates_malformed_content():
+    assert reduce_content_outline({}) == {"pages": []}
+    assert reduce_content_outline({"view": "bogus"}) == {"pages": []}
+    assert reduce_content_outline({"view": {"sections": ["junk", None]}}) == {"pages": []}

--- a/tests/test_report_authoring_helpers.py
+++ b/tests/test_report_authoring_helpers.py
@@ -9,10 +9,6 @@ shaping that back the create_report / apply_report_operations tools.
 """
 
 from sas_mcp_server.helpers.report_authoring_helpers import (
-    AGGREGATIONS,
-    NOT_ADDABLE,
-    OPERATION_KEYS,
-    REPORT_OBJECT_TYPES,
     CreateReportRequest,
     build_copy_body,
     build_create_body,
@@ -25,6 +21,12 @@ from sas_mcp_server.helpers.report_authoring_helpers import (
     validate_create,
     validate_operations,
     warn_operations,
+)
+from sas_mcp_server.helpers.report_authoring_registry import (
+    AGGREGATIONS,
+    NOT_ADDABLE,
+    OPERATION_KEYS,
+    REPORT_OBJECT_TYPES,
 )
 
 

--- a/tests/test_tier_selection.py
+++ b/tests/test_tier_selection.py
@@ -48,14 +48,16 @@ def test_env_var_drives_default(monkeypatch):
 
 async def test_register_all_tiers_registers_everything():
     names = await _register(None)
-    assert len(names) == 68
+    assert len(names) == 74
     assert "execute_sas_code" in names
     assert "publish_decision_flow" in names
+    assert "apply_report_operations" in names
+    assert "get_report_outline" in names
 
 
 async def test_register_subset_excludes_other_tiers():
     names = await _register("0-4")
-    assert len(names) == 36
+    assert len(names) == 42
     assert "execute_sas_code" in names  # tier 0
     assert "list_jobs" in names  # tier 4
     assert "list_mas_modules" not in names  # tier 6

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -13,6 +13,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 from fastmcp import Client
 
 from conftest import _make_mock_response
@@ -36,6 +37,12 @@ EXPECTED_TOOLS = [
     "list_reports",
     "get_report",
     "export_report",
+    "describe_report_objects",
+    "create_report",
+    "apply_report_operations",
+    "get_report_outline",
+    "copy_report",
+    "delete_report",
     "submit_batch_job",
     "get_job_status",
     "list_jobs",
@@ -618,6 +625,633 @@ async def test_export_report_unsupported_format(mcp_server_with_mock_client):
     assert result.data["status"] == "unsupported_format"
     assert "package" in result.data["supported"]
     mock_client.get.assert_not_called()
+
+
+# -----------------------------------------------------------------------
+# Tier 3 — Report Authoring (create / apply operations / describe)
+# -----------------------------------------------------------------------
+
+
+async def test_describe_report_objects_index(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("describe_report_objects", {})).data
+
+    assert "operations" in result
+    op_keys = {op["key"] for op in result["operations"]}
+    assert {"addData", "addObject", "addPage", "setParameterValue"} <= op_keys
+    schema_keys = {o["schema_key"] for o in result["objects"]}
+    assert "barChart" in schema_keys and "geoRegion" in schema_keys
+    # Pure local catalog read — no HTTP.
+    mock_client.get.assert_not_called()
+
+
+async def test_describe_report_objects_detail(mcp_server_with_mock_client):
+    mcp, _ = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("describe_report_objects", {"object_type": "bubblePlot"})).data
+
+    assert result["schema_key"] == "bubblePlot"
+    role_names = {r["name"] for r in result["data_roles"]}
+    assert {"xAxis", "yAxis", "size"} <= role_names
+    assert result["commonly_required"] == ["xAxis", "yAxis", "size"]
+    assert "addObject" in result["example"]
+
+
+async def test_describe_report_objects_not_addable(mcp_server_with_mock_client):
+    mcp, _ = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("describe_report_objects", {"object_type": "decisionTree"})).data
+
+    assert result["status"] == "not_addable"
+    assert result["nearest"] == "gradientBoosting"
+
+
+async def test_create_report_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("create_report", {"name": "Cars Dashboard"})).data
+
+    url = mock_client.post.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports")
+    body = json.loads(mock_client.post.call_args[1]["content"])
+    assert body["resultReportName"] == "Cars Dashboard"
+    assert body["resultNameConflict"] == "rename"
+    assert result["status"] == "created"
+    assert result["id"] == "test-id"
+
+
+async def test_create_report_one_shot_operations(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "create_report",
+            {
+                "name": "Cars",
+                "folder": "/folders/folders/abc",
+                "operations": [
+                    {"addData": {"cas": {"server": "cas-shared-default", "library": "Public", "table": "CARS"}}}
+                ],
+            },
+        )
+
+    body = json.loads(mock_client.post.call_args[1]["content"])
+    assert body["resultFolder"] == "/folders/folders/abc"
+    assert body["operations"][0]["addData"]["cas"]["table"] == "CARS"
+
+
+async def test_create_report_invalid_conflict(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("create_report", {"name": "X", "on_conflict": "merge"})).data
+
+    assert result["status"] == "invalid_request"
+    mock_client.post.assert_not_called()
+
+
+async def test_apply_report_operations_dry_run_normalizes(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "r1",
+                    "dry_run": True,
+                    "operations": [
+                        {
+                            "addObject": {
+                                "object": {"barChart": {"dataSource": "CARS",
+                                                        "dataRoles": {"category": "Origin", "measures": "MSRP"}}},
+                                "placement": {"page": {"target": "P1"}},
+                            }
+                        }
+                    ],
+                },
+            )
+        ).data
+
+    assert result["status"] == "valid"
+    # A bare column string is normalised to a list for the array-valued role.
+    roles = result["normalized_operations"][0]["addObject"]["object"]["barChart"]["dataRoles"]
+    assert roles["measures"] == ["MSRP"]
+    mock_client.put.assert_not_called()
+
+
+async def test_apply_report_operations_commit_etag(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"rpt-etag"'}
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "abc123",
+                    "operations": [
+                        {"addPage": {"pageName": "Overview"}},
+                        {
+                            "addObject": {
+                                "object": {"barChart": {"dataSource": "CARS",
+                                                        "dataRoles": {"category": "Origin", "measures": ["MSRP"]}}},
+                                "placement": {"page": {"target": "Overview"}},
+                            }
+                        },
+                    ],
+                },
+            )
+        ).data
+
+    # ETag is read from the Reports service, the operations PUT to Visual Analytics.
+    assert "/reports/reports/abc123" in mock_client.get.call_args[0][0]
+    put_url = mock_client.put.call_args[0][0]
+    assert put_url.endswith("/visualAnalytics/reports/abc123")
+    assert mock_client.put.call_args[1]["headers"]["If-Match"] == '"rpt-etag"'
+    sent = json.loads(mock_client.put.call_args[1]["content"])
+    assert sent["operations"][0]["addPage"]["pageName"] == "Overview"
+    assert result["status"] == "applied"
+    assert result["created"]["pages"][0]["label"] == "Overview"
+    assert "barChart" in {o["type"] for o in result["created"]["objects"]}
+
+
+async def test_apply_report_operations_412_retry(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    resp_412 = _make_mock_response(status_code=412)
+    resp_412.content = b""
+    resp_ok = _make_mock_response({"ok": True}, status_code=200)
+    mock_client.put.side_effect = [resp_412, resp_ok]
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {"report_id": "abc", "operations": [{"addPage": {"pageName": "P"}}]},
+            )
+        ).data
+
+    assert result["status"] == "applied"
+    assert mock_client.put.call_count == 2  # re-read + retry once on the stale ETag
+
+
+async def test_apply_report_operations_http_error_is_structured(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    err = _make_mock_response(status_code=400)
+    err.content = b""
+    err.text = ""
+    mock_client.put.return_value = err
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {"report_id": "abc", "operations": [{"addPage": {"pageName": "P"}}]},
+            )
+        ).data
+
+    assert result["status"] == "apply_failed"
+    assert result["http_status"] == 400
+
+
+async def test_apply_report_operations_attaches_warnings(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "abc",
+                    "operations": [
+                        {
+                            "addObject": {
+                                "object": {
+                                    "keyValue": {"dataSource": "CARS", "dataRoles": {"latticeCategory": "Origin"}}
+                                },
+                                "placement": {"page": {"target": "P"}},
+                            }
+                        }
+                    ],
+                },
+            )
+        ).data
+
+    # keyValue usually needs a measure; the applied result carries the soft warning.
+    assert result["status"] == "applied"
+    assert any("measure" in w for w in result.get("warnings", []))
+
+
+async def test_apply_report_operations_invalid_object_skips_http(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "r1",
+                    "operations": [{"addObject": {"object": {"decisionTree": {"dataSource": "CARS"}}}}],
+                },
+            )
+        ).data
+
+    assert result["status"] == "not_addable"
+    assert result["nearest"] == "gradientBoosting"
+    mock_client.put.assert_not_called()
+
+
+async def test_apply_report_operations_page_title_expands(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "abc",
+                    "operations": [{"addPage": {"pageName": "Overview", "title": "Sales Overview"}}],
+                },
+            )
+        ).data
+
+    sent = json.loads(mock_client.put.call_args[1]["content"])
+    # The page title became a body text band appended after the addPage —
+    # never a header object (VA's page header is controls-only).
+    assert len(sent["operations"]) == 2
+    text = sent["operations"][1]["addObject"]
+    assert text["object"]["text"]["options"]["content"] == "Sales Overview"
+    assert text["placement"]["page"]["context"] == "body"
+    assert text["placement"]["page"]["position"] == "start"
+    assert result["status"] == "applied"
+
+
+async def test_apply_report_operations_relative_placement(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    op = {
+        "addObject": {
+            "object": {"barChart": {"dataSource": "CARS", "dataRoles": {"category": "Origin", "measures": ["MSRP"]}}},
+            "placement": {"relativeToObject": {"target": "kv1", "position": "right"}},
+        }
+    }
+    async with Client(mcp) as client:
+        result = (await client.call_tool("apply_report_operations", {"report_id": "abc", "operations": [op]})).data
+
+    assert result["status"] == "applied"
+    sent = json.loads(mock_client.put.call_args[1]["content"])
+    assert sent["operations"][0]["addObject"]["placement"]["relativeToObject"]["position"] == "right"
+
+
+async def test_apply_report_operations_invalid_placement_skips_http(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    op = {
+        "addObject": {
+            "object": {"barChart": {"dataSource": "CARS", "dataRoles": {"category": "Origin"}}},
+            "placement": {"relativeToObject": {"target": "kv1", "position": "below"}},
+        }
+    }
+    async with Client(mcp) as client:
+        result = (await client.call_tool("apply_report_operations", {"report_id": "abc", "operations": [op]})).data
+
+    assert result["status"] == "invalid_placement"
+    assert "bottom" in result["valid_values"]
+    mock_client.put.assert_not_called()
+
+
+async def test_apply_report_operations_save_as(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    save_as_resp = _make_mock_response(
+        {
+            "resultReportId": "new-42",
+            "resultReportName": "From Template (2)",
+            "operations": [{"name": "vi8", "label": "SaveAsPage", "status": "Success"}],
+        },
+        status_code=201,
+    )
+    save_as_resp.content = b"x"
+    mock_client.put.return_value = save_as_resp
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "src-1",
+                    "operations": [{"addPage": {"pageName": "SaveAsPage"}}],
+                    "result_report_name": "From Template",
+                },
+            )
+        ).data
+
+    body = json.loads(mock_client.put.call_args[1]["content"])
+    assert body["resultReportName"] == "From Template"
+    assert body["resultNameConflict"] == "rename"
+    # Save-as still uses the SOURCE report's ETag handshake.
+    assert mock_client.put.call_args[1]["headers"]["If-Match"] == '"e1"'
+    assert result["status"] == "applied"
+    assert result["saved_as"]["id"] == "new-42"
+    assert result["saved_as"]["name"] == "From Template (2)"
+    assert result["saved_as"]["open_url"].endswith("/reports/reports/new-42")
+    assert result["created"]["pages"][0]["name"] == "vi8"
+
+
+async def test_apply_report_operations_accepts_stringified_list(mcp_server_with_mock_client):
+    """Some clients (observed live) send list params as JSON-encoded strings —
+    the tool coerces them instead of failing pydantic validation."""
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {"report_id": "abc", "operations": '[{"addPage": {"pageName": "P"}}]'},
+            )
+        ).data
+
+    assert result["status"] == "applied"
+    sent = json.loads(mock_client.put.call_args[1]["content"])
+    assert sent["operations"][0]["addPage"]["pageName"] == "P"
+
+
+async def test_export_report_accepts_stringified_and_bare_report_objects(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    csv_resp = _make_mock_response(status_code=200)
+    csv_resp.content = b"a,b"
+    csv_resp.text = "a,b"
+    csv_resp.headers = {"content-type": "text/csv"}
+    mock_client.get.return_value = csv_resp
+    async with Client(mcp) as client:
+        # JSON-encoded list
+        r1 = await client.call_tool(
+            "export_report",
+            {"report_id": "rep1", "export_format": "csv", "report_objects": '["Overview"]'},
+        )
+        # bare string -> one-element list
+        r2 = await client.call_tool(
+            "export_report",
+            {"report_id": "rep1", "export_format": "csv", "report_objects": "Overview"},
+        )
+    assert r1.content and r2.content
+    assert mock_client.get.call_count == 2
+
+
+def test_coerce_helpers_edge_cases():
+    from sas_mcp_server.tools._common import coerce_json_list, coerce_str_or_json_list
+
+    # A label that merely LOOKS like JSON is a label, not an error.
+    assert coerce_str_or_json_list("[Draft] Overview") == ["[Draft] Overview"]
+    # A double-encoded scalar unwraps once.
+    assert coerce_str_or_json_list('"Overview"') == ["Overview"]
+    assert coerce_str_or_json_list('["A", "B"]') == ["A", "B"]
+    assert coerce_str_or_json_list("Overview") == ["Overview"]
+    assert coerce_str_or_json_list(["A"]) == ["A"]
+    assert coerce_json_list('[{"a": 1}]') == [{"a": 1}]
+    with pytest.raises(ValueError):
+        coerce_json_list('{"a": 1}')  # object where an array is required
+
+
+async def test_create_report_attaches_warnings(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "create_report",
+                {
+                    "name": "Stacked",
+                    "operations": [
+                        {
+                            "addObject": {
+                                "object": {"barChart": {"dataSource": "T", "dataRoles": {"category": "C"}}},
+                                "placement": {"page": {"target": "P"}},
+                            }
+                        }
+                    ],
+                },
+            )
+        ).data
+
+    assert result["status"] == "created"
+    assert any("renders EMPTY" in w for w in result["warnings"])
+
+
+async def test_business_ruleset_accepts_stringified_signature(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "create_business_ruleset",
+            {
+                "name": "RS",
+                "signature": '[{"name": "score", "dataType": "decimal", "direction": "input"}]',
+            },
+        )
+
+    body = mock_client.post.call_args[1]["json"]
+    assert body["signature"][0]["name"] == "score"
+
+
+async def test_report_results_carry_open_url(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    async with Client(mcp) as client:
+        created = (await client.call_tool("create_report", {"name": "Cars"})).data
+        applied = (
+            await client.call_tool(
+                "apply_report_operations",
+                {"report_id": "abc", "operations": [{"addPage": {"pageName": "P"}}]},
+            )
+        ).data
+
+    assert created["open_url"].endswith("/SASVisualAnalytics/?reportUri=/reports/reports/test-id")
+    assert applied["open_url"].endswith("/SASVisualAnalytics/?reportUri=/reports/reports/abc")
+
+
+async def test_apply_text_misroute_detected_via_content_check(mcp_server_with_mock_client):
+    """When a batch creates text objects and the stored content does not match,
+    the result carries text_content_warning (one extra content GET)."""
+    mcp, mock_client = mcp_server_with_mock_client
+    etag_resp = _make_mock_response()
+    etag_resp.headers = {"etag": '"e1"'}
+    content_resp = _make_mock_response(
+        {
+            "visualElements": [
+                {"@element": "Text", "name": "ve9", "labelAttribute": "Text 1",
+                 "paragraphList": [{"elements": [{"text": "WRONG CONTENT"}]}]},
+            ],
+            "view": {"sections": [{"name": "vi7", "label": "P",
+                                   "body": {"containedElementList": [{"@element": "Visual", "ref": "ve9"}]}}]},
+        }
+    )
+    mock_client.get.side_effect = [etag_resp, content_resp]
+    put_resp = _make_mock_response(
+        {"operations": [{"name": "ve9", "label": "Text 1", "status": "Success"}]}, status_code=200
+    )
+    put_resp.content = b"x"
+    mock_client.put.return_value = put_resp
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "abc",
+                    "operations": [
+                        {"addObject": {"object": {"text": {"options": {"content": "Intended Title"}}},
+                                       "placement": {"page": {"target": "P"}}}}
+                    ],
+                },
+            )
+        ).data
+
+    assert result["status"] == "applied"
+    assert "misroutes" in result["text_content_warning"]
+    assert "Intended Title" in result["text_content_warning"]
+
+
+async def test_get_castable_columns_404_is_structured(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    missing = _make_mock_response(status_code=404)
+    missing.content = b""
+    missing.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("404", request=MagicMock(), response=missing)
+    )
+    mock_client.get.return_value = missing
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "get_castable_columns",
+                {"server_id": "cas-shared-default", "caslib_name": "Public", "table_name": "GHOST"},
+            )
+        ).data
+
+    assert result["status"] == "not_found"
+    assert "PROMOTE=YES" in result["message"]
+    assert "promote_table_to_memory" in result["message"]
+
+
+async def test_apply_report_operations_blank_save_as_rejected(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {
+                    "report_id": "src-1",
+                    "operations": [{"addPage": {"pageName": "P"}}],
+                    "result_report_name": "  ",
+                },
+            )
+        ).data
+
+    # A blank save-as name would silently edit the source in place.
+    assert result["status"] == "invalid_request"
+    mock_client.put.assert_not_called()
+
+
+async def test_apply_report_operations_failure_parses_operation_errors(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.get.return_value.headers = {"etag": '"e1"'}
+    err = _make_mock_response(status_code=400)
+    err.content = b"x"
+    err.text = (
+        '{"operations": [{"status": "Failed", "messages": ["The target was not found in the report: veX"]}],'
+        '"status": "Failed", "messages": ["Operation addObject failed at index 0"]}'
+    )
+    mock_client.put.return_value = err
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool(
+                "apply_report_operations",
+                {"report_id": "abc", "operations": [{"addPage": {"pageName": "P"}}]},
+            )
+        ).data
+
+    assert result["status"] == "apply_failed"
+    assert result["failed_operation_index"] == 0
+    assert "veX" in result["failed_operations"][0]["messages"][0]
+
+
+async def test_get_report_outline_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    content = {
+        "visualElements": [{"@element": "Text", "name": "ve9", "labelAttribute": "Text 1"}],
+        "view": {
+            "sections": [
+                {"name": "vi7", "label": "Overview",
+                 "body": {"containedElementList": [{"@element": "Visual", "ref": "ve9"}]}}
+            ]
+        },
+    }
+    outline_resp = _make_mock_response(content)
+    mock_client.get.return_value = outline_resp
+    async with Client(mcp) as client:
+        result = (await client.call_tool("get_report_outline", {"report_id": "rpt-1"})).data
+
+    url = mock_client.get.call_args[0][0]
+    assert url.endswith("/reports/reports/rpt-1/content")
+    # The BIRD content read requires the vnd media type (application/json gets a 415).
+    assert mock_client.get.call_args[1]["headers"]["Accept"] == "application/vnd.sas.report.content+json"
+    assert result["status"] == "ok"
+    assert result["pages"][0]["label"] == "Overview"
+    assert result["pages"][0]["objects"][0] == {"name": "ve9", "type": "Text", "label": "Text 1"}
+
+
+async def test_describe_report_objects_operation_mode(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("describe_report_objects", {"operation": "addData"})).data
+
+    assert result["key"] == "addData"
+    assert "dataItems" in result["example"]["addData"]
+    mock_client.get.assert_not_called()
+
+
+async def test_copy_report_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    copy_resp = _make_mock_response({"resultReportId": "copy-9"}, status_code=201)
+    copy_resp.content = b'{"resultReportId": "copy-9"}'
+    mock_client.put.return_value = copy_resp
+    async with Client(mcp) as client:
+        result = (
+            await client.call_tool("copy_report", {"report_id": "src-1", "name": "My Copy"})
+        ).data
+
+    url = mock_client.put.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports/src-1/copy")
+    # A copy mints a new report — no ETag/If-Match handshake.
+    assert "If-Match" not in mock_client.put.call_args[1]["headers"]
+    body = json.loads(mock_client.put.call_args[1]["content"])
+    assert body["resultReportName"] == "My Copy"
+    assert body["resultNameConflict"] == "rename"
+    assert result["status"] == "copied"
+    assert result["id"] == "copy-9"
+    assert result["source_report_id"] == "src-1"
+
+
+async def test_copy_report_invalid_conflict(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("copy_report", {"report_id": "src", "on_conflict": "merge"})).data
+
+    assert result["status"] == "invalid_request"
+    mock_client.put.assert_not_called()
+
+
+async def test_delete_report_request(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        result = (await client.call_tool("delete_report", {"report_id": "rpt-9"})).data
+
+    url = mock_client.delete.call_args[0][0]
+    assert url.endswith("/visualAnalytics/reports/rpt-9")
+    assert result["status"] == "deleted"
+    assert result["report_id"] == "rpt-9"
+
+
+async def test_delete_report_not_found_is_structured(mcp_server_with_mock_client):
+    mcp, mock_client = mcp_server_with_mock_client
+    missing = _make_mock_response(status_code=404)
+    missing.content = b""
+    mock_client.delete.return_value = missing
+    async with Client(mcp) as client:
+        result = (await client.call_tool("delete_report", {"report_id": "ghost"})).data
+
+    assert result["status"] == "not_found"
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds six Tier-3 tools that **author** VA reports through the API, rather than only reading and exporting them, plus the catalog and prompt that drive them. Tool count **68 → 74**.

| Tool | Purpose |
|---|---|
| `create_report` | Create a report; optionally build the whole thing in one atomic call via an `operations` array |
| `apply_report_operations` | The workhorse — apply an ordered, atomic batch of native VA operations (`addData`, `addPage`, `addObject`, `updateObject`, `setParameterValue`, `updateData`, `changeData`, `applyDataView`) with placement (`page` / `relativeToObject` / `container` / `report`), `dry_run`, the ETag concurrency handshake, and save-as via `result_report_name`/`result_folder` |
| `describe_report_objects` | The self-describing catalog the authoring loop reads: every operation and addable object with data roles, options, an intent→object map, placement guide, and the API's hard limits |
| `get_report_outline` | Read structure back, returning the object handles the other tools need |
| `copy_report` / `delete_report` | Copy (pairs with `changeData` for copy-and-replace) and delete |

Validation, the operation/object catalog, and payload construction live in `helpers/report_authoring_helpers.py`, so the tools stay thin wrappers. The new `build_va_dashboard` prompt drives the discover → shape → structure → polish → verify loop over them.

## Also fixed

Two things the authoring loop depends on:

- **Tolerant list/dict coercion.** Some MCP clients (observed live) serialize optional list/dict parameters as JSON-encoded strings (`'[{"addData": ...}]'` instead of the array). pydantic rejected the call before the tool body ran, and the model could not correct it from its side. `tools/_common.py` now absorbs the class server-side via `BeforeValidator`, leaving the published JSON schema unchanged.
- **`get_castable_columns` returns a structured `not_found`** explaining the two usual causes (an unloaded source table vs a session-scoped table created without `PROMOTE=YES`) instead of a raw HTTP 404.

## Testing

- **440 unit tests pass** (90% coverage gate met at 92.75%) at this commit.
- **Live integration suite green** (2026-08-05): all 30 integration tests pass against a live Viya environment, including the new `test_report_authoring_workflow` exercising the full authoring loop — describe → atomic create → chained operations with relative placement → outline read-back → save-as → copy → delete.

## Note

Stacked below #30 (read-only mode), which classifies these six tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
