### PR TITLE
fix: field-feedback batch — full SAS log, fresh_session, folder/binary upload_file, real-HTTP auth tests, fastmcp 3.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+- **`upload_file` can now stage binary files into Content folders** — the file content can be provided through exactly one of `content` (inline text, the original behaviour), `file_path` (the server reads the bytes off its own disk — binary-safe, gated by `ALLOW_LOCAL_FILE_UPLOAD`, mirroring `upload_data`), or `url` (server-side fetch). A new `parent_folder_uri` argument files the upload into a Content folder (`/folders/folders/{id}`) — the location `%include`/`filesrvc` ingestion needs — instead of landing unfiled. `content_type` now defaults per source: `text/plain` for inline content, else guessed from the file name (`application/octet-stream` fallback). Field feedback: staging a multi-sheet Excel workbook for filesrvc ingestion previously required going around the server to the raw Files REST API.
+- **`execute_sas_code` `fresh_session` flag** — `fresh_session=true` discards the cached compute session before running, so the code starts with no inherited SAS state (equivalent to calling `reset_compute_session` first). The docstring now flags the state-persistence gotcha prominently — a warm session surviving between calls can make re-run checks double-count — and recommends `libname casuser cas;` over log-flooding `caslib _all_ assign;` preambles.
+
+### Fixed
+- **`execute_sas_code` returns the whole log and listing** — the compute log/listing endpoints are paged collections, and a single unpaginated GET silently truncated long logs to the first page (~a few KB), cutting exactly the trailing PASS/ERROR lines audit-style callers read. Both are now fetched page by page to the end; a defensive 10-million-line backstop appends an explicit `[output truncated after N lines]` marker instead of cutting silently. Field feedback: the log is the deliverable for verification workflows, and the truncation forced a `proc printto` → filesrvc → REST-download workaround.
+- **stdio mode no longer prints the FastMCP startup banner** — the banner went to stderr, and a programmatic client that doesn't drain stderr deadlocked on the filled pipe before the first MCP message. `show_banner=False`; diagnostics still log normally.
+
+### Changed
+- **fastmcp lock bumped 3.4.2 → 3.4.6** — picks up upstream security hardening (OAuth redirect-scheme and DCR redirect-URI validation, SSRF bypass blocks, streamable-HTTP DNS-rebinding protection with the host-guard defaults relaxed again in 3.4.4 for reverse-proxy/ASGI deployments) and a JWKS fix (a single unsupported key type no longer rejects every token). The `>=3.0.0,<4.0.0` range is unchanged.
+
+### Tests
+- **The real-HTTP auth stack is now exercised un-mocked** — new regression tests drive the exact ASGI app uvicorn serves via in-process HTTP: a raw upstream JWT with `ALLOW_RAW_BEARER=true` passes the full starlette `AuthenticationMiddleware` → `BearerAuthBackend` → `PermissiveOAuthProxy` chain end to end (verified live against Viya during diagnosis), is refused when the flag is off, and a missing bearer is a 401. Previously every HTTP-auth test mocked `load_access_token`, so this layer had no non-mocked coverage — the gap behind a field report that the raw-bearer HTTP path was dead.
+
 ## [1.7.0] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The headings below match the numbered **tiers** above, so `MCP_TIERS` maps direc
 - **upload_inline_data**: Create a *small* CAS table from inline csv/tsv text passed as a string (a lookup/mapping table the model builds on the fly, or a quick test table). The payload travels through the model's context, so it's for tiny tables only — use **upload_data** for files or anything larger.
 - **promote_table_to_memory**: Load a source table into memory at global scope (idempotent)
 - **list_files**: List files in the Viya Files Service
-- **upload_file**: Upload a file to Viya Files Service
+- **upload_file**: Upload a file to the Viya Files Service, optionally into a Content folder (`parent_folder_uri`). Content comes from exactly one of `content` (inline text), `file_path` (read **server-side**, binary-safe — xlsx, zip, images — gated by `ALLOW_LOCAL_FILE_UPLOAD`), or `url` (server-side fetch)
 - **download_file**: Download file content
 
 #### Tier 3 — Reports & Visualization

--- a/src/sas_mcp_server/stdio_server.py
+++ b/src/sas_mcp_server/stdio_server.py
@@ -328,7 +328,10 @@ register_prompts(mcp)
 
 def main() -> None:
     """Run the MCP server in stdio mode."""
-    mcp.run(transport="stdio")
+    # No startup banner: FastMCP prints it to stderr, and a programmatic driver
+    # that doesn't drain stderr deadlocks on the filled pipe before the first
+    # MCP message. Diagnostics still log normally.
+    mcp.run(transport="stdio", show_banner=False)
 
 
 if __name__ == "__main__":

--- a/src/sas_mcp_server/tools/compute.py
+++ b/src/sas_mcp_server/tools/compute.py
@@ -20,18 +20,30 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
     viya_session, _ = make_session_helpers(get_token)
 
     @mcp.tool()
-    async def execute_sas_code(sas_code: str, ctx: Context) -> dict[str, str]:
+    async def execute_sas_code(
+        sas_code: str, ctx: Context, fresh_session: bool = False
+    ) -> dict[str, str]:
         """
         Executes the provided SAS code in the Viya environment and returns information about the completed Job.
         This will create a job definition for the SAS code, execute it, and then retrieve the results.
 
-        The code runs in a reusable compute session that is kept warm and shared
-        across calls (per user), so SAS state — WORK tables, macro variables, and
-        assigned librefs — persists between successive ``execute_sas_code`` calls.
-        Call ``reset_compute_session`` to discard that state and start fresh.
+        IMPORTANT — state persists between calls: the code runs in a reusable
+        compute session that is kept warm and shared across calls (per user),
+        so SAS state — WORK tables, macro variables, and assigned librefs —
+        survives between successive ``execute_sas_code`` calls. A re-run can
+        therefore see leftovers from earlier calls (e.g. a check that counts
+        results twice). Pass ``fresh_session=True`` (or call
+        ``reset_compute_session``) when the code must start from a clean slate.
+
+        Tip: to reach CAS data, prefer ``libname casuser cas;`` (or a targeted
+        ``caslib`` statement) over ``caslib _all_ assign;`` — on tenants with
+        many caslibs the latter floods the log with assignment NOTEs.
 
         Args:
             sas_code (str): the SAS code snippet to be executed using the Viya Job Execution API Service
+            fresh_session: When True, discard any cached compute session first
+                so the code runs with no inherited SAS state (equivalent to
+                calling ``reset_compute_session`` immediately before).
 
         Returns:
             A dictionary with four string fields describing the executed job:
@@ -43,6 +55,11 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         """
         logger.info("--- TOOL USED: execute_sas_code ---")
         token = await get_token(ctx)
+        if fresh_session and not COMPUTE_SESSION_ID:
+            # Fixed externally managed sessions can't be reset; run_one_snippet
+            # creates a new cached session transparently after the reset.
+            async with make_client(token) as client:
+                await reset_cached_session(client, CONTEXT_NAME, token)
         return await run_one_snippet(sas_code, "1", token)
 
     @mcp.tool()

--- a/src/sas_mcp_server/tools/data_ops.py
+++ b/src/sas_mcp_server/tools/data_ops.py
@@ -3,6 +3,7 @@
 
 """Tier 2 — Data Operations & Files tools."""
 
+import mimetypes
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -464,21 +465,66 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
 
     @mcp.tool()
     async def upload_file(
-        file_name: str, content: str, ctx: Context, content_type: str = "text/plain"
+        file_name: str,
+        ctx: Context,
+        content: str | None = None,
+        file_path: str | None = None,
+        url: str | None = None,
+        parent_folder_uri: str | None = None,
+        content_type: str | None = None,
     ) -> dict[str, Any]:
-        """Upload a file to the Viya Files Service.
+        """Upload a file to the Viya Files Service, optionally into a Content folder.
+
+        Provide the file content through **exactly one** of:
+
+        - ``content`` — inline text (the original behaviour; text files only).
+        - ``file_path`` — a path the **server** reads directly from its own disk
+          (in stdio mode that's your machine). Handles binary files (xlsx, zip,
+          images) untouched. Disable with ``ALLOW_LOCAL_FILE_UPLOAD=false``.
+        - ``url`` — an HTTP(S) URL the server fetches the file from. Also binary-safe.
+
+        ``parent_folder_uri`` files the upload into a Content folder (e.g.
+        ``/folders/folders/{folderId}``) — the location ``%include``/``filesrvc``
+        ingestion and other folder-scoped consumers need. Without it the file
+        lands unfiled under the caller's user context.
 
         Args:
             file_name: Name for the file.
-            content: File content as a string.
-            content_type: MIME type (default 'text/plain').
+            content: File content as an inline string (small text files).
+            file_path: Path to a file the server reads directly from disk.
+            url: HTTP(S) URL the server fetches the file from.
+            parent_folder_uri: Target folder URI (``/folders/folders/{id}``);
+                get one from list_files or the Folders service.
+            content_type: MIME type. Defaults to ``text/plain`` for ``content``,
+                else guessed from ``file_name`` (``application/octet-stream``
+                when unguessable).
         """
+        provided = [
+            n for n, v in (("content", content), ("file_path", file_path), ("url", url)) if v is not None
+        ]
+        if len(provided) != 1:
+            return {
+                "status": "invalid_source",
+                "provided": provided,
+                "message": "Provide exactly one of content, file_path, or url.",
+            }
+        if content is not None:
+            file_bytes = content.encode("utf-8")
+            resolved_type = content_type or "text/plain"
+        else:
+            file_bytes, error = await _resolve_source_bytes(file_path, url)
+            if error is not None:
+                return error
+            assert file_bytes is not None
+            resolved_type = content_type or mimetypes.guess_type(file_name)[0] or "application/octet-stream"
+        params = {"parentFolderUri": parent_folder_uri} if parent_folder_uri else None
         async with viya_session("upload_file", ctx) as client:
             resp = await client.post(
                 f"{VIYA_ENDPOINT}/files/files",
-                content=content.encode("utf-8"),
+                params=params,
+                content=file_bytes,
                 headers={
-                    "Content-Type": content_type,
+                    "Content-Type": resolved_type,
                     "Content-Disposition": f'attachment; filename="{file_name}"',
                     "Accept": "application/json",
                 },

--- a/src/sas_mcp_server/viya_utils.py
+++ b/src/sas_mcp_server/viya_utils.py
@@ -242,6 +242,33 @@ async def submit_job(client: httpx.AsyncClient, session_id: str, code: str) -> s
     return job["id"]
 
 
+# Page size for compute log/listing collection fetches, and a loop backstop far
+# above any real log (10k pages x 1000 lines). Hitting the backstop appends an
+# explicit truncation marker rather than cutting silently.
+_LINES_PAGE_LIMIT = 1000
+_LINES_MAX_PAGES = 10_000
+
+
+async def _fetch_all_lines(client: httpx.AsyncClient, url: str) -> list[str]:
+    """Collect every ``line`` of a compute log/listing collection.
+
+    The log and listing endpoints return *paged* collections (default page ~10
+    lines), so a single unpaginated GET silently truncates anything longer —
+    for audit-style work the log IS the deliverable, so every page is fetched.
+    """
+    lines: list[str] = []
+    start = 0
+    for _ in range(_LINES_MAX_PAGES):
+        resp = await client.get(url, params={"start": start, "limit": _LINES_PAGE_LIMIT})
+        items = resp.json().get("items", [])
+        lines.extend(item.get("line", "") for item in items)
+        if len(items) < _LINES_PAGE_LIMIT:
+            return lines
+        start += _LINES_PAGE_LIMIT
+    lines.append(f"[output truncated after {len(lines)} lines]")
+    return lines
+
+
 async def wait_job(
     client: httpx.AsyncClient, session_id: str, job_id: str, poll: float = 2
 ) -> tuple[str, str, str]:
@@ -251,20 +278,13 @@ async def wait_job(
         resp = await client.get(state_url)
         state = resp.text.strip()
         if state in ("completed", "error", "warning", "canceled"):
-            # Fetch log
             log_url = f"{VIYA_ENDPOINT}/compute/sessions/{session_id}/jobs/{job_id}/log"
-            log_resp = await client.get(log_url)
-            log = log_resp.json()
-            lines = [item["line"] for item in log.get("items", [])]
-            log_text = "\n".join(lines)
+            log_text = "\n".join(await _fetch_all_lines(client, log_url))
 
-            # Fetch listing (plain text output)
             listing_url = (
                 f"{VIYA_ENDPOINT}/compute/sessions/{session_id}/jobs/{job_id}/listing"
             )
-            listing_resp = await client.get(listing_url)
-            listing_json = listing_resp.json()
-            listing_lines = [item["line"] for item in listing_json.get("items", [])]
+            listing_lines = await _fetch_all_lines(client, listing_url)
             listing_text = (
                 "\n".join(listing_lines) if listing_lines else "(no listing output)"
             )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,9 +8,11 @@ token getter, and the AuthenticationError type.
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+from mcp.server.auth.provider import AccessToken
 
-from sas_mcp_server import mcp_server
+from sas_mcp_server import config, mcp_server
 from sas_mcp_server.mcp_server import AuthenticationError
 
 
@@ -129,3 +131,85 @@ async def test_auth_middleware_swap_failure_does_not_set_state():
     assert result == "R"
     ctx.fastmcp_context.set_state.assert_not_awaited()
     call_next.assert_awaited_once_with(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Real-HTTP auth stack (field finding: this layer had no non-mocked coverage)
+# ---------------------------------------------------------------------------
+#
+# These drive mcp_server.app — the exact ASGI app uvicorn serves — through
+# httpx's ASGITransport, so the starlette AuthenticationMiddleware,
+# BearerAuthBackend, and PermissiveOAuthProxy.load_access_token all run for
+# real. Only the innermost JWKS verifier is faked (no live Viya in CI).
+
+_INIT_PAYLOAD = {
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "id": 1,
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "auth-test", "version": "0"},
+    },
+}
+
+
+def _mcp_headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+async def _post_initialize(token: str | None) -> httpx.Response:
+    app = mcp_server.app
+    transport = httpx.ASGITransport(app=app)
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(transport=transport, base_url="http://testserver") as client,
+    ):
+        return await client.post("/mcp", headers=_mcp_headers(token), json=_INIT_PAYLOAD)
+
+
+@pytest.mark.asyncio
+async def test_http_raw_bearer_accepted_end_to_end():
+    """With ALLOW_RAW_BEARER on, a raw upstream JWT authenticates a real /mcp request.
+
+    The token is not a proxy-issued JWT, so the standard swap fails and the
+    request is only accepted because the raw-bearer fallback reaches the
+    upstream token verifier through the real starlette middleware chain.
+    """
+    verifier = AsyncMock(
+        return_value=AccessToken(token="RAWJWT", client_id="test", scopes=["openid"], expires_at=None)
+    )
+    with patch.object(config, "ALLOW_RAW_BEARER", True), \
+         patch.object(config.viya_auth, "_token_validator") as validator:
+        validator.verify_token = verifier
+        resp = await _post_initialize("RAWJWT")
+    assert resp.status_code == 200
+    verifier.assert_awaited_once_with("RAWJWT")
+
+
+@pytest.mark.asyncio
+async def test_http_raw_bearer_rejected_when_disabled():
+    """With ALLOW_RAW_BEARER off (the default), the same raw JWT is refused with 401."""
+    verifier = AsyncMock(
+        return_value=AccessToken(token="RAWJWT", client_id="test", scopes=["openid"], expires_at=None)
+    )
+    with patch.object(config, "ALLOW_RAW_BEARER", False), \
+         patch.object(config.viya_auth, "_token_validator") as validator:
+        validator.verify_token = verifier
+        resp = await _post_initialize("RAWJWT")
+    assert resp.status_code == 401
+    assert "invalid_token" in resp.headers.get("www-authenticate", "")
+    verifier.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_no_bearer_is_401():
+    """A /mcp request with no Authorization header is refused by the HTTP auth layer."""
+    resp = await _post_initialize(None)
+    assert resp.status_code == 401

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -185,8 +185,11 @@ async def test_http_raw_bearer_accepted_end_to_end():
     verifier = AsyncMock(
         return_value=AccessToken(token="RAWJWT", client_id="test", scopes=["openid"], expires_at=None)
     )
+    # Patch the provider instance wired into the app (mcp_server.viya_auth) —
+    # test_config.py reloads sas_mcp_server.config, rebinding config.viya_auth
+    # to a fresh object the app never sees.
     with patch.object(config, "ALLOW_RAW_BEARER", True), \
-         patch.object(config.viya_auth, "_token_validator") as validator:
+         patch.object(mcp_server.viya_auth, "_token_validator") as validator:
         validator.verify_token = verifier
         resp = await _post_initialize("RAWJWT")
     assert resp.status_code == 200
@@ -200,7 +203,7 @@ async def test_http_raw_bearer_rejected_when_disabled():
         return_value=AccessToken(token="RAWJWT", client_id="test", scopes=["openid"], expires_at=None)
     )
     with patch.object(config, "ALLOW_RAW_BEARER", False), \
-         patch.object(config.viya_auth, "_token_validator") as validator:
+         patch.object(mcp_server.viya_auth, "_token_validator") as validator:
         validator.verify_token = verifier
         resp = await _post_initialize("RAWJWT")
     assert resp.status_code == 401

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -446,6 +446,80 @@ async def test_upload_file_request(mcp_server_with_mock_client):
     assert kwargs["headers"]["Accept"] == "application/json"
 
 
+async def test_upload_file_into_folder_from_file_path(mcp_server_with_mock_client, tmp_path):
+    """file_path: binary bytes are read server-side and filed under parentFolderUri."""
+    mcp, mock_client = mcp_server_with_mock_client
+    blob = tmp_path / "book.xlsx"
+    payload = b"PK\x03\x04binary-workbook-bytes"
+    blob.write_bytes(payload)
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "upload_file",
+            {
+                "file_name": "book.xlsx",
+                "file_path": str(blob),
+                "parent_folder_uri": "/folders/folders/f-123",
+                "content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            },
+        )
+
+    url = mock_client.post.call_args[0][0]
+    assert url.endswith("/files/files")
+    kwargs = mock_client.post.call_args[1]
+    assert kwargs["params"] == {"parentFolderUri": "/folders/folders/f-123"}
+    assert kwargs["content"] == payload
+    assert kwargs["headers"]["Content-Type"].startswith("application/vnd.openxmlformats")
+    assert 'filename="book.xlsx"' in kwargs["headers"]["Content-Disposition"]
+
+
+async def test_upload_file_unknown_extension_defaults_to_octet_stream(
+    mcp_server_with_mock_client, tmp_path
+):
+    """Without content_type, an unguessable extension falls back to octet-stream."""
+    mcp, mock_client = mcp_server_with_mock_client
+    blob = tmp_path / "payload.viyabin"
+    blob.write_bytes(b"\x00\x01\x02")
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "upload_file", {"file_name": "payload.viyabin", "file_path": str(blob)}
+        )
+
+    kwargs = mock_client.post.call_args[1]
+    assert kwargs["headers"]["Content-Type"] == "application/octet-stream"
+    assert kwargs["params"] is None
+
+
+async def test_upload_file_requires_exactly_one_source(mcp_server_with_mock_client):
+    """Zero or multiple content sources is rejected before any Viya call."""
+    mcp, mock_client = mcp_server_with_mock_client
+    async with Client(mcp) as client:
+        none = await client.call_tool("upload_file", {"file_name": "x.txt"})
+        both = await client.call_tool(
+            "upload_file",
+            {"file_name": "x.txt", "content": "hi", "file_path": "/tmp/x.txt"},
+        )
+    assert none.data["status"] == "invalid_source"
+    assert both.data["status"] == "invalid_source"
+    assert set(both.data["provided"]) == {"content", "file_path"}
+    mock_client.post.assert_not_called()
+
+
+async def test_upload_file_local_read_respects_gate(
+    mcp_server_with_mock_client, tmp_path, monkeypatch
+):
+    """ALLOW_LOCAL_FILE_UPLOAD=false blocks server-side reads for upload_file too."""
+    mcp, mock_client = mcp_server_with_mock_client
+    blob = tmp_path / "x.txt"
+    blob.write_text("hello")
+    monkeypatch.setenv("ALLOW_LOCAL_FILE_UPLOAD", "false")
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "upload_file", {"file_name": "x.txt", "file_path": str(blob)}
+        )
+    assert result.data["status"] == "file_upload_disabled"
+    mock_client.post.assert_not_called()
+
+
 async def test_download_file_request(mcp_server_with_mock_client):
     mcp, mock_client = mcp_server_with_mock_client
     mock_client.get.return_value.text = "file content here"
@@ -2173,6 +2247,36 @@ async def test_execute_sas_code_request(mcp_server_with_mock_client):
             "log": "LOG",
             "listing": "LISTING",
         }
+
+
+async def test_execute_sas_code_fresh_session_resets_first(mcp_server_with_mock_client):
+    """fresh_session=True discards the cached compute session before running."""
+    mcp, _ = mcp_server_with_mock_client
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value="CLIENT")
+    cm.__aexit__ = AsyncMock(return_value=False)
+    with patch("sas_mcp_server.tools.compute.run_one_snippet") as mock_run, \
+         patch("sas_mcp_server.tools.compute.reset_cached_session", new_callable=AsyncMock) as mock_reset, \
+         patch("sas_mcp_server.tools.compute.make_client", return_value=cm):
+        mock_run.return_value = {"snippet_id": "1", "state": "completed", "log": "", "listing": ""}
+        async with Client(mcp) as client:
+            await client.call_tool(
+                "execute_sas_code", {"sas_code": "data _null_; run;", "fresh_session": True}
+            )
+        mock_reset.assert_awaited_once()
+        assert mock_reset.await_args[0][0] == "CLIENT"
+        mock_run.assert_called_once_with("data _null_; run;", "1", "test-token")
+
+
+async def test_execute_sas_code_default_keeps_session(mcp_server_with_mock_client):
+    """Without fresh_session, the cached session is reused untouched."""
+    mcp, _ = mcp_server_with_mock_client
+    with patch("sas_mcp_server.tools.compute.run_one_snippet") as mock_run, \
+         patch("sas_mcp_server.tools.compute.reset_cached_session", new_callable=AsyncMock) as mock_reset:
+        mock_run.return_value = {"snippet_id": "1", "state": "completed", "log": "", "listing": ""}
+        async with Client(mcp) as client:
+            await client.call_tool("execute_sas_code", {"sas_code": "data _null_; run;"})
+        mock_reset.assert_not_awaited()
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_viya_utils.py
+++ b/tests/test_viya_utils.py
@@ -189,6 +189,40 @@ async def test_wait_job_error_state(
 
 
 @pytest.mark.asyncio
+async def test_wait_job_fetches_all_log_pages(mock_httpx_client, mock_env_vars):
+    """A log longer than one page is returned completely.
+
+    Regression: the log/listing endpoints are paged collections, and a single
+    unpaginated GET silently truncated long logs to the first page — cutting
+    exactly the trailing PASS/ERROR lines audit-style callers need.
+    """
+    mock_state = AsyncMock()
+    mock_state.text = "completed"
+
+    full_page = AsyncMock()
+    full_page.json = MagicMock(
+        return_value={"items": [{"line": f"NOTE: line {i}"} for i in range(1000)]}
+    )
+    tail_page = AsyncMock()
+    tail_page.json = MagicMock(return_value={"items": [{"line": "NOTE: the PASS line"}]})
+    empty_listing = AsyncMock()
+    empty_listing.json = MagicMock(return_value={"items": []})
+
+    mock_httpx_client.get.side_effect = [mock_state, full_page, tail_page, empty_listing]
+
+    state, log, listing = await wait_job(mock_httpx_client, "s", "j", poll=0.01)
+
+    assert state == "completed"
+    lines = log.split("\n")
+    assert len(lines) == 1001
+    assert lines[0] == "NOTE: line 0"
+    assert lines[-1] == "NOTE: the PASS line"
+    log_calls = [c for c in mock_httpx_client.get.call_args_list if c[0][0].endswith("/log")]
+    assert log_calls[0][1]["params"] == {"start": 0, "limit": 1000}
+    assert log_calls[1][1]["params"] == {"start": 1000, "limit": 1000}
+
+
+@pytest.mark.asyncio
 async def test_run_one_snippet_success(
     sample_sas_code, mock_access_token, mock_env_vars
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -378,19 +378,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.2"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/e2c78e26233cd8a416b21513e1925435d54c008a0ec467dbdaa80369daf7/fastmcp-3.4.6.tar.gz", hash = "sha256:2287938da8364ad7071bec2d2393af6ae10fd4e836f06f506569f1456cc87eb4", size = 28808130, upload-time = "2026-08-05T14:54:42.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a5/c02275db111892388972edbb05fbcbfdf1e83cbd1fd03356b3a49b93f839/fastmcp-3.4.6-py3-none-any.whl", hash = "sha256:2a29967be9f68cdd1b4cefb413ede74f83adefd923919a37aaac3611eccdd749", size = 8017, upload-time = "2026-08-05T14:54:38.473Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.2"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -400,9 +400,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b6/b5b9e81e67a3f39534881d2af6aa3fbd2dc367eaa070c3c932770a0c062f/fastmcp_slim-3.4.6.tar.gz", hash = "sha256:6a1e6e42c697ba90abcb1be617a26947d07316f13c6fa138ae7b0de24558e32c", size = 594167, upload-time = "2026-08-05T14:54:15.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/02c254c46b4323ae5262b76a29af73b50a863efc5739a3454d144d3605ee/fastmcp_slim-3.4.6-py3-none-any.whl", hash = "sha256:3e08e6acb03523a47aa17f4d2ab9943e648a41e20b24084da491a732c46dffdc", size = 769174, upload-time = "2026-08-05T14:54:14.663Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

A builder shipping on this server sent detailed field feedback (five findings). This PR addresses all of them, plus a fastmcp refresh. Verification notes per item below.

## 1. `execute_sas_code` truncated the log (~first page) — **fixed**

The compute log/listing endpoints are *paged* collections; `wait_job` issued one unpaginated GET, silently cutting long logs to the first page — dropping exactly the trailing PASS/ERROR lines audit-style callers read (the reporter worked around it with `proc printto` → filesrvc → REST download). Both log and listing are now fetched page-by-page (`limit=1000`) to the end, with a 10M-line backstop that appends an explicit `[output truncated after N lines]` marker instead of cutting silently.

**Verified live:** a 3,120-line (~97 KB) log came back complete from a real Viya — first line, line 3000, and the final PASS line all present — proving the live compute API accepts the paging.

## 2. Reported HTTP raw-bearer auth failure — **could not reproduce; regression tests added**

The report: with fastmcp 3.4.2 + `ALLOW_RAW_BEARER=true`, the starlette auth middleware never fires and every `/mcp` request 401s. Instrumenting every layer and driving the exact ASGI app uvicorn serves — in-process and **live against Viya with a real JWT** — the full chain fires and returns HTTP 200: `AuthenticationMiddleware` → `BearerAuthBackend` → `PermissiveOAuthProxy.load_access_token` → raw-bearer fallback → JWKS verification.

What *was* true: every existing HTTP-auth test mocked `load_access_token`, so this layer had zero un-mocked coverage and the claim couldn't be checked by CI. Three new regression tests now drive real in-process HTTP through the served app: raw JWT accepted with the flag on, refused with it off, and 401 with no bearer. (Likely explanations for the field failure: `ALLOW_RAW_BEARER` is read at config **import time**, so setting it after import silently does nothing; or the app was re-hosted in a way that dropped its middleware stack.)

## 3. Warm-session state surprise — `fresh_session` flag

The docstring has warned about state persistence since v1.2.0, but it's now prominent (\"IMPORTANT — state persists between calls\", with the double-count example from the field report), and `execute_sas_code(fresh_session=true)` discards the cached session before running — equivalent to calling `reset_compute_session` first. Also added the preamble tip: `libname casuser cas;` over `caslib _all_ assign;` (log-flooding on many-caslib tenants).

## 4. `upload_file` — binary + folder targeting

Content now comes from exactly one of `content` (inline text, original behaviour), `file_path` (server-side read, **binary-safe**, `ALLOW_LOCAL_FILE_UPLOAD` gate — reuses `upload_data`'s resolver), or `url` (server-side fetch). New `parent_folder_uri` files the upload into a Content folder — the location `%include`/filesrvc ingestion needs (the reporter had to bypass the server for an 8.6 MB multi-sheet workbook). `content_type` defaults per source, with a `mimetypes` guess for by-reference uploads.

## 5. stdio banner deadlock — one-liner

FastMCP's startup banner goes to stderr; a programmatic driver that doesn't drain the pipe deadlocks before the first MCP message. `mcp.run(transport=\"stdio\", show_banner=False)`.

## fastmcp 3.4.2 → 3.4.6 (lock only)

Reviewed 3.4.3–3.4.6 release notes: security hardening (OAuth redirect-scheme + DCR redirect-URI validation, SSRF bypass blocks, streamable-HTTP DNS-rebinding protection; host-guard defaults relaxed again in 3.4.4 for reverse-proxy/ASGI deployments) and a JWKS fix (one unsupported key type no longer rejects every token). Range in pyproject unchanged.

## Testing

- **482 unit tests pass (92.94% coverage)** on fastmcp **3.4.6** in a clean venv; ruff + pyright clean. 10 new tests (log pagination, fresh_session on/off, 4× upload_file, 3× real-HTTP auth).
- **Live spot-checks against Viya**: the 3,120-line log round-trip (item 1) and the raw-bearer `initialize` → HTTP 200 (item 2).
- **Full live `@integration` suite green on this branch** (fastmcp 3.4.6): 29 passed, 1 skipped, 0 failures in 10m58s. The skip is `test_scoring_workflow`'s pre-existing environment condition ("No MAS modules found" — nothing published to MAS on the test tenant), unrelated to these changes; the workflows covering the touched tools (code execution, file service, data upload) all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
