### PR TITLE
Fix quotes in COMPUTE_CONTEXT_NAME in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,7 +8,7 @@ MCP_SIGNING_KEY=default # Should be a strong random string in production
 # External URL of the MCP server (e.g. https://sas-mcp.company.com).
 # Leave empty to default to http://localhost:HOST_PORT.
 MCP_BASE_URL=
-COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
+COMPUTE_CONTEXT_NAME='SAS Job Execution compute context'
 
 # Expose only a subset of tool tiers (default: all). Accepts ranges and comma
 # lists, e.g. MCP_TIERS=0-4 or MCP_TIERS=0,1,6,7. Tiers: 0 Compute & Code

--- a/.env.sample
+++ b/.env.sample
@@ -4,11 +4,12 @@ VIYA_ENDPOINT=
 # Optional
 CLIENT_ID=sas-mcp
 HOST_PORT=8134
-MCP_SIGNING_KEY=default # Should be a strong random string in production
+# Should be a strong random string in production
+MCP_SIGNING_KEY=default
 # External URL of the MCP server (e.g. https://sas-mcp.company.com).
 # Leave empty to default to http://localhost:HOST_PORT.
 MCP_BASE_URL=
-COMPUTE_CONTEXT_NAME='SAS Job Execution compute context'
+COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
 
 # Expose only a subset of tool tiers (default: all). Accepts ranges and comma
 # lists, e.g. MCP_TIERS=0-4 or MCP_TIERS=0,1,6,7. Tiers: 0 Compute & Code


### PR DESCRIPTION
Suppose I copy the `.env.sample` to `.env`. Without the quotes around:

```bash
COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
```
if I run `source .env` in a Bash terminal it will throw an error `bash: Job: command not found`.