### PR TITLE
feat(registry): list the container image on the MCP Registry

### DIFF
--- a/.github/mcp-registry.md
+++ b/.github/mcp-registry.md
@@ -1,0 +1,139 @@
+# Listing this server on the MCP Registry
+
+**Maintainer notes.** Nothing here is needed to run or deploy the server — see
+[`../deploy/`](../deploy/README.md) for that. This is about how the container
+image gets published to the public [MCP Registry][registry] so MCP clients can
+discover and install it without being told about it first, and it sits beside
+[`workflows/publish-ghcr.yml`](workflows/publish-ghcr.yml), which implements it.
+
+The registry stores **metadata only** — the artifact stays on GHCR, and this
+repo stays the source of truth. There is one package entry and it is the OCI
+image, so a user installs the same container this repo already ships. Nothing
+new is built or published.
+
+## What the listing tells a client to run
+
+```sh
+docker run -i --rm \
+  -e VIYA_ENDPOINT=https://viya.example.com \
+  -v "$HOME/.sas:/app/.sas" \
+  ghcr.io/sassoftware/sas-mcp-server:1.9.1 app-stdio
+```
+
+The client supplies `docker run -i --rm` and the image reference itself; the
+`-v` mount comes from `runtimeArguments`, the `app-stdio` from
+`packageArguments`, and the `-e` values from `environmentVariables`.
+
+Three details in that command are load-bearing:
+
+- **`app-stdio`** overrides the image's `CMD ["app"]`. The default entry point
+  starts the uvicorn HTTP server on 8134, which speaks no stdio and would leave
+  the client waiting forever. `app-stdio` is a real console script in
+  `pyproject.toml`, not something invented for the listing.
+- **The mount target must be `/app/.sas`.** `$HOME` is `/app` in the image
+  (`adduser --home /app sas`), and stdio mode reads
+  `~/.sas/credentials.json` — the cache `sas-viya auth loginCode` writes.
+  Mounting anywhere else silently falls through to the device-code flow.
+- **stdio, not HTTP.** Local OCI packages are stdio in every published example
+  and in every client that installs them. The HTTP deployment is a different
+  product — see [`../deploy/README.md`](../deploy/README.md) — and is not what a registry listing
+  describes.
+
+Verified against the published `1.9.0` image rather than assumed: driving it
+through a real MCP client over stdio registers **75 tools**, loads the token
+(`Loaded access token from /app/.sas/credentials.json`) and returns live data
+from `list_compute_contexts`.
+
+### Auth is the one rough edge
+
+The mount is marked `isRequired: true`, so clients prompt for it at install
+time. That is deliberate. Without a token cache the server falls back to the
+RFC 8628 device-code flow, which prints its URL and code to **stderr** — inside
+a container, with no browser to open and no TTY, that surfaces only in whatever
+log pane the client happens to show. Better to state the prerequisite up front
+than to ship an install that appears to hang.
+
+So a user needs the SAS Viya CLI and one `sas-viya auth loginCode` before this
+works. That is inherent to stdio mode, not something the listing adds.
+
+## The four moving parts
+
+| Piece | Where | Why |
+|---|---|---|
+| `server.json` | repo root | The listing itself. `mcp-publisher` reads it from the working directory. |
+| `LABEL io.modelcontextprotocol.server.name` | `Dockerfile` | Ownership proof. Must equal `name` in `server.json`. |
+| `publish-mcp-registry` job | `.github/workflows/publish-ghcr.yml` | Publishes on `v*` tags, after the image is pushed. |
+| OIDC | same job | How the `io.github.sassoftware` namespace is reachable. |
+
+### Why the namespace needs CI
+
+`io.github.<orgname>/*` is granted to a human only if they are an **Owner** of
+that GitHub organisation — ordinary membership was deliberately removed as
+sufficient. Publishing `io.github.sassoftware/sas-mcp-server` from a laptop
+therefore fails for most maintainers.
+
+GitHub Actions OIDC takes a different route: the registry validates the Actions
+token and reads its `repository_owner` claim, granting `io.github.<owner>/*`.
+A workflow running in `sassoftware/sas-mcp-server` gets the namespace because
+of where it runs, with no personal org role and no long-lived token to store.
+That is why publishing lives in CI and not in the release checklist.
+
+### Why the job hangs off the image build
+
+The registry does not take ownership on trust. At publish time it fetches
+`ghcr.io/sassoftware/sas-mcp-server:<version>` anonymously, reads
+`Config.Labels`, and rejects the listing unless
+`io.modelcontextprotocol.server.name` matches `name`. So:
+
+- the image must already be pushed → `needs: build-and-push`;
+- the image must be **public** — a private package fails with "is private or
+  requires authentication";
+- multi-arch is fine. The validator resolves the manifest list to a platform
+  image before reading the config, so our `linux/amd64` + `linux/arm64` index
+  works unchanged.
+
+## Constraints the schema enforces
+
+The [blog post][blog] and the `mcp-publisher init` template both show an npm
+package, and copying that shape into an OCI entry fails validation:
+
+- **no `version` field on the package** — the tag goes in `identifier`
+  (`ghcr.io/owner/image:1.9.0`). A `version` alongside it is rejected outright.
+- **no `registryBaseUrl`** — same reason.
+- **`description` is capped at 100 characters.** The `pyproject.toml`
+  description is 118 and does not fit.
+- `registryType` is **`oci`**, not `docker`.
+
+`ghcr.io` is on the allowlist, along with Docker Hub, Quay, Google Artifact
+Registry, Azure Container Registry and MCR. Private registries are not.
+
+## Publishing
+
+Automatic on any `v*` tag, as a second job after the image push. Nothing to run
+by hand. The job rewrites `version` and the image tag in `server.json` from the
+git tag before publishing, so a forgotten bump cannot publish metadata pointing
+at the previous image — the committed values only need to be correct enough to
+validate.
+
+To check what landed:
+
+```sh
+curl "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.sassoftware/sas-mcp-server"
+```
+
+### First publish rides the next release
+
+Every image on GHCR up to and including `1.9.1` was built before the label
+existed — confirmed by inspecting them — so publishing `server.json` as it
+stands today would fail ownership validation. The first successful publish is
+whatever tag first ships an image built from this Dockerfile.
+
+### Getting into the GitHub MCP Registry
+
+Publishing to `registry.modelcontextprotocol.io` is the prerequisite, not the
+whole job. Per the [GitHub blog post][blog], inclusion in the GitHub MCP
+Registry itself is a separate request — email `partnerships@github.com` and ask.
+That is a decision for the maintainers, and this repo does not automate it.
+
+[registry]: https://registry.modelcontextprotocol.io
+[blog]: https://github.blog/ai-and-ml/generative-ai/how-to-find-install-and-manage-mcp-servers-with-the-github-mcp-registry/

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -70,3 +70,48 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  # Lists the image just pushed on the public MCP Registry
+  # (registry.modelcontextprotocol.io), which is what feeds the GitHub MCP
+  # Registry and other client-side catalogues. Metadata only — the artifact
+  # stays on GHCR.
+  publish-mcp-registry:
+    # MUST run after the image exists. The registry validates ownership by
+    # fetching ghcr.io/<repo>:<version> anonymously and reading the
+    # io.modelcontextprotocol.server.name label off its config, so a standalone
+    # workflow on the same tag would race the build and fail with
+    # "OCI image ... does not exist in the registry".
+    needs: build-and-push
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # OIDC is what makes the io.github.sassoftware namespace reachable at all:
+      # the registry reads the `repository_owner` claim off the Actions token and
+      # grants io.github.<owner>/*. Publishing by hand instead would require the
+      # human running it to be an Owner of the sassoftware org.
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Pin server.json to the released version
+        # Derived from the tag rather than trusted from the file, so a forgotten
+        # bump cannot publish metadata pointing at the previous image.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" --arg img "${REGISTRY}/${IMAGE_NAME}:${VERSION}" \
+            '.version = $v | .packages[0].identifier = $img' server.json > server.tmp
+          mv server.tmp server.json
+          cat server.json
+
+      - name: Authenticate to the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish
+        run: ./mcp-publisher publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **The server is listed on the MCP Registry, as the container image** — a `server.json` at the repo root describing the published OCI package, so MCP clients can discover and install this server instead of having to be told about it. Metadata only; the artifact stays on GHCR and nothing new is built. The listing declares `docker run -i --rm -v <home>/.sas:/app/.sas <image> app-stdio`: `app-stdio` overrides the image's `CMD ["app"]`, which starts the HTTP server and speaks no stdio, and the mount target must be `/app/.sas` because `$HOME` is `/app` in the image and stdio mode reads the `sas-viya auth loginCode` token cache from `~/.sas/credentials.json`. Verified against a published image through a real MCP client: 75 tools registered, token loaded from the mount, live data returned.
+  - **Ownership proof** is a new `LABEL io.modelcontextprotocol.server.name` in the `Dockerfile`. The registry fetches the image anonymously at publish time and refuses the listing unless that label equals `name` in `server.json`, so the two must stay in step. Every image published so far predates the label, so the first successful publish is whichever tag first ships an image built from this Dockerfile.
+  - **Publishing runs in CI** (`publish-mcp-registry`, gated on `needs: build-and-push` so the image exists before it is validated). It authenticates with GitHub Actions OIDC, which is what makes the `io.github.sassoftware` namespace reachable at all: the registry grants `io.github.<owner>/*` from the token's `repository_owner` claim, whereas a human publishing by hand would have to be an **Owner** of the organisation. The job rewrites `version` and the image tag from the git tag, so a forgotten bump cannot publish metadata pointing at the previous image.
+  - `.github/mcp-registry.md` — maintainer notes, beside the workflow that implements them — records the shape and the constraints that are not obvious from the published examples — OCI packages must carry the tag in `identifier` and must **not** have `version` or `registryBaseUrl`, `registryType` is `oci` rather than `docker`, and `description` is capped at 100 characters.
+
 ## [1.9.1] - 2026-08-12
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ FROM python:3.12-slim-bookworm AS runner
 ARG HOST_PORT=8134
 
 LABEL maintainer="david.weik@sas.com"
+# Ownership proof for the MCP Registry. It fetches this image anonymously at
+# publish time and refuses the listing unless this label equals `name` in
+# server.json — it is the only thing stopping someone binding their registry
+# entry to an image they do not control. Keep the two in step.
+LABEL io.modelcontextprotocol.server.name="io.github.sassoftware/sas-mcp-server"
 LABEL org.opencontainers.image.source=https://github.com/sassoftware/sas-mcp-server
 LABEL org.opencontainers.image.description="SAS MCP Server — Model Context Protocol server for SAS Viya"
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ If your compute deployment does not expose `/compute/contexts` and only supports
 - **Deploying for a team or on a server?** Use **Docker** — portable, no Python dependency on the host, easy to integrate with orchestrators.
 - **Running it for a whole organisation?** Use **Kubernetes** — a sample manifest and a Helm chart are in [deploy/](/deploy/README.md), including the ingress routing the OAuth flow needs.
 - **Using Gemini CLI?** Use **stdio** — Gemini CLI does not support HTTP mode or browser-based OAuth. See [Gemini CLI configuration](examples/configuration.md#gemini-cli).
+- **Installing from a client's server catalogue?** That path runs the published container in **stdio** mode (`app-stdio`), not as an HTTP server, so it authenticates from your `~/.sas` token cache — which has to be mounted into the container at `/app/.sas`.
 
 ### Limiting exposed tools (tiers)
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sassoftware/sas-mcp-server",
+  "title": "SAS Viya",
+  "description": "Execute SAS code and query Compute, CAS, and model APIs on SAS Viya via OAuth 2.0.",
+  "repository": {
+    "url": "https://github.com/sassoftware/sas-mcp-server",
+    "source": "github"
+  },
+  "version": "1.9.1",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/sassoftware/sas-mcp-server:1.9.1",
+      "runtimeHint": "docker",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "app-stdio"
+        }
+      ],
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-v",
+          "value": "{sas_token_dir}:/app/.sas",
+          "description": "Mount the SAS Viya CLI token cache into the container. The server reads ~/.sas/credentials.json, and $HOME is /app inside the image, so the .sas directory has to land at /app/.sas.",
+          "isRequired": true,
+          "variables": {
+            "sas_token_dir": {
+              "description": "The .sas directory in your home directory, written by `sas-viya auth loginCode`. On Windows, C:\\Users\\<you>\\.sas.",
+              "format": "filepath",
+              "isRequired": true
+            }
+          }
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "VIYA_ENDPOINT",
+          "description": "Base URL of your SAS Viya environment, e.g. https://viya.example.com. No trailing slash.",
+          "format": "string",
+          "isRequired": true
+        },
+        {
+          "name": "SSL_VERIFY",
+          "description": "Set false only for a self-signed Viya certificate. Disables verification for the whole process, so prefer a trusted certificate.",
+          "format": "string",
+          "default": "true"
+        },
+        {
+          "name": "CLIENT_ID",
+          "description": "SASLogon OAuth client id used for the token refresh exchange.",
+          "format": "string",
+          "default": "sas-mcp"
+        },
+        {
+          "name": "COMPUTE_CONTEXT_NAME",
+          "description": "Compute context that backs SAS code execution.",
+          "format": "string",
+          "default": "SAS Job Execution compute context"
+        },
+        {
+          "name": "MCP_TIERS",
+          "description": "Expose only some tool tiers, e.g. 0-4 or 0,1,7. Empty exposes all 75 tools. Tiers: 0 Compute, 1 Data Discovery, 2 Data Operations, 3 Reports, 4 Batch Jobs, 5 AutoML, 6 Models, 7 Decisioning.",
+          "format": "string"
+        },
+        {
+          "name": "MCP_READ_ONLY",
+          "description": "Expose only tools that neither change server-side state nor cause server-side work (43 of 75). Composes with MCP_TIERS.",
+          "format": "string",
+          "default": "false"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Lists the container image on the public [MCP Registry](https://registry.modelcontextprotocol.io) so MCP clients can discover and install this server instead of having to be told about it. Metadata only — the artifact stays on GHCR, nothing new is built or published, and no server behaviour changes.

Purely additive: 276 insertions, 0 deletions, across 6 files.

## What a user gets

```sh
docker run -i --rm \
  -e VIYA_ENDPOINT=https://viya.example.com \
  -v "$HOME/.sas:/app/.sas" \
  ghcr.io/sassoftware/sas-mcp-server:1.9.1 app-stdio
```

The client supplies `docker run -i --rm` and the image reference; the rest comes from `server.json`.

## Why stdio and not HTTP

Local OCI packages are stdio in every published example and in every client that installs them. The HTTP deployment is a different product (`deploy/`) and is not what a registry listing describes.

That needs two things the default container does not do:

- **`app-stdio` overrides `CMD ["app"]`.** The default entry point starts uvicorn, which speaks no stdio — a client would wait forever. `app-stdio` is an existing console script in `pyproject.toml`, not something invented for this.
- **The mount target must be `/app/.sas`.** `$HOME` is `/app` in the image (`adduser --home /app sas`) and stdio mode reads `~/.sas/credentials.json`. Mounting anywhere else silently falls through to the device-code flow.

**Verified against the published `1.9.0` image**, driven through a real MCP client over stdio rather than reasoned about:

```
tools registered: 75
INFO  Loaded access token from /app/.sas/credentials.json
list_compute_contexts -> [{"name":"Data Mining compute context"}, ...]
```

The credentials mount is marked `isRequired: true` deliberately. Without a token cache the server falls back to the RFC 8628 device-code flow, which prints its URL and code to **stderr** — inside a container, with no browser and no TTY, that surfaces only in whatever log pane the client happens to show. Better to state the prerequisite at install time than to ship something that appears to hang.

## Two findings worth a reviewer's attention

**The namespace needs CI, not a person.** `io.github.<org>/*` is granted only to an **Owner** of that GitHub organisation — ordinary membership was deliberately removed as sufficient — so publishing from a maintainer's laptop fails for most of us. Actions OIDC takes a different route: the registry reads the token's `repository_owner` claim and grants `io.github.<owner>/*` based on *where the workflow runs*. A job in this repo gets the namespace with no personal org role and no long-lived token to store. That is why publishing lives in CI rather than in the release checklist.

**The publish job hangs off the image build.** The registry does not take ownership on trust: at publish time it fetches `ghcr.io/sassoftware/sas-mcp-server:<version>` anonymously, reads `Config.Labels`, and rejects the listing unless `io.modelcontextprotocol.server.name` matches `name` in `server.json`. Hence `needs: build-and-push` — a standalone workflow on the same tag would race the build and fail with *"does not exist in the registry"*. Multi-arch is fine; the validator resolves the manifest list before reading the config.

## Constraints the published examples get wrong

The blog post and `mcp-publisher init` both show an npm package, and copying that shape into an OCI entry fails validation:

- `registryType` is **`oci`**, not `docker`
- **no `version` on the package** — the tag goes in `identifier`; a `version` alongside it is rejected outright
- **no `registryBaseUrl`** — same
- **`description` is capped at 100 characters** (`pyproject.toml`'s is 118)

`mcp-publisher validate` passes.

## Files

| File | Change |
|---|---|
| `server.json` | New. The listing. |
| `Dockerfile` | +5. The ownership label and why it must track `server.json`. |
| `.github/workflows/publish-ghcr.yml` | +45. The `publish-mcp-registry` job. |
| `.github/mcp-registry.md` | New. Maintainer notes, beside the workflow that implements them. |
| `README.md` | +1. One line so a user installing from a catalogue knows it runs stdio and needs the token cache mounted. |
| `CHANGELOG.md` | +6. |

## After merging

**Merging publishes nothing.** The registry job is gated `if: startsWith(github.ref, 'refs/tags/v')`, so a push to main only rebuilds `edge` and `sha-` images (which start carrying the label). The first listing goes live on the next release tag — every image up to and including `1.9.1` predates the label, so it cannot be published before then.

The committed `1.9.1` in `server.json` does not need chasing at release time: the job rewrites both `version` and the image tag from the git tag, so a forgotten bump cannot publish metadata pointing at the previous image.

Inclusion in the **GitHub** MCP Registry is a separate request to `partnerships@github.com` after this is live — a maintainers' call, not automated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
