### PR TITLE
feat: make advertised MCP server name configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,11 @@ MCP_SIGNING_KEY=default
 MCP_BASE_URL=
 COMPUTE_CONTEXT_NAME=SAS Job Execution compute context
 
+# Name this server advertises to MCP clients (serverInfo.name). Clients such as
+# VS Code label servers with this value rather than the key in their own config,
+# so give each deployment a distinct name when you run more than one.
+MCP_SERVER_NAME=SAS Viya Execution MCP Server
+
 # Expose only a subset of tool tiers (default: all). Accepts ranges and comma
 # lists, e.g. MCP_TIERS=0-4 or MCP_TIERS=0,1,6,7. Tiers: 0 Compute & Code
 # Execution, 1 Data Discovery, 2 Data Operations & Files, 3 Reports, 4 Batch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Configurable server name** — `MCP_SERVER_NAME` sets the name the server advertises to MCP clients (`serverInfo.name`), defaulting to the previous hardcoded `SAS Viya Execution MCP Server`. Clients such as VS Code label servers with this value rather than the key in their own configuration, so operators running one server per Viya environment can now tell them apart. Applied to both the HTTP (`mcp_server.py`) and stdio (`stdio_server.py`) entry points, and read in `config.py` following the existing `COMPUTE_CONTEXT_NAME` pattern.
+
 ## [1.6.1] - 2026-08-01
 
 ### Fixed

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -113,6 +113,7 @@ The .env file used by the MCP Server allows for customizable options that the us
 | `MCP_SIGNING_KEY` | No | `default` | Secret key used to sign [FastMCP Proxy JWTs](https://gofastmcp.com/servers/auth/oauth-proxy#param-jwt-signing-key) |
 | `MCP_BASE_URL` | No | `http://localhost:{HOST_PORT}` | External URL of the MCP server (set for k8s/reverse proxy deployments) |
 | `COMPUTE_CONTEXT_NAME` | No | `SAS Job Execution compute context` | Viya compute context to use for code execution |
+| `MCP_SERVER_NAME` | No | `SAS Viya Execution MCP Server` | Name advertised to MCP clients (`serverInfo.name`); set a distinct name per deployment when running multiple servers |
 | `SSL_VERIFY` | No | `true` | Set to `false` to disable SSL certificate verification (e.g. for self-signed Viya certificates) |
 | `ALLOW_RAW_BEARER` | No | `false` | When `true`, the HTTP-mode server also accepts a raw Viya access token in the `Authorization` header alongside the default OAuth2 PKCE flow. Useful for automation that already holds a Viya token. |
 | `VIYA_AUTH` | No | `true` | Master auth toggle. Set to `false` to disable SASLogon/OAuth handling (HTTP and stdio) and send Viya API calls without an `Authorization` header. |

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -118,6 +118,10 @@ CLIENT_ID = os.getenv("CLIENT_ID", "sas-mcp")
 HOST_PORT = int(os.getenv("HOST_PORT", "8134"))
 MCP_SIGNING_KEY = os.getenv("MCP_SIGNING_KEY", "default")
 CONTEXT_NAME = os.getenv("COMPUTE_CONTEXT_NAME", "SAS Job Execution compute context")
+# Name advertised to MCP clients as serverInfo.name during the initialize
+# handshake. Clients label the server with this rather than the key in their own
+# config, so one server per Viya environment can be told apart.
+SERVER_NAME = os.getenv("MCP_SERVER_NAME", "SAS Viya Execution MCP Server")
 COMPUTE_SESSION_ID = os.getenv("COMPUTE_SESSION_ID", "").strip()
 # Optional tool-tier selection, e.g. "0-4" or "0,1,7". Empty means all tiers.
 # Parsed by sas_mcp_server.tools.resolve_enabled_tiers.

--- a/src/sas_mcp_server/mcp_server.py
+++ b/src/sas_mcp_server/mcp_server.py
@@ -17,7 +17,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from .config import AUTH_ENABLED, VIYA_ENDPOINT, viya_auth
+from .config import AUTH_ENABLED, SERVER_NAME, VIYA_ENDPOINT, viya_auth
 from .exceptions import AuthenticationError
 from .prompts import register_prompts
 from .telemetry import install_telemetry
@@ -73,7 +73,7 @@ else:
     logger.warning(
         "VIYA_AUTH=false: SASLogon authentication is disabled; Viya API calls are sent without Authorization headers"
     )
-mcp = FastMCP("SAS Viya Execution MCP Server", **_mcp_kwargs)
+mcp = FastMCP(SERVER_NAME, **_mcp_kwargs)
 # Opt-in telemetry (no-op unless COLLECTION_MODE is enabled). Added FIRST so it
 # is the OUTERMOST middleware — it wraps AuthMiddleware and the tool, so an auth
 # failure is recorded as status="error" and re-raised unchanged.

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -46,7 +46,7 @@ import httpx
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
 
-from .config import AUTH_ENABLED, CLIENT_ID, SSL_VERIFY, VIYA_ENDPOINT
+from .config import AUTH_ENABLED, CLIENT_ID, SERVER_NAME, SSL_VERIFY, VIYA_ENDPOINT
 from .exceptions import AuthenticationError
 from .prompts import register_prompts
 from .telemetry import install_telemetry
@@ -319,7 +319,7 @@ if not AUTH_ENABLED:
         "VIYA_AUTH=false: SASLogon authentication is disabled; "
         "Viya API calls are sent without Authorization headers"
     )
-mcp = FastMCP("SAS Viya Execution MCP Server", lifespan=_lifespan)
+mcp = FastMCP(SERVER_NAME, lifespan=_lifespan)
 register_tools(mcp, _stdio_get_token)
 # Opt-in telemetry (no-op unless COLLECTION_MODE is enabled).
 install_telemetry(mcp, "stdio")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,7 @@ def test_config_default_values(monkeypatch):
     monkeypatch.delenv("HOST_PORT", raising=False)
     monkeypatch.delenv("MCP_SIGNING_KEY", raising=False)
     monkeypatch.delenv("COMPUTE_CONTEXT_NAME", raising=False)
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
     monkeypatch.delenv("VIYA_AUTH", raising=False)
     # Block module-level load_dotenv from repopulating from .env.
     with patch('dotenv.load_dotenv'):
@@ -83,7 +84,18 @@ def test_config_default_values(monkeypatch):
     assert cfg.HOST_PORT == 8134
     assert cfg.MCP_SIGNING_KEY == "default"
     assert cfg.CONTEXT_NAME == "SAS Job Execution compute context"
+    # Unset MCP_SERVER_NAME keeps the name deployments have always advertised.
+    assert cfg.SERVER_NAME == "SAS Viya Execution MCP Server"
     assert cfg.AUTH_ENABLED is True
+
+
+def test_config_server_name_override(monkeypatch):
+    """MCP_SERVER_NAME overrides the advertised server name."""
+    monkeypatch.setenv("VIYA_ENDPOINT", "https://test.viya.com")
+    monkeypatch.setenv("MCP_SERVER_NAME", "SAS Viya MCP (dev)")
+    with patch("dotenv.load_dotenv"):
+        cfg = _reload_config()
+    assert cfg.SERVER_NAME == "SAS Viya MCP (dev)"
 
 
 def test_config_viya_auth_enabled(monkeypatch):


### PR DESCRIPTION
### What

Adds an optional `MCP_SERVER_NAME` environment variable that sets the name the
server advertises to MCP clients. Defaults to the current hardcoded value, so
nothing changes for existing deployments.

### Why

MCP clients label a connected server using the `serverInfo.name` it returns
during the `initialize` handshake — not the key the user chose in their own
client configuration. Because that name is hardcoded, every deployment of this
server reports `SAS Viya Execution MCP Server`.

That is fine for a single server. It becomes a problem as soon as someone
connects to more than one, which is the normal case when the server is deployed
alongside each Viya environment.

We run a SAS MCP Server next to each of our Viya demo environments. When a user
configures two of them in VS Code, the tool picker lists both as
`SAS Viya Execution MCP Server` with no way to tell which is which — including
no way to tell which environment a tool is about to run against.

The client cannot work around this. VS Code has no `displayName` override in
`mcp.json`; there is an open request for exactly that
([microsoft/vscode#319049](https://github.com/microsoft/vscode/issues/319049)),
which cites this same multi-deployment pattern. Until it ships, the only place
the name can be fixed is the server.

### How

- `config.py`: `SERVER_NAME = os.getenv("MCP_SERVER_NAME", "SAS Viya Execution MCP Server")`,
  following the existing `CONTEXT_NAME` / `COMPUTE_CONTEXT_NAME` pattern.
- `mcp_server.py` and `stdio_server.py`: import `SERVER_NAME` from config and
  pass it to `FastMCP(...)` instead of the literal. Both modes are covered so
  HTTP and stdio deployments behave consistently.
- `.env.sample`: documents the new variable.
- `tests/test_config.py`: asserts both the unset default and the override.
- `CHANGELOG.md`: entry under `[Unreleased]`.

### Backward compatibility

No conflicts expected. `MCP_SERVER_NAME` is optional and defaults to the exact string
used today, so an existing deployment that does not set it reports the same name
it always has.

### Testing

Tested on Windows 11, Python 3.12.13, `fastmcp` 3.4.2.

**Gates and unit suite** — `./run_tests.sh` (ruff + pyright + unit tests):

- `ruff check .` — clean
- `pyright src` — 0 errors, 0 warnings
- `pytest -m "not integration"` — **316 passed**, 28 deselected; coverage
  **93.38%** against the 90% floor in `pytest.ini`

Two tests added in `tests/test_config.py`: an assertion in
`test_config_default_values` that an unset `MCP_SERVER_NAME` yields the previous
literal, and a new `test_config_server_name_override`. Both patch out
`load_dotenv` so a local `.env` cannot influence the result.

**HTTP mode** — ran two instances of this build side by side to reproduce the
multi-deployment case, one with the variable unset as a control, and read
`serverInfo.name` straight off the `initialize` handshake:

```
HOST_PORT=8134                                       (MCP_SERVER_NAME unset)
HOST_PORT=8135 MCP_SERVER_NAME="SAS Viya MCP - dev"

:8134  serverInfo.name = 'SAS Viya Execution MCP Server'
:8135  serverInfo.name = 'SAS Viya MCP - dev'
```

**Stdio mode** — same two cases, with a client launching `uv run app-stdio`:

```
unset                              -> 'SAS Viya Execution MCP Server'
MCP_SERVER_NAME="SAS Viya MCP - dev" -> 'SAS Viya MCP - dev'
```

So all four combinations of {HTTP, stdio} × {unset, set} were checked, and the
two unset cases are the backward-compatibility evidence.

**What I did not run**

- The integration suite — it needs live Viya credentials and exercises nothing
  this change touches.
- The handshake checks above ran with `VIYA_AUTH=false`, because with auth on an
  unauthenticated `initialize` is rejected by the OAuth proxy before reaching
  this code. `SERVER_NAME` is read at import and passed to `FastMCP(...)` on the
  same line in both auth modes, so the auth setting does not affect what is
  advertised — but flagging it rather than implying I tested the authenticated
  path.
- I verified the value on the wire rather than by screenshotting a client UI.

### Open questions

- Happy to rename the variable if you prefer something else — `MCP_SERVER_NAME`
  was chosen to sit alongside the existing `MCP_TIERS` / `MCP_BASE_URL` prefix.
