### PR TITLE
style: fix the ruff SIM117 failure on main (follow-up to #44)

### DIFF
--- a/src/sas_mcp_server/tools/data_ops.py
+++ b/src/sas_mcp_server/tools/data_ops.py
@@ -203,24 +203,26 @@ async def _resolve_source_bytes(file_path: str | None, url: str | None) -> tuple
     # url — fetch with a plain client (no Viya bearer on an external URL).
     assert url is not None
     try:
-        async with httpx.AsyncClient(timeout=120.0, follow_redirects=True, verify=SSL_VERIFY) as fetch_client:
-            async with fetch_client.stream("GET", url) as fetch_resp:
-                # Plain raise_for_status on purpose: this is an arbitrary caller-supplied
-                # URL, not Viya, so there is no vnd.sas.error+json body worth quoting
-                # and folding a third-party page into the message adds only noise.
-                fetch_resp.raise_for_status()
-                # Refuse on the declared size when there is one, but never trust
-                # it: the cap is enforced again while the body streams in, so an
-                # absent or lying Content-Length cannot blow past the limit.
-                declared = fetch_resp.headers.get("Content-Length")
-                if declared and declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES:
-                    return None, _source_too_large("url", int(declared))
-                buf = bytearray()
-                async for chunk in fetch_resp.aiter_bytes():
-                    buf += chunk
-                    if len(buf) > MAX_UPLOAD_BYTES:
-                        return None, _source_too_large("url", None)
-                return bytes(buf), None
+        async with (
+            httpx.AsyncClient(timeout=120.0, follow_redirects=True, verify=SSL_VERIFY) as fetch_client,
+            fetch_client.stream("GET", url) as fetch_resp,
+        ):
+            # Plain raise_for_status on purpose: this is an arbitrary caller-supplied
+            # URL, not Viya, so there is no vnd.sas.error+json body worth quoting
+            # and folding a third-party page into the message adds only noise.
+            fetch_resp.raise_for_status()
+            # Refuse on the declared size when there is one, but never trust
+            # it: the cap is enforced again while the body streams in, so an
+            # absent or lying Content-Length cannot blow past the limit.
+            declared = fetch_resp.headers.get("Content-Length")
+            if declared and declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES:
+                return None, _source_too_large("url", int(declared))
+            buf = bytearray()
+            async for chunk in fetch_resp.aiter_bytes():
+                buf += chunk
+                if len(buf) > MAX_UPLOAD_BYTES:
+                    return None, _source_too_large("url", None)
+            return bytes(buf), None
     except httpx.HTTPError as exc:
         return None, {"status": "fetch_failed", "url": url, "message": str(exc)}
 


### PR DESCRIPTION
PR #44 was merged while its lint fix was still in flight: the follow-up commit landed on the branch after the merge, so it never reached main and never got a CI run (pushes to a merged PR's branch trigger nothing). Since then, main's CI fails on exactly one finding - ruff SIM117, nested sync with in the URL upload path introduced by #44.

This cherry-picks that one commit: the two nested sync with statements are combined into a single parenthesized one. Pure style, no behavior change; ruff and the full unit suite pass locally (597 tests).

Given the merged feature is functionally sound (all tests green, only lint red), this follow-up is the minimal repair - the auto-created \evert-44-feat/max-upload-bytes\ branch can be deleted rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)