### PR TITLE
feat: cap server-side upload sources at MAX_UPLOAD_BYTES (default 100 MiB)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -36,6 +36,20 @@ MCP_READ_ONLY=false
 # Set to false to disable SSL verification (e.g. for self-signed Viya certificates)
 SSL_VERIFY=true
 
+# Upper bound in bytes for the server-side upload sources (upload_data /
+# upload_file with file_path or url). The whole source is buffered in server
+# memory while it is re-posted to Viya, so this cap is what keeps one oversized
+# fetch from exhausting the process. Default 104857600 (100 MiB) matches SAS
+# Viya's default file-upload limit — if your administrator raises the Viya-side
+# limit, raise this with it (see deploy/SCALING.md before doing so).
+MAX_UPLOAD_BYTES=104857600
+
+# Upper bound in bytes for binary report exports returned inline by
+# export_report (default 26214400 = 25 MiB). Larger exports are refused with
+# guidance. Base64 + JSON framing roughly doubles the transient memory cost of
+# an export — size the container memory limit accordingly (deploy/SCALING.md).
+MAX_EXPORT_INLINE_BYTES=26214400
+
 # Set to true to accept raw upstream Viya JWTs in the Authorization header
 # alongside the default OAuth2 PKCE flow. When enabled, a bearer token that
 # fails the MCP JWT swap is validated against Viya's JWKS and used as-is.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **The server-side upload sources are no longer unbounded — `MAX_UPLOAD_BYTES`, default 100 MiB.** `upload_data` and `upload_file` with `file_path`/`url` buffer the entire source in process memory while it is re-posted to Viya, and the `url` source had no cap at all: one multi-GB fetch was an OOM kill in a single call — and an OOM kill is SIGKILL, so the lifespan never runs and every warm compute session leaks until Viya reaps it (this bit a real deployment). Both sources now refuse anything over `MAX_UPLOAD_BYTES` with a structured `source_too_large` error. The default matches SAS Viya's own 100 MB file-upload limit, on the logic that a bigger payload would be refused upstream anyway, so buffering it locally only spends memory on a guaranteed failure; administrators who raise the Viya-side limit raise the env var with it. The `url` source is refused up front on a declared `Content-Length` and the cap is enforced again while the body streams in, so an absent or lying header cannot blow past it. `deploy/SCALING.md` gains a section naming the three buffer-heavy tools (`export_report`, the `upload_data`/`upload_file` sources, `download_file`) and the bound on each; `MAX_UPLOAD_BYTES` and `MAX_EXPORT_INLINE_BYTES` are now documented in `.env.sample` and `examples/configuration.md`.
+
+### Fixed
+- **`deploy/K8S-DEPLOYMENT.md`'s inline manifest snippet now shows the 1Gi memory limit** the shipped manifest and Helm chart already default to. The stale `512Mi` in the snippet was exactly the limit a single large `export_report` can transiently exceed (see SCALING.md), and a deployment copied from the doc — rather than from `deploy/k8s/` or the chart — inherited the OOM-prone value.
+
 ## [1.9.2] - 2026-08-12
 
 ### Fixed

--- a/deploy/K8S-DEPLOYMENT.md
+++ b/deploy/K8S-DEPLOYMENT.md
@@ -289,7 +289,7 @@ spec:
             httpGet: { path: /health, port: 8134 }
           resources:
             requests: { cpu: 100m, memory: 256Mi }
-            limits:   { memory: 512Mi }
+            limits:   { memory: 1Gi }   # headroom for transient result buffers, see SCALING.md
       volumes:
         - name: fastmcp-state
           emptyDir: {}                # PVC instead, to survive restarts

--- a/deploy/SCALING.md
+++ b/deploy/SCALING.md
@@ -160,8 +160,41 @@ helm upgrade sas-mcp deploy/helm/sas-mcp-server -n sas-mcp --reuse-values \
 ```
 
 Lower `MAX_EXPORT_INLINE_BYTES` instead (or as well) if inline exports are not
-needed. `query_data` is bounded at 10,000 rows and `execute_sas_code` logs are
-paged, so exports are the outlier.
+needed.
+
+---
+
+## The three tools that buffer big payloads
+
+The "transient result buffers" term above is not abstract — it is three
+specific tools, and they are the only ones worth briefing users on. Everything
+else is bounded small: `query_data` caps at 10,000 rows, `get_castable_data`
+defaults to 100, and `execute_sas_code` logs are paged.
+
+| Tool | What is buffered in the pod | Bound |
+|---|---|---|
+| `export_report` | the whole binary export, then base64 (×1.33) plus JSON framing on top | `MAX_EXPORT_INLINE_BYTES`, default 25 MiB — the worst amplifier |
+| `upload_data` / `upload_file` (`file_path`/`url` sources) | the whole source file, held while it is re-posted to Viya | `MAX_UPLOAD_BYTES`, default 100 MiB |
+| `download_file` | the whole Files-service file | no code-side cap, but bounded in practice by Viya's own file-upload limit — everything in the Files service arrived under it |
+
+**`MAX_UPLOAD_BYTES` defaults to 100 MiB to match SAS Viya's default 100 MB
+file-upload limit**: a payload over the Viya cap would be refused upstream
+anyway, so buffering it in the pod would spend memory on a guaranteed failure.
+(Before this cap the `url` source was unbounded — one multi-GB fetch was an
+OOM kill in a single call.) The `url` source is refused up front on a declared
+`Content-Length`, and the cap is enforced again while the body streams in, so
+an absent or lying header cannot blow past it. **If your Viya administrator
+raises the Viya-side limit, raise `MAX_UPLOAD_BYTES` with it — and revisit the
+pod memory limit at the same time**, since a single upload can transiently
+hold roughly twice the payload size (the buffer plus the multipart body being
+posted).
+
+Practical guidance for teams sharing a deployment: route bulk data movement
+through SAS itself (`execute_sas_code`, path-based caslibs +
+`promote_table_to_memory`) rather than through the MCP response path, and keep
+inline report exports small or disabled. A deployment that does not need the
+file tools at all can drop them wholesale with `MCP_TIERS` (tier 2) — tools
+that are not registered cannot OOM anything.
 
 ---
 

--- a/examples/configuration.md
+++ b/examples/configuration.md
@@ -118,6 +118,8 @@ The .env file used by the MCP Server allows for customizable options that the us
 | `ALLOW_RAW_BEARER` | No | `false` | When `true`, the HTTP-mode server also accepts a raw Viya access token in the `Authorization` header alongside the default OAuth2 PKCE flow. Useful for automation that already holds a Viya token. |
 | `VIYA_AUTH` | No | `true` | Master auth toggle. Set to `false` to disable SASLogon/OAuth handling (HTTP and stdio) and send Viya API calls without an `Authorization` header. |
 | `COMPUTE_SESSION_ID` | No | — | Fixed compute session id (for deployments without `/compute/contexts`). When set (e.g. `0001`), compute tools use that session directly. |
+| `MAX_UPLOAD_BYTES` | No | `104857600` (100 MiB) | Upper bound for the server-side upload sources (`upload_data`/`upload_file` with `file_path` or `url`). The default matches SAS Viya's 100 MB file-upload limit — if your administrator raises the Viya-side limit, raise this with it (see [deploy/SCALING.md](../deploy/SCALING.md)). |
+| `MAX_EXPORT_INLINE_BYTES` | No | `26214400` (25 MiB) | Upper bound for binary report exports returned inline by `export_report`; larger exports are refused with guidance. |
 | `SAS_CLI_CONFIG` | Stdio (optional) | `$HOME` | Parent directory for the SAS Viya CLI credential cache. The token is read from `$SAS_CLI_CONFIG/.sas/credentials.json`. |
 | `VIYA_USERNAME` | Tests only | — | Used by the integration test suite to acquire a token via the legacy `sas.cli` password grant. Not used by the MCP server itself. |
 | `VIYA_PASSWORD` | Tests only | — | See `VIYA_USERNAME`. |

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -109,6 +109,16 @@ MCP_BASE_URL = _mcp_base_url if _mcp_base_url and not _mcp_base_url.startswith("
 # streamed through the model context (default 25 MiB).
 MAX_EXPORT_INLINE_BYTES = int(os.getenv("MAX_EXPORT_INLINE_BYTES", str(25 * 1024 * 1024)))
 
+# Upper bound on bytes accepted from the server-side upload sources
+# (``upload_data`` / ``upload_file`` with ``file_path`` or ``url``). The whole
+# source is buffered in memory while it is re-posted to Viya, so without a cap
+# one oversized URL fetch can OOM-kill the process. Default 100 MiB — SAS
+# Viya's own default file-upload limit — because a bigger payload would be
+# refused upstream anyway; if your Viya administrator raises the Viya-side
+# limit, raise this with it (and revisit the pod memory limit, see
+# deploy/SCALING.md).
+MAX_UPLOAD_BYTES = int(os.getenv("MAX_UPLOAD_BYTES", str(100 * 1024 * 1024)))
+
 if not VIYA_ENDPOINT:
     raise ConfigError(
         "VIYA_ENDPOINT is not set. Please set it in the environment variables."

--- a/src/sas_mcp_server/tools/data_ops.py
+++ b/src/sas_mcp_server/tools/data_ops.py
@@ -12,7 +12,7 @@ from typing import Any
 import httpx
 from fastmcp import Context, FastMCP
 
-from ..config import SSL_VERIFY, VIYA_ENDPOINT
+from ..config import MAX_UPLOAD_BYTES, SSL_VERIFY, VIYA_ENDPOINT
 from ..env import env_bool
 from ..viya_client import (
     contains_filter,
@@ -141,12 +141,34 @@ def _resolve_data_format(
     return fmt, None
 
 
+def _source_too_large(source: str, size_bytes: int | None) -> dict[str, Any]:
+    """Structured refusal for an upload source over ``MAX_UPLOAD_BYTES``."""
+    error: dict[str, Any] = {
+        "status": "source_too_large",
+        "source": source,
+        "limit_bytes": MAX_UPLOAD_BYTES,
+        "message": (
+            f"The {source} source exceeds the {MAX_UPLOAD_BYTES:,}-byte upload "
+            "limit (MAX_UPLOAD_BYTES; the default matches SAS Viya's 100 MB "
+            "file-upload cap, so a larger payload would be refused upstream "
+            "anyway). For large data, load it via a path-based caslib and "
+            "promote_table_to_memory, or ask the administrator to raise both limits."
+        ),
+    }
+    if size_bytes is not None:
+        error["size_bytes"] = size_bytes
+    return error
+
+
 async def _resolve_source_bytes(file_path: str | None, url: str | None) -> tuple[bytes | None, dict[str, Any] | None]:
     """Materialize the upload bytes server-side from ``file_path`` or ``url``.
 
     Assumes exactly one of the two is set (the caller's exactly-one-source
     guard). The bytes are read off the server's disk or fetched over HTTP, never
-    routed through the model context. Returns ``(bytes, None)`` or ``(None, error)``.
+    routed through the model context. Either source is refused past
+    ``MAX_UPLOAD_BYTES`` — the payload is held in memory in full while it is
+    re-posted to Viya, so the cap is what keeps one oversized source from
+    exhausting the process. Returns ``(bytes, None)`` or ``(None, error)``.
     """
     if file_path:
         if not env_bool("ALLOW_LOCAL_FILE_UPLOAD", True):
@@ -168,6 +190,9 @@ async def _resolve_source_bytes(file_path: str | None, url: str | None) -> tuple
                 ),
             }
         try:
+            size = path.stat().st_size
+            if size > MAX_UPLOAD_BYTES:
+                return None, _source_too_large("file_path", size)
             return path.read_bytes(), None
         except OSError as exc:
             return None, {
@@ -179,12 +204,23 @@ async def _resolve_source_bytes(file_path: str | None, url: str | None) -> tuple
     assert url is not None
     try:
         async with httpx.AsyncClient(timeout=120.0, follow_redirects=True, verify=SSL_VERIFY) as fetch_client:
-            fetch_resp = await fetch_client.get(url)
-            # Plain raise_for_status on purpose: this is an arbitrary caller-supplied
-            # URL, not Viya, so there is no vnd.sas.error+json body worth quoting
-            # and folding a third-party page into the message adds only noise.
-            fetch_resp.raise_for_status()
-            return fetch_resp.content, None
+            async with fetch_client.stream("GET", url) as fetch_resp:
+                # Plain raise_for_status on purpose: this is an arbitrary caller-supplied
+                # URL, not Viya, so there is no vnd.sas.error+json body worth quoting
+                # and folding a third-party page into the message adds only noise.
+                fetch_resp.raise_for_status()
+                # Refuse on the declared size when there is one, but never trust
+                # it: the cap is enforced again while the body streams in, so an
+                # absent or lying Content-Length cannot blow past the limit.
+                declared = fetch_resp.headers.get("Content-Length")
+                if declared and declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES:
+                    return None, _source_too_large("url", int(declared))
+                buf = bytearray()
+                async for chunk in fetch_resp.aiter_bytes():
+                    buf += chunk
+                    if len(buf) > MAX_UPLOAD_BYTES:
+                        return None, _source_too_large("url", None)
+                return bytes(buf), None
     except httpx.HTTPError as exc:
         return None, {"status": "fetch_failed", "url": url, "message": str(exc)}
 
@@ -279,8 +315,10 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
         * ``url`` — the server fetches it over HTTP.
 
         Either way the bytes are read server-side and never pass through the calling
-        model's context window. To create a *small* table you are building inline (no
-        file or URL), use the ``upload_inline_data`` tool instead.
+        model's context window. Sources larger than ``MAX_UPLOAD_BYTES`` (default
+        100 MiB — SAS Viya's own default file-upload limit) are refused. To create a
+        *small* table you are building inline (no file or URL), use the
+        ``upload_inline_data`` tool instead.
 
         The casManagement uploadTable endpoint only accepts an uploaded file (multipart
         form-data) and has no URL parameter, so ``url`` is fetched and sent on as the
@@ -482,6 +520,9 @@ def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> No
           (in stdio mode that's your machine). Handles binary files (xlsx, zip,
           images) untouched. Disable with ``ALLOW_LOCAL_FILE_UPLOAD=false``.
         - ``url`` — an HTTP(S) URL the server fetches the file from. Also binary-safe.
+
+        ``file_path`` and ``url`` sources larger than ``MAX_UPLOAD_BYTES`` (default
+        100 MiB — SAS Viya's own default file-upload limit) are refused.
 
         ``parent_folder_uri`` files the upload into a Content folder (e.g.
         ``/folders/folders/{folderId}``) — the location ``%include``/``filesrvc``

--- a/tests/test_tool_payloads.py
+++ b/tests/test_tool_payloads.py
@@ -2339,6 +2339,126 @@ async def test_upload_data_from_file_path(mcp_server_with_mock_client, tmp_path)
     assert result.data["rows_uploaded"] == 2
 
 
+async def test_upload_data_file_path_over_limit(mcp_server_with_mock_client, tmp_path, monkeypatch):
+    """A file over MAX_UPLOAD_BYTES is refused before any read or Viya call."""
+    from sas_mcp_server.tools import data_ops
+
+    mcp, mock_client = mcp_server_with_mock_client
+    monkeypatch.setattr(data_ops, "MAX_UPLOAD_BYTES", 16)
+    big = tmp_path / "big.csv"
+    big.write_bytes(b"a,b\n" + b"1,2\n" * 10)  # 44 bytes > 16
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "upload_data",
+            {
+                "server_id": "cas1",
+                "caslib_name": "Public",
+                "table_name": "T",
+                "file_path": str(big),
+            },
+        )
+    assert result.data["status"] == "source_too_large"
+    assert result.data["source"] == "file_path"
+    assert result.data["limit_bytes"] == 16
+    assert result.data["size_bytes"] == 44
+    mock_client.post.assert_not_called()
+
+
+async def test_upload_data_url_over_limit_by_content_length(mcp_server_with_mock_client, monkeypatch):
+    """A URL whose declared Content-Length exceeds the cap is refused up front."""
+    from sas_mcp_server.tools import data_ops
+
+    mcp, mock_client = mcp_server_with_mock_client
+    monkeypatch.setattr(data_ops, "MAX_UPLOAD_BYTES", 16)
+    real_client = httpx.AsyncClient
+
+    def handler(request):
+        return httpx.Response(200, content=b"x" * 32)  # Content-Length: 32
+
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda **kw: real_client(transport=httpx.MockTransport(handler))
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "upload_data",
+            {
+                "server_id": "cas1",
+                "caslib_name": "Public",
+                "table_name": "T",
+                "url": "https://example.com/big.csv",
+            },
+        )
+    assert result.data["status"] == "source_too_large"
+    assert result.data["source"] == "url"
+    assert result.data["size_bytes"] == 32
+    mock_client.post.assert_not_called()
+
+
+async def test_upload_data_url_over_limit_while_streaming(mcp_server_with_mock_client, monkeypatch):
+    """Without a Content-Length, the cap is still enforced as the body streams in."""
+    from sas_mcp_server.tools import data_ops
+
+    mcp, mock_client = mcp_server_with_mock_client
+    monkeypatch.setattr(data_ops, "MAX_UPLOAD_BYTES", 16)
+    real_client = httpx.AsyncClient
+
+    async def chunks():
+        for _ in range(5):  # 40 bytes total, no Content-Length header
+            yield b"xxxxxxxx"
+
+    def handler(request):
+        return httpx.Response(200, content=chunks())
+
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda **kw: real_client(transport=httpx.MockTransport(handler))
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "upload_data",
+            {
+                "server_id": "cas1",
+                "caslib_name": "Public",
+                "table_name": "T",
+                "url": "https://example.com/stream.csv",
+            },
+        )
+    assert result.data["status"] == "source_too_large"
+    assert result.data["source"] == "url"
+    assert "size_bytes" not in result.data  # size unknown when the header is absent
+    mock_client.post.assert_not_called()
+
+
+async def test_upload_data_from_url_under_limit(mcp_server_with_mock_client, monkeypatch):
+    """The url source streams the file and forwards the exact bytes to CAS."""
+    mcp, mock_client = mcp_server_with_mock_client
+    mock_client.post.return_value = _make_mock_response(
+        {"name": "T", "rowCount": 2, "columnCount": 2, "caslibName": "Public", "scope": "global"},
+        status_code=200,
+    )
+    real_client = httpx.AsyncClient
+
+    def handler(request):
+        return httpx.Response(200, content=b"a,b\n1,2\n3,4")
+
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda **kw: real_client(transport=httpx.MockTransport(handler))
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "upload_data",
+            {
+                "server_id": "cas1",
+                "caslib_name": "Public",
+                "table_name": "T",
+                "url": "https://example.com/data.csv",
+            },
+        )
+    kwargs = mock_client.post.call_args[1]
+    assert kwargs["files"]["file"][1] == b"a,b\n1,2\n3,4"
+    assert result.data["status"] == "success"
+    assert result.data["source"] == "url"
+
+
 async def test_upload_data_file_path_not_found(mcp_server_with_mock_client):
     """A missing file returns a structured error and never calls Viya."""
     mcp, mock_client = mcp_server_with_mock_client


### PR DESCRIPTION
## Motivation

A field deployment had its pod OOM-killed this week (512Mi limit). Investigating which requests can actually do that surfaced one unbounded path: `upload_data` / `upload_file` with a `url` (or `file_path`) source buffer the **entire** source in process memory while re-posting it to Viya — a multi-GB URL was an OOM kill in a single tool call. And an OOM kill is SIGKILL: the lifespan never runs, so every warm compute session leaks until Viya reaps it.

## What changed

- **`MAX_UPLOAD_BYTES`** (new env var, default **100 MiB**) caps both server-side upload sources in the shared `_resolve_source_bytes` chokepoint, returning a structured `source_too_large` error with the limit and guidance (path-based caslib + `promote_table_to_memory` for big data).
  - The default matches SAS Viya's own default 100 MB file-upload limit: a bigger payload would be refused upstream anyway, so buffering it locally only spends memory on a guaranteed failure. Admins who raise the Viya-side limit raise this with it.
  - The `url` source is refused up front on a declared `Content-Length`, and the fetch now **streams** with the cap enforced per chunk — an absent or lying header cannot blow past it.
  - `file_path` is checked via `stat()` before any read.
- **`deploy/SCALING.md`** gains a section naming the three buffer-heavy tools and the bound on each: `export_report` (`MAX_EXPORT_INLINE_BYTES`, 25 MiB, the worst amplifier at base64 ×1.33 + JSON framing), the upload sources (`MAX_UPLOAD_BYTES`), and `download_file` (bounded in practice by Viya's own files-service cap). Includes team guidance: bulk data movement belongs in SAS itself, not the MCP response path, and tier 2 can be dropped entirely via `MCP_TIERS` where file tools aren't needed.
- **`deploy/K8S-DEPLOYMENT.md`'s inline manifest snippet now shows the 1Gi memory limit** the shipped manifest and Helm chart already default to — the stale `512Mi` in the doc was exactly the OOM-prone value, and deployments copied from the snippet inherited it.
- `MAX_UPLOAD_BYTES` and the previously undocumented `MAX_EXPORT_INLINE_BYTES` are now listed in `.env.sample` and `examples/configuration.md`.

## Verification

- New unit tests: `file_path` over-limit (refused before read, no Viya call), `url` over-limit via `Content-Length` (refused before download), `url` over-limit **mid-stream with no `Content-Length`** (chunked async body), and a `url` happy path asserting the exact bytes forwarded to CAS.
- Full unit suite: **597 passed**, coverage 92.7% (gate: 90%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
