### PR TITLE
feat: add no-auth and fixed compute session modes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,9 @@ VIYA_ENDPOINT=
 CLIENT_ID=sas-mcp
 HOST_PORT=8134
 MCP_SIGNING_KEY=default # Should be a strong random string in production
-MCP_BASE_URL= # External URL of the MCP server (e.g. https://sas-mcp.company.com) — defaults to http://localhost:HOST_PORT
+# External URL of the MCP server (e.g. https://sas-mcp.company.com).
+# Leave empty to default to http://localhost:HOST_PORT.
+MCP_BASE_URL=
 COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
 
 # Expose only a subset of tool tiers (default: all). Accepts ranges and comma
@@ -22,6 +24,16 @@ SSL_VERIFY=true
 # fails the MCP JWT swap is validated against Viya's JWKS and used as-is.
 # Useful for automation/CI clients that already hold a Viya access token.
 ALLOW_RAW_BEARER=false
+
+# Set to false to disable all SASLogon/OAuth flows (HTTP and stdio).
+# In this mode, the server does not require client Authorization headers and
+# sends Viya API requests without an Authorization header.
+VIYA_AUTH=true
+
+# Optional fixed compute session id for environments that do not expose
+# /compute/contexts or context-based session creation (e.g. session "0001").
+# When set, compute tools reuse this session directly.
+COMPUTE_SESSION_ID=
 
 # Stdio mode: authenticates via OAuth 2.0 device-code flow.
 # The server reads the token cached by `sas-viya auth loginCode` from

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ curl -H "Authorization: Bearer $VIYA_TOKEN" http://localhost:8134/mcp ...
 
 The server validates the token against Viya's JWKS and uses it upstream as-is, bypassing the MCP JWT swap. The default OAuth2 PKCE flow keeps working alongside — both client types share the same `/mcp` endpoint.
 
+If your Viya APIs are intentionally exposed without auth (for example, a local/dev Compute API endpoint), set `VIYA_AUTH=false` to bypass all SASLogon/OAuth flows in both HTTP and stdio modes. In this mode the server sends upstream requests without an `Authorization` header.
+
+If your compute deployment does not expose `/compute/contexts` and only supports a fixed session, set `COMPUTE_SESSION_ID=<session_id>`. The compute tools will use that session directly instead of creating context-backed sessions.
+
 ### Choosing a deployment mode
 
 | | **HTTP** | **Stdio** | **Docker** |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server for executing SAS code, training AutoML pr
 
 ## Features
 
-- 68 tools across 8 selectable tiers, spanning the Analytics Life Cycle on SAS Viya
+- 68 tools across 9 selectable tiers, spanning the Analytics Life Cycle on SAS Viya
 - Prompt Templates for improving your SAS Code
 - OAuth2 authentication with PKCE flow
 - HTTP-based MCP server compatible with MCP clients
@@ -150,6 +150,7 @@ Tools are grouped into numbered tiers. By default the server exposes all of them
 | 5 | Automated Machine Learning |
 | 6 | Model Management & Scoring |
 | 7 | Decisioning (SAS Intelligent Decisioning) |
+| 8 | Workbench (Execute Code Only) |
 
 ```sh
 # Example: expose only compute/discovery/data-ops and reporting
@@ -241,6 +242,9 @@ Build and manage SAS Intelligent Decisioning rule sets and decision flows end to
 - **get_decision_flow_code**: Retrieve the generated DS2 execution code for a flow
 - **lock_decision_flow_revision** / **list_decision_flow_revisions** / **get_decision_flow_revision**: Lock, list, and fetch immutable decision revisions
 - **publish_decision_flow**: Publish a locked decision revision to a MAS destination, polling to completion and returning the server-generated MAS `moduleId` (directly usable with **get_mas_module_step_signature** / **score_data**)
+
+#### Tier 8 — Workbench (Execute Code Only)
+- **execute_sas_code**: Execute SAS code snippets and retrieve execution results (log and listing output). Runs in a reusable compute session that is kept warm across calls, so SAS state (WORK tables, macro variables, assigned librefs) persists between successive calls
 
 ### Prompt Templates
 

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -2,7 +2,7 @@
 
 ### Authentication modes — at a glance
 
-The server supports five authentication paths across HTTP and stdio modes. Pick one per deployment; HTTP mode lets PKCE and raw-bearer clients share the same endpoint.
+The server supports six authentication paths across HTTP and stdio modes. Pick one per deployment; HTTP mode lets PKCE and raw-bearer clients share the same endpoint.
 
 | Mode                              | Transport | What the client does                                      | What the server does                                                                                        | Admin client registration?                                                                        | External CLI?     | Best for                                                                                                                    |
 | --------------------------------- | --------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -11,11 +11,13 @@ The server supports five authentication paths across HTTP and stdio modes. Pick 
 | **`sas-viya` CLI cache**          | stdio     | Runs `sas-viya auth loginCode` once                       | Reads access token from `~/.sas/credentials.json` on each tool call                                         | ❌ Not needed (uses built-in `sas.cli` client)                                                    | ✅ `sas-viya` CLI | Operators who already use the SAS Viya CLI                                                                                  |
 | **`sas-mcp-login` cache**         | stdio     | Runs `uv run sas-mcp-login` once                          | Reads access token from `~/.sas-mcp-server/credentials.json` on each tool call                              | ❌ Not needed (uses built-in `vscode` client)                                                     | ❌ None           | Zero-prereq bootstrap; lowest friction on Viya 2022.11+                                                                     |
 | **Native device-code (fallback)** | stdio     | None — server prints a URL and code on first tool call    | RFC 8628 device-authorization flow against SAS Logon                                                        | ⚠️ Only if your registered client has the device-code grant type                                  | ❌ None           | Viya deployments that don't CSRF-protect `/SASLogon/oauth/device_authorization`                                             |
+| **No-auth mode**                  | HTTP/stdio | Sets `VIYA_AUTH=false`                                      | Skips SASLogon/OAuth entirely; forwards requests to Viya without an `Authorization` header                  | ❌ No                                                                                              | ❌ None           | Compute/API deployments that are already reachable without authentication                                                    |
 
 **Defaults and ordering**
 
 - **HTTP mode** always runs PKCE. The raw-bearer path is additive and opt-in via `ALLOW_RAW_BEARER=true`; when off, only PKCE clients can authenticate.
 - **stdio mode** tries the cache files in order: `sas-viya` CLI cache → `sas-mcp-login` cache → native device-code. The first hit wins.
+- **No-auth override**: set `VIYA_AUTH=false` to bypass all auth flows in both HTTP and stdio modes.
 
 **Removed**
 
@@ -113,6 +115,8 @@ The .env file used by the MCP Server allows for customizable options that the us
 | `COMPUTE_CONTEXT_NAME` | No | `SAS Job Execution compute context` | Viya compute context to use for code execution |
 | `SSL_VERIFY` | No | `true` | Set to `false` to disable SSL certificate verification (e.g. for self-signed Viya certificates) |
 | `ALLOW_RAW_BEARER` | No | `false` | When `true`, the HTTP-mode server also accepts a raw Viya access token in the `Authorization` header alongside the default OAuth2 PKCE flow. Useful for automation that already holds a Viya token. |
+| `VIYA_AUTH` | No | `true` | Master auth toggle. Set to `false` to disable SASLogon/OAuth handling (HTTP and stdio) and send Viya API calls without an `Authorization` header. |
+| `COMPUTE_SESSION_ID` | No | — | Fixed compute session id (for deployments without `/compute/contexts`). When set (e.g. `0001`), compute tools use that session directly. |
 | `SAS_CLI_CONFIG` | Stdio (optional) | `$HOME` | Parent directory for the SAS Viya CLI credential cache. The token is read from `$SAS_CLI_CONFIG/.sas/credentials.json`. |
 | `VIYA_USERNAME` | Tests only | — | Used by the integration test suite to acquire a token via the legacy `sas.cli` password grant. Not used by the MCP server itself. |
 | `VIYA_PASSWORD` | Tests only | — | See `VIYA_USERNAME`. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sas-mcp-server"
-version = "1.5.0"
+version = "1.6.0"
 description = "An MCP server for executing SAS code and querying Compute, CAS, and model APIs on SAS Viya via OAuth 2.0."
 readme = "README.md"
 authors = [{name = "SAS Institute Inc."}]

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -122,7 +122,11 @@ COMPUTE_SESSION_ID = os.getenv("COMPUTE_SESSION_ID", "").strip()
 # Optional tool-tier selection, e.g. "0-4" or "0,1,7". Empty means all tiers.
 # Parsed by sas_mcp_server.tools.resolve_enabled_tiers.
 MCP_TIERS = os.getenv("MCP_TIERS", "")
-MCP_BASE_URL = os.getenv("MCP_BASE_URL", f"http://localhost:{HOST_PORT}")
+_mcp_base_url = os.getenv("MCP_BASE_URL", "").strip()
+# An empty value is the documented .env.sample default. Also ignore values
+# that are plainly placeholder comments instead of URLs.
+MCP_BASE_URL = _mcp_base_url if _mcp_base_url and not _mcp_base_url.startswith("#") else f"http://localhost:{HOST_PORT}"
+
 # Upper bound on binary export bytes returned inline as an embedded resource by
 # ``export_report``. Larger exports are refused with guidance rather than
 # streamed through the model context (default 25 MiB).

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -10,13 +10,14 @@ from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from mcp.server.auth.provider import AccessToken
 
-from .env import env_bool
+from .env import _FALSE, _TRUE, env_bool
 from .exceptions import ConfigError
 
 load_dotenv()
 
 SSL_VERIFY = env_bool("SSL_VERIFY", True)
 ALLOW_RAW_BEARER = env_bool("ALLOW_RAW_BEARER", False)
+AUTH_ENABLED = env_bool("VIYA_AUTH", True)
 
 # --- Opt-in collection mode (telemetry) -------------------------------------
 # Master switch. Default OFF; must be explicitly true/1/yes/on. When false,
@@ -117,6 +118,7 @@ CLIENT_ID = os.getenv("CLIENT_ID", "sas-mcp")
 HOST_PORT = int(os.getenv("HOST_PORT", "8134"))
 MCP_SIGNING_KEY = os.getenv("MCP_SIGNING_KEY", "default")
 CONTEXT_NAME = os.getenv("COMPUTE_CONTEXT_NAME", "SAS Job Execution compute context")
+COMPUTE_SESSION_ID = os.getenv("COMPUTE_SESSION_ID", "").strip()
 # Optional tool-tier selection, e.g. "0-4" or "0,1,7". Empty means all tiers.
 # Parsed by sas_mcp_server.tools.resolve_enabled_tiers.
 MCP_TIERS = os.getenv("MCP_TIERS", "")

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -10,7 +10,7 @@ from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from mcp.server.auth.provider import AccessToken
 
-from .env import _FALSE, _TRUE, env_bool
+from .env import env_bool
 from .exceptions import ConfigError
 
 load_dotenv()

--- a/src/sas_mcp_server/mcp_server.py
+++ b/src/sas_mcp_server/mcp_server.py
@@ -17,7 +17,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from .config import VIYA_ENDPOINT, viya_auth
+from .config import AUTH_ENABLED, VIYA_ENDPOINT, viya_auth
 from .exceptions import AuthenticationError
 from .prompts import register_prompts
 from .telemetry import install_telemetry
@@ -66,12 +66,20 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict]:
 
 # Initialize the FastMCP server
 logger.info("Connecting to SAS Viya at %s", VIYA_ENDPOINT)
-mcp = FastMCP("SAS Viya Execution MCP Server", auth=viya_auth, lifespan=_lifespan)
+_mcp_kwargs: dict[str, Any] = {"lifespan": _lifespan}
+if AUTH_ENABLED:
+    _mcp_kwargs["auth"] = viya_auth
+else:
+    logger.warning(
+        "VIYA_AUTH=false: SASLogon authentication is disabled; Viya API calls are sent without Authorization headers"
+    )
+mcp = FastMCP("SAS Viya Execution MCP Server", **_mcp_kwargs)
 # Opt-in telemetry (no-op unless COLLECTION_MODE is enabled). Added FIRST so it
 # is the OUTERMOST middleware — it wraps AuthMiddleware and the tool, so an auth
 # failure is recorded as status="error" and re-raised unchanged.
 install_telemetry(mcp, "http")
-mcp.add_middleware(AuthMiddleware())
+if AUTH_ENABLED:
+    mcp.add_middleware(AuthMiddleware())
 
 
 @mcp.custom_route("/health", methods=["GET"])
@@ -82,6 +90,8 @@ async def health_check(request: Request) -> JSONResponse:
 
 # Token getter for HTTP mode: reads from context state set by AuthMiddleware
 async def _http_get_token(ctx: Context) -> str:
+    if not AUTH_ENABLED:
+        return ""
     token = await ctx.get_state("access_token")
     if not token:
         raise AuthenticationError("No auth header found. Cannot authenticate to Viya")

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -280,10 +280,6 @@ def _refresh_cached_token(path: Path, client_id: str) -> str | None:
 
 def _get_viya_token() -> str:
     if not AUTH_ENABLED:
-        logger.warning(
-            "VIYA_AUTH=false: SASLogon authentication is disabled; "
-            "Viya API calls are sent without Authorization headers"
-        )
         return ""
     for path, client_id in (
         (_sas_cli_credentials_path(), SAS_CLI_CLIENT_ID),
@@ -318,6 +314,11 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict]:
 
 
 logger.info("Connecting to SAS Viya at %s", VIYA_ENDPOINT)
+if not AUTH_ENABLED:
+    logger.warning(
+        "VIYA_AUTH=false: SASLogon authentication is disabled; "
+        "Viya API calls are sent without Authorization headers"
+    )
 mcp = FastMCP("SAS Viya Execution MCP Server", lifespan=_lifespan)
 register_tools(mcp, _stdio_get_token)
 # Opt-in telemetry (no-op unless COLLECTION_MODE is enabled).

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -46,7 +46,7 @@ import httpx
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
 
-from .config import CLIENT_ID, SSL_VERIFY, VIYA_ENDPOINT
+from .config import AUTH_ENABLED, CLIENT_ID, SSL_VERIFY, VIYA_ENDPOINT
 from .exceptions import AuthenticationError
 from .prompts import register_prompts
 from .telemetry import install_telemetry
@@ -279,6 +279,12 @@ def _refresh_cached_token(path: Path, client_id: str) -> str | None:
 
 
 def _get_viya_token() -> str:
+    if not AUTH_ENABLED:
+        logger.warning(
+            "VIYA_AUTH=false: SASLogon authentication is disabled; "
+            "Viya API calls are sent without Authorization headers"
+        )
+        return ""
     for path, client_id in (
         (_sas_cli_credentials_path(), SAS_CLI_CLIENT_ID),
         (_helper_credentials_path(), HELPER_CLIENT_ID),

--- a/src/sas_mcp_server/tools/__init__.py
+++ b/src/sas_mcp_server/tools/__init__.py
@@ -31,6 +31,7 @@ from . import (
     jobs,
     model_scoring,
     reports,
+    workbench,
 )
 
 Registrar = Callable[[FastMCP, Callable[[Context], Awaitable[str]]], None]
@@ -44,6 +45,7 @@ _TIER_REGISTRARS: dict[int, Registrar] = {
     5: automl.register,
     6: model_scoring.register,
     7: decisioning.register,
+    8: workbench.register,
 }
 
 TIER_TITLES: dict[int, str] = {
@@ -55,6 +57,7 @@ TIER_TITLES: dict[int, str] = {
     5: "Automated Machine Learning",
     6: "Model Management & Scoring",
     7: "Decisioning (SAS Intelligent Decisioning)",
+    8: "Workbench (Execute Code Only)",
 }
 
 ALL_TIERS: frozenset[int] = frozenset(_TIER_REGISTRARS)
@@ -124,6 +127,9 @@ def register_tools(
     enabled = resolve_enabled_tiers(tiers)
     logger.info("Registering tool tiers: %s", sorted(enabled))
     for tier in sorted(enabled):
+        # Tier 8's sole tool is already included when Tier 0 is enabled.
+        if tier == 8 and 0 in enabled:
+            continue
         _TIER_REGISTRARS[tier](mcp, get_token)
 
 

--- a/src/sas_mcp_server/tools/compute.py
+++ b/src/sas_mcp_server/tools/compute.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from fastmcp import Context, FastMCP
 
-from ..config import CONTEXT_NAME
+from ..config import COMPUTE_SESSION_ID, CONTEXT_NAME
 from ..viya_client import contains_filter, get_paged_items, logger, make_client, return_items
 from ..viya_utils import reset_cached_session, run_one_snippet
 from ._common import make_session_helpers
@@ -50,6 +50,14 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         ctx: Context, limit: int = 50, start: int = 0, filter_name: str | None = None
     ) -> list[dict[str, Any]]:
         """List available compute contexts on the Viya environment."""
+        if COMPUTE_SESSION_ID:
+            return [{
+                "name": f"fixed-session:{COMPUTE_SESSION_ID}",
+                "description": (
+                    "Fixed compute session mode enabled via COMPUTE_SESSION_ID; "
+                    "context discovery is bypassed."
+                ),
+            }]
         async with viya_session("list_compute_contexts", ctx) as client:
             filters = contains_filter(filter_name)
             items, _ = await get_paged_items("/compute/contexts", client, limit=limit, start=start, filters=filters)
@@ -72,6 +80,15 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
                 ``execute_sas_code`` uses).
         """
         context_name = compute_context_name or CONTEXT_NAME
+        if COMPUTE_SESSION_ID:
+            return {
+                "status": "fixed_session_mode",
+                "compute_context": context_name,
+                "message": (
+                    "COMPUTE_SESSION_ID is configured; the session is externally "
+                    "managed and cannot be reset by this server."
+                ),
+            }
         logger.info("--- TOOL USED: reset_compute_session ---")
         token = await get_token(ctx)
         async with make_client(token) as client:

--- a/src/sas_mcp_server/tools/workbench.py
+++ b/src/sas_mcp_server/tools/workbench.py
@@ -1,0 +1,34 @@
+# Copyright © 2026, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 8 — Workbench (Execute Code Only)."""
+
+from collections.abc import Awaitable, Callable
+
+from fastmcp import Context, FastMCP
+
+from ..viya_client import logger
+from ..viya_utils import run_one_snippet
+
+
+def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> None:
+    """Register Tier 8 (Workbench) tools on *mcp*."""
+
+    @mcp.tool()
+    async def execute_sas_code(sas_code: str, ctx: Context) -> dict[str, str]:
+        """Execute SAS code in a reusable Viya compute session.
+
+        Args:
+            sas_code (str): the SAS code snippet to be executed using the Viya Job Execution API Service
+
+        Returns:
+            A dictionary with four string fields describing the executed job:
+            ``snippet_id`` (the job's snippet identifier), ``state`` (the final
+            job state, e.g. ``completed``/``error``/``warning``), ``log`` (the
+            full SAS log — execution details, notes, and any errors/warnings),
+            and ``listing`` (the SAS listing output, i.e. the intended results
+            when the code ran successfully).
+        """
+        logger.info("--- TOOL USED: execute_sas_code ---")
+        token = await get_token(ctx)
+        return await run_one_snippet(sas_code, "1", token)

--- a/src/sas_mcp_server/viya_client.py
+++ b/src/sas_mcp_server/viya_client.py
@@ -128,11 +128,13 @@ async def delete_resource(url: str, client: httpx.AsyncClient) -> None:
     resp.raise_for_status()
 
 
-def make_client(token: str) -> httpx.AsyncClient:
+def make_client(token: str | None) -> httpx.AsyncClient:
     """Create an :class:`httpx.AsyncClient` with auth headers for Viya API calls."""
-    if not token.startswith("Bearer "):
-        token = f"Bearer {token}"
-    headers = {"Authorization": token}
+    headers: dict[str, str] = {}
+    if token:
+        if not token.startswith("Bearer "):
+            token = f"Bearer {token}"
+        headers["Authorization"] = token
     return httpx.AsyncClient(
         headers=headers, verify=SSL_VERIFY, timeout=_CLIENT_TIMEOUT
     )

--- a/src/sas_mcp_server/viya_utils.py
+++ b/src/sas_mcp_server/viya_utils.py
@@ -24,7 +24,7 @@ import json
 
 import httpx
 
-from .config import CONTEXT_NAME, VIYA_ENDPOINT
+from .config import COMPUTE_SESSION_ID, CONTEXT_NAME, VIYA_ENDPOINT
 from .viya_client import logger, make_client
 
 
@@ -196,12 +196,15 @@ class _ComputeSessionCache:
 
 
 _SESSION_CACHE = _ComputeSessionCache()
+_FIXED_SESSION_JOB_LOCK = asyncio.Lock()
 
 
 async def get_cached_session(
     client: httpx.AsyncClient, context_name: str, token: str
 ) -> str:
     """Return the reusable compute session id for the token's user + context."""
+    if COMPUTE_SESSION_ID:
+        return COMPUTE_SESSION_ID
     return await _SESSION_CACHE.get_or_create(
         client, context_name, _token_user_key(token), token
     )
@@ -214,6 +217,8 @@ async def reset_cached_session(
 
     Returns the deleted session id, or ``None`` if there was no cached session.
     """
+    if COMPUTE_SESSION_ID:
+        return None
     return await _SESSION_CACHE.reset(client, context_name, _token_user_key(token))
 
 
@@ -285,9 +290,17 @@ async def run_one_snippet(
     async with make_client(token) as client:
         sid = await get_cached_session(client, CONTEXT_NAME, token)
         try:
-            jid = await submit_job(client, sid, code)
-            logger.info("Job submitted: %s", jid)
-            state, log_text, listing_text = await wait_job(client, sid, jid)
+            # A fixed externally managed session (e.g. "0001") can be shared
+            # across callers; serialize job runs to avoid session-state races.
+            if COMPUTE_SESSION_ID:
+                async with _FIXED_SESSION_JOB_LOCK:
+                    jid = await submit_job(client, sid, code)
+                    logger.info("Job submitted: %s", jid)
+                    state, log_text, listing_text = await wait_job(client, sid, jid)
+            else:
+                jid = await submit_job(client, sid, code)
+                logger.info("Job submitted: %s", jid)
+                state, log_text, listing_text = await wait_job(client, sid, jid)
             logger.info("Job completed: %s", state)
             return {
                 "snippet_id": snippet_id,

--- a/src/sas_mcp_server/viya_utils.py
+++ b/src/sas_mcp_server/viya_utils.py
@@ -21,6 +21,7 @@ import base64
 import binascii
 import hashlib
 import json
+from contextlib import nullcontext
 
 import httpx
 
@@ -292,12 +293,8 @@ async def run_one_snippet(
         try:
             # A fixed externally managed session (e.g. "0001") can be shared
             # across callers; serialize job runs to avoid session-state races.
-            if COMPUTE_SESSION_ID:
-                async with _FIXED_SESSION_JOB_LOCK:
-                    jid = await submit_job(client, sid, code)
-                    logger.info("Job submitted: %s", jid)
-                    state, log_text, listing_text = await wait_job(client, sid, jid)
-            else:
+            job_lock = _FIXED_SESSION_JOB_LOCK if COMPUTE_SESSION_ID else nullcontext()
+            async with job_lock:
                 jid = await submit_job(client, sid, code)
                 logger.info("Job submitted: %s", jid)
                 state, log_text, listing_text = await wait_job(client, sid, jid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,9 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("HOST_PORT", "8134")
     monkeypatch.setenv("MCP_SIGNING_KEY", "test-key")
     monkeypatch.setenv("COMPUTE_CONTEXT_NAME", "Test Context")
+    monkeypatch.setenv("VIYA_AUTH", "true")
+    monkeypatch.setenv("MCP_TIERS", "")
+    monkeypatch.setenv("COMPUTE_SESSION_ID", "")
 
 
 @pytest.fixture
@@ -200,7 +203,7 @@ def mcp_server_with_mock_client():
             return "test-token"
 
         from sas_mcp_server.tools import register_tools
-        register_tools(mcp, mock_get_token)
+        register_tools(mcp, mock_get_token, tiers="")
         yield mcp, mock_client
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,7 @@ def test_config_loading_with_env_vars(mock_env_vars):
     assert cfg.HOST_PORT == 8134
     assert cfg.MCP_SIGNING_KEY == "test-key"
     assert cfg.CONTEXT_NAME == "Test Context"
+    assert cfg.AUTH_ENABLED is True
 
     # Derived endpoints
     assert cfg.AUTHORIZATION_ENDPOINT == "https://test.viya.com/SASLogon/oauth/authorize"
@@ -74,6 +75,7 @@ def test_config_default_values(monkeypatch):
     monkeypatch.delenv("HOST_PORT", raising=False)
     monkeypatch.delenv("MCP_SIGNING_KEY", raising=False)
     monkeypatch.delenv("COMPUTE_CONTEXT_NAME", raising=False)
+    monkeypatch.delenv("VIYA_AUTH", raising=False)
     # Block module-level load_dotenv from repopulating from .env.
     with patch('dotenv.load_dotenv'):
         cfg = _reload_config()
@@ -81,3 +83,23 @@ def test_config_default_values(monkeypatch):
     assert cfg.HOST_PORT == 8134
     assert cfg.MCP_SIGNING_KEY == "default"
     assert cfg.CONTEXT_NAME == "SAS Job Execution compute context"
+    assert cfg.AUTH_ENABLED is True
+
+
+def test_config_viya_auth_enabled(monkeypatch):
+    """VIYA_AUTH env var is parsed as the auth toggle."""
+    monkeypatch.setenv("VIYA_ENDPOINT", "https://test.viya.com")
+    monkeypatch.setenv("VIYA_AUTH", "false")
+    with patch("dotenv.load_dotenv"):
+        cfg = _reload_config()
+    assert cfg.AUTH_ENABLED is False
+
+
+def test_config_mcp_base_url_comment_value_falls_back_to_default(monkeypatch):
+    """Comment-like MCP_BASE_URL values are ignored and defaulted."""
+    monkeypatch.setenv("VIYA_ENDPOINT", "https://test.viya.com")
+    monkeypatch.setenv("HOST_PORT", "8134")
+    monkeypatch.setenv("MCP_BASE_URL", "# invalid")
+    with patch("dotenv.load_dotenv"):
+        cfg = _reload_config()
+    assert cfg.MCP_BASE_URL == "http://localhost:8134"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,6 +14,12 @@ from sas_mcp_server import mcp_server
 from sas_mcp_server.mcp_server import AuthenticationError
 
 
+@pytest.fixture(autouse=True)
+def _force_auth_enabled():
+    with patch.object(mcp_server, "AUTH_ENABLED", True):
+        yield
+
+
 def test_authentication_error():
     """AuthenticationError carries its message and renders a prefixed string."""
     error = AuthenticationError("Test error message")

--- a/tests/test_stdio_server.py
+++ b/tests/test_stdio_server.py
@@ -15,6 +15,12 @@ from sas_mcp_server import stdio_server
 from sas_mcp_server.exceptions import AuthenticationError
 
 
+@pytest.fixture(autouse=True)
+def _force_auth_enabled():
+    with patch.object(stdio_server, "AUTH_ENABLED", True):
+        yield
+
+
 def _iso(minutes_from_now: float) -> str:
     """ISO-8601 timestamp offset from now, for building credential expiries."""
     return (datetime.now(UTC) + timedelta(minutes=minutes_from_now)).isoformat()
@@ -122,6 +128,14 @@ def test_get_viya_token_falls_back_to_device(tmp_path, monkeypatch):
     monkeypatch.setattr(stdio_server, "_helper_credentials_path", lambda: tmp_path / "b.json")
     monkeypatch.setattr(stdio_server, "_native_device_code_token", lambda: "DEVTOK")
     assert stdio_server._get_viya_token() == "DEVTOK"
+
+
+def test_get_viya_token_no_auth_mode_skips_all_auth(tmp_path, monkeypatch):
+    with patch.object(stdio_server, "AUTH_ENABLED", False), patch(
+        "sas_mcp_server.stdio_server.httpx.post"
+    ) as post:
+        assert stdio_server._get_viya_token() == ""
+        post.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -255,6 +255,15 @@ def test_make_client_preserves_bearer_prefix(mock_env_vars):
         assert call_kwargs["headers"]["Authorization"] == "Bearer my-token"
 
 
+def test_make_client_without_token_omits_auth_header(mock_env_vars):
+    """make_client(None) should send no Authorization header."""
+    with patch("sas_mcp_server.viya_client.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        make_client(None)
+        call_kwargs = mock_cls.call_args[1]
+        assert call_kwargs["headers"] == {}
+
+
 # ---------------------------------------------------------------------------
 # return_items
 # ---------------------------------------------------------------------------

--- a/tests/test_viya_utils.py
+++ b/tests/test_viya_utils.py
@@ -25,6 +25,13 @@ from sas_mcp_server.viya_utils import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _default_dynamic_compute_sessions():
+    """Keep tests on the context-backed session path unless overridden."""
+    with patch("sas_mcp_server.viya_utils.COMPUTE_SESSION_ID", ""):
+        yield
+
+
 def _resp(json_data=None, status_code=200):
     """Build a minimal sync mock HTTP response for compute-cache tests."""
     resp = MagicMock()
@@ -445,6 +452,18 @@ async def test_get_cached_session_is_per_user(mock_env_vars):
 
 
 @pytest.mark.asyncio
+async def test_get_cached_session_fixed_session_mode_skips_context_lookup(mock_env_vars):
+    """When COMPUTE_SESSION_ID is set, no context/session APIs are called."""
+    clear_session_cache()
+    client = AsyncMock()
+    with patch("sas_mcp_server.viya_utils.COMPUTE_SESSION_ID", "0001"):
+        sid = await get_cached_session(client, "Ctx", "tok-fixed")
+    assert sid == "0001"
+    client.get.assert_not_called()
+    client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_reset_cached_session_deletes_and_forgets(mock_env_vars):
     """Reset deletes the server-side session and clears the cache entry."""
     clear_session_cache()
@@ -471,6 +490,15 @@ async def test_reset_cached_session_noop_when_empty(mock_env_vars):
     client = AsyncMock()
 
     assert await reset_cached_session(client, "Ctx", "tok-ddd") is None
+    client.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reset_cached_session_fixed_session_mode_is_noop(mock_env_vars):
+    """Fixed-session mode leaves externally managed sessions untouched."""
+    client = AsyncMock()
+    with patch("sas_mcp_server.viya_utils.COMPUTE_SESSION_ID", "0001"):
+        assert await reset_cached_session(client, "Ctx", "tok-any") is None
     client.delete.assert_not_called()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -1274,7 +1270,7 @@ wheels = [
 
 [[package]]
 name = "sas-mcp-server"
-version = "1.4.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -1322,8 +1318,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
# Summary

  Adds support for SAS Viya Compute deployments that operate without authentication or rely on a pre-existing fixed compute session.

# Changes

  - Add VIYA_AUTH=false mode for HTTP and stdio transports.
      - Skips SASLogon/OAuth flows.
      - Removes MCP authentication middleware.
      - Sends upstream Viya requests without an Authorization header.
  - Add COMPUTE_SESSION_ID configuration.
      - Bypasses compute-context discovery and session creation.
      - Reuses an externally managed compute session.
      - Serializes jobs to prevent shared-session state races.
      - Prevents the server from resetting the fixed session.
  - Document both configuration options in the sample environment file, README, and configuration guide.
  - Add tests for no-auth clients, configuration parsing, and fixed-session behavior.
  - Bump the package version to 1.6.0.

# Testing

  Added coverage for:

  - VIYA_AUTH configuration and defaults
  - stdio authentication bypass
  - HTTP clients without authorization headers
  - fixed-session lookup and reset behavior
  - HTTP and stdio server configuration

  ## Configuration example

  VIYA_AUTH=false
  COMPUTE_SESSION_ID=0001

  Existing authenticated, context-backed deployments remain the default and are unaffected.
