### PR TITLE
feat: advertise MCP tool annotations (readOnlyHint / destructiveHint / idempotentHint / openWorldHint) on every tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Every tool now advertises MCP tool annotations** (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` — spec revision 2025-03-26). Until now the server shipped none, which under the spec's defaults presents every one of the 75 tools to clients as writable, destructive and open-world — `list_caslibs` included — so clients such as Claude filed them all in a flat "other tools" bucket with per-tool approval. `readOnlyHint` is derived from the *same* `READ_ONLY_TOOLS` table that `MCP_READ_ONLY` enforces (43 tools), so what a client is told and what the server enforces cannot drift; `destructiveHint` (15 tools: arbitrary code, deletes, cancel/reset, the `update_*` PUTs, report operations, `create_report`/`copy_report` with their `replace` policy, model publish), `idempotentHint` and `openWorldHint` (arbitrary code and the upload tools' `url` source only) come from three small sets beside it in `tools/_access.py`, each a documented judgement. Injected at registration by the existing `_TierRecorder` wrapper — tier modules are untouched, and a tier that passes its own `annotations=` keeps them — with a fail-closed fallback to the pessimistic defaults for an unclassified tool and a test that no registered tool takes that path. Read-only tools can now be bulk-approved and destructive ones warned about in clients that honour the hints; nothing changes about what a client can reach, and the hints are advisory by spec. The browser landing page marks each tool `read-only` / `write` / `destructive` from the same annotations, with a legend.
+
 ## [1.10.0] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ The definition is strict: a tool qualifies only if it can neither write nor star
 
 Classification is fail-closed: a tool that is not explicitly classified as read-only is withheld. The list lives in [`src/sas_mcp_server/tools/_access.py`](src/sas_mcp_server/tools/_access.py), and a test asserts it covers every registered tool, so a newly added tool cannot silently land in read-only mode.
 
+### Tool annotations (what clients are told)
+
+The same classification is **advertised** to every client as [MCP tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#tool-annotations) on each `tools/list` entry — whether or not read-only mode is on:
+
+| Hint | Derived from |
+|---|---|
+| `readOnlyHint` | exactly the read-only set above — one table, so what a client is told and what `MCP_READ_ONLY` enforces cannot drift |
+| `destructiveHint` | tools that can remove or overwrite existing state: arbitrary code (`execute_sas_code`, `submit_batch_job`), `delete_*`, `cancel_job`, `reset_compute_session`, the `update_*` PUTs, `apply_report_operations`, `create_report`/`copy_report` (their `replace` conflict policy), `publish_ml_champion_model` |
+| `idempotentHint` | reads, the `update_*` PUTs, deletes, `cancel_job`, `reset_compute_session`, `promote_table_to_memory` |
+| `openWorldHint` | only tools that can reach beyond Viya: arbitrary code and the upload tools' `url` source |
+
+Clients use these to shape their approval UX — e.g. Claude groups read-only tools for one-click approval and warns before destructive ones — and to decide when to interrupt the user. They are hints, not enforcement: the spec tells clients to treat them as untrusted unless the server is trusted, and `MCP_READ_ONLY` remains the server-side control. Without annotations a client must assume the spec's pessimistic defaults (writable, destructive, open-world) for every tool, so this only ever reduces friction. The browser landing page marks each tool `read-only` / `write` / `destructive` from the same hints.
+
 ### Available Tools
 
 The headings below match the numbered **tiers** above, so `MCP_TIERS` maps directly to the tools you expose (e.g. `MCP_TIERS=0-3` gives Tiers 0–3).

--- a/src/sas_mcp_server/landing.py
+++ b/src/sas_mcp_server/landing.py
@@ -79,6 +79,19 @@ PAGE_TITLE = "SAS Viya MCP Server"
 class ToolEntry:
     name: str
     summary: str
+    # From the tool's MCP annotations (readOnlyHint / destructiveHint); None
+    # when the tool carries none, so the page never invents a classification.
+    read_only: bool | None = None
+    destructive: bool | None = None
+
+    @property
+    def kind(self) -> str:
+        """``"read-only"``, ``"destructive"``, ``"write"`` or ``""`` (unknown)."""
+        if self.read_only:
+            return "read-only"
+        if self.read_only is None and self.destructive is None:
+            return ""
+        return "destructive" if self.destructive else "write"
 
 
 @dataclass(frozen=True)
@@ -193,7 +206,15 @@ async def collect_facts(
 
     by_tier: dict[int | None, list[ToolEntry]] = {}
     for t in tools:
-        by_tier.setdefault(TOOL_TIERS.get(t.name), []).append(ToolEntry(name=t.name, summary=summarize(t.description)))
+        ann = getattr(t, "annotations", None)
+        by_tier.setdefault(TOOL_TIERS.get(t.name), []).append(
+            ToolEntry(
+                name=t.name,
+                summary=summarize(t.description),
+                read_only=getattr(ann, "readOnlyHint", None),
+                destructive=getattr(ann, "destructiveHint", None),
+            )
+        )
     groups: list[TierGroup] = []
     for tier in sorted(k for k in by_tier if k is not None):
         groups.append(
@@ -385,11 +406,24 @@ details summary .count { color: var(--muted); font-weight: 400; font-size: 0.9re
 details .tools { margin: 0; padding: 0 16px 12px; list-style: none; }
 details .tools li {
   padding: 6px 0; border-top: 1px solid var(--line);
-  display: grid; grid-template-columns: minmax(180px, 34%) 1fr; gap: 12px;
+  display: grid; grid-template-columns: minmax(180px, 32%) 6.5em 1fr; gap: 12px; align-items: baseline;
 }
 details .tools li code { background: none; padding: 0; }
 details .tools li span { color: var(--muted); font-size: 0.95rem; }
-@media (max-width: 600px) { details .tools li { grid-template-columns: 1fr; gap: 2px; } }
+details .tools li .kind {
+  font-style: normal; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em;
+  color: var(--muted); white-space: nowrap;
+}
+details .tools li .kind.read-only { color: var(--ok); }
+details .tools li .kind.destructive { color: var(--warn); }
+.legend { color: var(--muted); font-size: 0.9rem; margin: 6px 0 12px; }
+.legend .kind { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; font-style: normal; }
+.legend .kind.read-only { color: var(--ok); }
+.legend .kind.destructive { color: var(--warn); }
+@media (max-width: 600px) {
+  details .tools li { grid-template-columns: 1fr auto; gap: 2px 8px; }
+  details .tools li span { grid-column: 1 / -1; }
+}
 .steps { padding-left: 20px; }
 .steps li { margin: 6px 0; }
 footer {
@@ -441,7 +475,10 @@ def _render_snippet(s: ClientSnippet) -> str:
 
 def _render_tier(g: TierGroup, *, open_: bool) -> str:
     label = f"Tier {g.tier} — {g.title}" if g.tier is not None else g.title
-    items = "".join(f"<li><code>{_e(t.name)}</code><span>{_e(t.summary)}</span></li>" for t in g.tools)
+    items = "".join(
+        f'<li><code>{_e(t.name)}</code><em class="kind {_e(t.kind)}">{_e(t.kind)}</em><span>{_e(t.summary)}</span></li>'
+        for t in g.tools
+    )
     n = len(g.tools)
     return (
         f"<details{' open' if open_ else ''}>"
@@ -514,6 +551,16 @@ def render_page(facts: ServerFacts, *, nonce: str) -> str:
 
     snippets = "".join(_render_snippet(s) for s in client_snippets(facts.mcp_url))
     tier_html = "".join(_render_tier(g, open_=(i == 0)) for i, g in enumerate(facts.tiers))
+    kinds = {t.kind for g in facts.tiers for t in g.tools}
+    legend = (
+        '<p class="legend">Each tool advertises its behaviour to your client as MCP tool annotations — '
+        '<em class="kind read-only">read-only</em> tools only read; '
+        '<em class="kind write">write</em> tools add or start something; '
+        '<em class="kind destructive">destructive</em> tools can change or remove what already exists. '
+        "Clients use these to group tools and to decide when to ask you before running one.</p>"
+        if kinds - {""}
+        else ""
+    )
     prompt_items = "".join(f"<li><code>{_e(p.name)}</code><span>{_e(p.summary)}</span></li>" for p in facts.prompts)
     prompts_html = (
         f'<details><summary>Prompt templates<span class="count">{len(facts.prompts)}</span></summary>'
@@ -571,6 +618,7 @@ def render_page(facts: ServerFacts, *, nonce: str) -> str:
 
 <h2>What it can do</h2>
 {scope_para}
+{legend}
 {tier_html}
 {prompts_html}
 

--- a/src/sas_mcp_server/tools/__init__.py
+++ b/src/sas_mcp_server/tools/__init__.py
@@ -39,7 +39,15 @@ from . import (
     reports,
     workbench,
 )
-from ._access import READ_ONLY_TOOLS, WRITE_TOOLS, ReadOnlyGate
+from ._access import (
+    DESTRUCTIVE_TOOLS,
+    IDEMPOTENT_WRITE_TOOLS,
+    OPEN_WORLD_TOOLS,
+    READ_ONLY_TOOLS,
+    WRITE_TOOLS,
+    ReadOnlyGate,
+    annotations_for,
+)
 
 Registrar = Callable[[FastMCP, Callable[[Context], Awaitable[str]]], None]
 
@@ -76,25 +84,36 @@ TOOL_TIERS: dict[str, int] = {}
 
 
 class _TierRecorder:
-    """FastMCP stand-in that records which tier registered each tool.
+    """FastMCP stand-in that records which tier registered each tool and
+    stamps the tool's MCP annotations.
 
     Mirrors :class:`ReadOnlyGate`'s duck-typing so the tier modules stay
     unmodified, and composes with it (it wraps whichever target is in play).
-    Recording is a side effect only — every call is forwarded untouched.
+    Two things happen on the way through, neither visible to the tier:
+
+    * ``TOOL_TIERS[name] = tier`` — a side effect for telemetry and the landing
+      page.
+    * ``annotations=`` is filled in from :func:`annotations_for` (the central
+      read/write classification) unless the tier passed its own, so every tool
+      advertises ``readOnlyHint`` & co. to clients without any per-tool code.
     """
 
     def __init__(self, target: Any, tier: int) -> None:
         self._target = target
         self._tier = tier
 
+    def _record(self, name: str, kwargs: dict[str, Any]) -> None:
+        TOOL_TIERS[name] = self._tier
+        kwargs.setdefault("annotations", annotations_for(name))
+
     def tool(self, name_or_fn: Any = None, **kwargs: Any) -> Any:
         if callable(name_or_fn):  # bare @mcp.tool
-            TOOL_TIERS[kwargs.get("name") or name_or_fn.__name__] = self._tier
+            self._record(kwargs.get("name") or name_or_fn.__name__, kwargs)
             return self._target.tool(name_or_fn, **kwargs)
 
         def decorator(fn: Callable[..., Any]) -> Any:
             explicit = name_or_fn if isinstance(name_or_fn, str) else kwargs.get("name")
-            TOOL_TIERS[explicit or fn.__name__] = self._tier
+            self._record(explicit or fn.__name__, kwargs)
             return self._target.tool(name_or_fn, **kwargs)(fn)
 
         return decorator
@@ -191,9 +210,14 @@ def register_tools(
 
 __all__ = [
     "ALL_TIERS",
+    "DESTRUCTIVE_TOOLS",
+    "IDEMPOTENT_WRITE_TOOLS",
+    "OPEN_WORLD_TOOLS",
     "READ_ONLY_TOOLS",
     "TIER_TITLES",
+    "TOOL_TIERS",
     "WRITE_TOOLS",
+    "annotations_for",
     "register_tools",
     "resolve_enabled_tiers",
 ]

--- a/src/sas_mcp_server/tools/_access.py
+++ b/src/sas_mcp_server/tools/_access.py
@@ -25,12 +25,25 @@ jobs and leave run records; ``promote_table_to_memory`` mutates CAS state;
 both sets — a newly added one, say — is withheld in read-only mode rather than
 silently exposed. ``test_read_only.py`` asserts the two sets exactly partition
 the registered surface, so adding a tool without classifying it fails CI.
+
+**Advertised as well as enforced.** The same partition is published to clients
+as MCP *tool annotations* (spec revision 2025-03-26, "Tool annotations"):
+``readOnlyHint`` is derived from :data:`READ_ONLY_TOOLS` — one table, one
+truth — and the finer ``destructiveHint`` / ``idempotentHint`` /
+``openWorldHint`` come from the small sets below. Annotations are hints for the
+*client's* approval UX (group read-only tools, warn before destructive ones),
+not enforcement; ``MCP_READ_ONLY`` remains the enforcement, and the spec tells
+clients to treat hints as untrusted unless the server is trusted. Without them
+a client must assume the pessimistic defaults — writable, destructive,
+open-world — for every tool, ``list_caslibs`` included. See
+:func:`annotations_for`.
 """
 
 from collections.abc import Callable
 from typing import Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 # --- classification ----------------------------------------------------------
 # Grouped by tier, matching src/sas_mcp_server/tools/<module>.py.
@@ -147,6 +160,98 @@ WRITE_TOOLS: frozenset[str] = frozenset(
 )
 
 
+# --- behaviour hints (MCP tool annotations) ----------------------------------
+# All three sets are subsets of WRITE_TOOLS (asserted in tests); a read-only
+# tool is by definition non-destructive, idempotent and — here — closed-world.
+
+# May remove or overwrite state that exists before the call. The spec's
+# contrast is "destructive updates" vs "only additive updates", so an update
+# that replaces an object's content counts, as does a create with a
+# name-conflict policy that can overwrite. Arbitrary code can do anything.
+DESTRUCTIVE_TOOLS: frozenset[str] = frozenset(
+    {
+        "execute_sas_code",  # arbitrary code
+        "submit_batch_job",  # arbitrary code
+        "reset_compute_session",  # destroys the caller's session
+        "cancel_job",  # kills a running job
+        "delete_report",
+        "delete_business_ruleset",
+        "delete_business_rule",
+        "delete_decision_flow",
+        "update_business_ruleset",  # PUT replaces the rule set's content
+        "update_business_rule",  # PUT replaces the rule's content
+        "update_decision_flow",  # PUT replaces the full flow
+        "apply_report_operations",  # operations can remove pages/objects
+        "create_report",  # on_conflict="replace" can overwrite a report
+        "copy_report",  # result_name_conflict="replace" likewise
+        "publish_ml_champion_model",  # re-publish replaces the destination module
+    }
+)
+
+# Repeating the call with the same arguments has no additional effect: PUTs
+# (the update_* tools), deletes of something already gone, cancelling a
+# cancelled job, and promote_table_to_memory's explicit already-loaded guard.
+# Everything else on the write side creates, uploads, or starts work anew each
+# time — or we could not verify otherwise, and the spec's default is "no".
+IDEMPOTENT_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "update_business_ruleset",
+        "update_business_rule",
+        "update_decision_flow",
+        "delete_report",
+        "delete_business_ruleset",
+        "delete_business_rule",
+        "delete_decision_flow",
+        "cancel_job",
+        "reset_compute_session",
+        "promote_table_to_memory",
+    }
+)
+
+# Can reach beyond the one authenticated Viya deployment: arbitrary SAS code
+# (PROC HTTP, FILENAME URL, ...) and the upload tools' `url` source. Every
+# other tool talks only to Viya, so its world is closed.
+OPEN_WORLD_TOOLS: frozenset[str] = frozenset(
+    {
+        "execute_sas_code",
+        "submit_batch_job",
+        "upload_data",
+        "upload_file",
+    }
+)
+
+# What an unclassified tool advertises: the spec's own pessimistic defaults,
+# stated explicitly rather than left implicit. test_read_only.py guarantees no
+# registered tool takes this path, so this is belt-and-braces, not a policy.
+_PESSIMISTIC = ToolAnnotations(
+    readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True
+)
+
+
+def annotations_for(name: str) -> ToolAnnotations:
+    """MCP tool annotations for *name*, derived from the classification above.
+
+    ``readOnlyHint`` mirrors :data:`READ_ONLY_TOOLS` exactly, so what a client
+    is told and what ``MCP_READ_ONLY`` enforces cannot drift apart. Unknown
+    names get the pessimistic defaults (fail closed).
+    """
+    if name in READ_ONLY_TOOLS:
+        return ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=name in OPEN_WORLD_TOOLS,
+        )
+    if name in WRITE_TOOLS:
+        return ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=name in DESTRUCTIVE_TOOLS,
+            idempotentHint=name in IDEMPOTENT_WRITE_TOOLS,
+            openWorldHint=name in OPEN_WORLD_TOOLS,
+        )
+    return _PESSIMISTIC.model_copy()
+
+
 # --- registration gate -------------------------------------------------------
 
 
@@ -195,4 +300,12 @@ class ReadOnlyGate:
         return getattr(self._mcp, item)
 
 
-__all__ = ["READ_ONLY_TOOLS", "WRITE_TOOLS", "ReadOnlyGate"]
+__all__ = [
+    "DESTRUCTIVE_TOOLS",
+    "IDEMPOTENT_WRITE_TOOLS",
+    "OPEN_WORLD_TOOLS",
+    "READ_ONLY_TOOLS",
+    "WRITE_TOOLS",
+    "ReadOnlyGate",
+    "annotations_for",
+]

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -222,6 +222,40 @@ def test_render_page_without_version_or_prompts():
     assert "Prompt templates" not in page
 
 
+def test_tool_entry_kind():
+    assert ToolEntry("a", "s").kind == ""  # no annotations → no claim
+    assert ToolEntry("a", "s", read_only=True, destructive=False).kind == "read-only"
+    assert ToolEntry("a", "s", read_only=False, destructive=False).kind == "write"
+    assert ToolEntry("a", "s", read_only=False, destructive=True).kind == "destructive"
+
+
+def test_render_page_shows_behaviour_markers_and_legend():
+    facts = _facts(
+        tiers=(
+            TierGroup(
+                tier=0,
+                title="T",
+                tools=(
+                    ToolEntry("execute_sas_code", "Run.", read_only=False, destructive=True),
+                    ToolEntry("list_caslibs", "List.", read_only=True, destructive=False),
+                    ToolEntry("upload_data", "Up.", read_only=False, destructive=False),
+                ),
+            ),
+        )
+    )
+    page = render_page(facts, nonce="n")
+    assert '<em class="kind destructive">destructive</em>' in page
+    assert '<em class="kind read-only">read-only</em>' in page
+    assert '<em class="kind write">write</em>' in page
+    assert 'class="legend"' in page and "MCP tool annotations" in page
+
+
+def test_render_page_without_annotations_makes_no_claims():
+    page = render_page(_facts(), nonce="n")  # fixture tools carry no hints
+    assert 'class="legend"' not in page
+    assert '<em class="kind "></em>' in page  # empty marker cell, nothing invented
+
+
 def test_tier_range_formatting():
     assert landing._tier_range(frozenset()) == ""
     assert landing._tier_range(frozenset({4})) == "4"
@@ -255,6 +289,9 @@ async def test_collect_facts_groups_registered_tools_by_tier():
     assert facts.tiers[0].title == tools.TIER_TITLES[0]
     names0 = {t.name for t in facts.tiers[0].tools}
     assert "execute_sas_code" in names0
+    by_name = {t.name: t for g in facts.tiers for t in g.tools}
+    assert by_name["execute_sas_code"].kind == "destructive"  # picked up from the tool's annotations
+    assert by_name["list_compute_contexts"].kind == "read-only"
     assert all(t.summary for t in facts.tiers[0].tools)  # every tool has a one-liner
     # sorted within a tier
     assert [t.name for t in facts.tiers[1].tools] == sorted(t.name for t in facts.tiers[1].tools)

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,205 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MCP tool annotations (readOnlyHint / destructiveHint /
+idempotentHint / openWorldHint) — their derivation from the central
+classification in ``tools/_access.py`` and their injection at registration."""
+
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from mcp.types import ToolAnnotations
+
+from sas_mcp_server import tools
+from sas_mcp_server.tools import _access
+from sas_mcp_server.tools._access import (
+    DESTRUCTIVE_TOOLS,
+    IDEMPOTENT_WRITE_TOOLS,
+    OPEN_WORLD_TOOLS,
+    READ_ONLY_TOOLS,
+    WRITE_TOOLS,
+    annotations_for,
+)
+
+
+async def _list(tiers=None, read_only=None):
+    mcp = FastMCP("annotations-test")
+
+    async def get_token(ctx):
+        return "t"
+
+    tools.register_tools(mcp, get_token, tiers=tiers, read_only=read_only)
+    async with Client(mcp) as client:
+        return await client.list_tools()
+
+
+# --- the tables are internally consistent -------------------------------------
+
+
+def test_hint_sets_are_subsets_of_the_write_side():
+    """A read-only tool is non-destructive and idempotent by definition, so
+    the finer sets may only name write tools (open-world may name either)."""
+    assert DESTRUCTIVE_TOOLS <= WRITE_TOOLS, DESTRUCTIVE_TOOLS - WRITE_TOOLS
+    assert IDEMPOTENT_WRITE_TOOLS <= WRITE_TOOLS, IDEMPOTENT_WRITE_TOOLS - WRITE_TOOLS
+    assert OPEN_WORLD_TOOLS <= (READ_ONLY_TOOLS | WRITE_TOOLS), OPEN_WORLD_TOOLS - (READ_ONLY_TOOLS | WRITE_TOOLS)
+
+
+def test_arbitrary_code_tools_are_destructive_and_open_world():
+    for name in ("execute_sas_code", "submit_batch_job"):
+        assert name in DESTRUCTIVE_TOOLS
+        assert name in OPEN_WORLD_TOOLS
+        assert name not in IDEMPOTENT_WRITE_TOOLS
+
+
+# --- annotations_for ------------------------------------------------------------
+
+
+def test_read_only_tool_hints():
+    a = annotations_for("list_caslibs")
+    assert isinstance(a, ToolAnnotations)
+    assert (a.readOnlyHint, a.destructiveHint, a.idempotentHint, a.openWorldHint) == (
+        True,
+        False,
+        True,
+        False,
+    )
+
+
+@pytest.mark.parametrize(
+    "name,destructive,idempotent,open_world",
+    [
+        ("execute_sas_code", True, False, True),
+        ("delete_report", True, True, False),
+        ("update_business_rule", True, True, False),  # ETag-guarded PUT
+        ("create_report", True, False, False),  # on_conflict="replace"
+        ("upload_data", False, False, True),  # 409 on existing table; url source
+        ("promote_table_to_memory", False, True, False),  # explicit already-loaded guard
+        ("query_data", False, False, False),  # SELECT-only, but starts work
+        ("catalog_run_agent", False, False, False),
+        ("publish_ml_champion_model", True, False, False),
+    ],
+)
+def test_write_tool_hints(name, destructive, idempotent, open_world):
+    a = annotations_for(name)
+    assert a.readOnlyHint is False
+    assert a.destructiveHint is destructive
+    assert a.idempotentHint is idempotent
+    assert a.openWorldHint is open_world
+
+
+def test_readonly_hint_mirrors_the_enforced_partition_exactly():
+    """What clients are told and what MCP_READ_ONLY enforces come from one table."""
+    for name in READ_ONLY_TOOLS:
+        assert annotations_for(name).readOnlyHint is True, name
+    for name in WRITE_TOOLS:
+        assert annotations_for(name).readOnlyHint is False, name
+
+
+def test_unknown_tool_gets_pessimistic_defaults_and_a_fresh_object():
+    a = annotations_for("tool_nobody_classified")
+    assert (a.readOnlyHint, a.destructiveHint, a.idempotentHint, a.openWorldHint) == (
+        False,
+        True,
+        False,
+        True,
+    )
+    # A copy each time, so a caller mutating its annotations cannot poison the shared default.
+    assert a is not annotations_for("tool_nobody_classified")
+    assert a is not _access._PESSIMISTIC
+
+
+# --- injection at registration, observed on the wire ----------------------------
+
+
+async def test_every_registered_tool_carries_consistent_annotations():
+    listed = await _list()
+    assert listed, "no tools registered"
+    for t in listed:
+        a = t.annotations
+        assert a is not None, f"{t.name} has no annotations"
+        assert a.readOnlyHint is (t.name in READ_ONLY_TOOLS), t.name
+        assert a.destructiveHint is (t.name in DESTRUCTIVE_TOOLS), t.name
+        assert a.openWorldHint is (t.name in OPEN_WORLD_TOOLS), t.name
+        expected_idem = (t.name in READ_ONLY_TOOLS) or (t.name in IDEMPOTENT_WRITE_TOOLS)
+        assert a.idempotentHint is expected_idem, t.name
+
+
+async def test_no_registered_tool_takes_the_pessimistic_path():
+    """The drift guard, from the annotation side: registering an unclassified
+    tool would advertise worst-case hints — make that a red build, not a
+    silent downgrade."""
+    listed = await _list()
+    unclassified = {t.name for t in listed} - (READ_ONLY_TOOLS | WRITE_TOOLS)
+    assert unclassified == set(), unclassified
+
+
+async def test_read_only_mode_registers_only_read_only_annotated_tools():
+    listed = await _list(read_only=True)
+    assert listed
+    assert all(t.annotations is not None and t.annotations.readOnlyHint for t in listed)
+
+
+async def test_annotation_counts_match_the_classification():
+    listed = await _list()
+    names = {t.name for t in listed}
+    assert sum(1 for t in listed if t.annotations.readOnlyHint) == len(READ_ONLY_TOOLS & names)
+    assert sum(1 for t in listed if t.annotations.destructiveHint) == len(DESTRUCTIVE_TOOLS & names)
+
+
+# --- the recorder honours every decorator form and never overrides a tier ---------
+
+
+class _Spy:
+    """Stand-in target that captures the kwargs each ``tool()`` call forwards."""
+
+    def __init__(self):
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def tool(self, name_or_fn=None, **kwargs):
+        if callable(name_or_fn):
+            self.calls.append((kwargs.get("name") or name_or_fn.__name__, kwargs))
+            return name_or_fn
+
+        def decorator(fn):
+            explicit = name_or_fn if isinstance(name_or_fn, str) else kwargs.get("name")
+            self.calls.append((explicit or fn.__name__, kwargs))
+            return fn
+
+        return decorator
+
+
+def test_tier_recorder_injects_annotations_for_every_calling_form():
+    spy = _Spy()
+    rec = tools._TierRecorder(spy, tier=1)
+
+    @rec.tool
+    def list_caslibs(): ...
+
+    @rec.tool()
+    def get_castable_info(): ...
+
+    @rec.tool("list_castables")
+    def _renamed(): ...
+
+    @rec.tool(name="delete_report")
+    def _kw(): ...
+
+    seen = {name: kw["annotations"] for name, kw in spy.calls}
+    assert set(seen) == {"list_caslibs", "get_castable_info", "list_castables", "delete_report"}
+    assert seen["list_caslibs"].readOnlyHint is True
+    assert seen["list_castables"].readOnlyHint is True  # keyed by the explicit name, not _renamed
+    assert seen["delete_report"].destructiveHint is True
+    assert all(name in tools.TOOL_TIERS for name in seen)
+
+
+def test_tier_recorder_keeps_annotations_a_tier_passed_explicitly():
+    spy = _Spy()
+    rec = tools._TierRecorder(spy, tier=3)
+    mine = ToolAnnotations(readOnlyHint=False, destructiveHint=False, title="Custom")
+
+    @rec.tool(annotations=mine)
+    def delete_report(): ...
+
+    ((_, kw),) = spy.calls
+    assert kw["annotations"] is mine


### PR DESCRIPTION
## What

Every tool now carries [MCP tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#tool-annotations) on its `tools/list` entry:

| Hint | Derived from | Count |
|---|---|---|
| `readOnlyHint` | **exactly** the `READ_ONLY_TOOLS` table that `MCP_READ_ONLY` already enforces — one table, so what a client is told and what the server enforces cannot drift | 43 |
| `destructiveHint` | tools that can remove or overwrite existing state: arbitrary code (`execute_sas_code`, `submit_batch_job`), `delete_*`, `cancel_job`, `reset_compute_session`, the `update_*` PUTs, `apply_report_operations`, `create_report`/`copy_report` (their `replace` conflict policy), `publish_ml_champion_model` | 15 |
| `idempotentHint` | reads, the `update_*` PUTs (ETag-guarded), deletes, `cancel_job`, `reset_compute_session`, `promote_table_to_memory` (has an explicit already-loaded guard) | 53 |
| `openWorldHint` | only what can reach beyond Viya: arbitrary code and the upload tools' `url` source | 4 |

Wire sample (`list_caslibs`): `{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}`.

## Why

Annotations have been in the spec since revision 2025-03-26 (PR modelcontextprotocol/specification#185), and the defaults for a tool that ships none are the pessimistic ones — `readOnlyHint: false`, `destructiveHint: true`, `openWorldHint: true`. So until now every one of the 75 tools was presented to clients as writable, destructive and open-world, `list_caslibs` included, and clients such as Claude filed them all in a flat "other tools" bucket with per-tool approval. With honest hints, clients that use them can group the 43 read-only tools for one-click approval and warn before the destructive ones. Nothing changes about what a client can *reach* — hints are advisory by spec ("clients MUST treat annotations as untrusted unless from a trusted server"), and `MCP_READ_ONLY` / tiers / Viya's own authorization stay the controls. This is the server describing its surface so the harness's approval UX can do its job; it can only ever reduce friction.

## How

- `tools/_access.py`: three small documented sets (`DESTRUCTIVE_TOOLS`, `IDEMPOTENT_WRITE_TOOLS`, `OPEN_WORLD_TOOLS`, all ⊆ the write side) beside the existing read/write partition, and `annotations_for(name)` that derives a `ToolAnnotations` from them. Unknown names get the spec's pessimistic defaults (fail closed) — and a test asserts no registered tool takes that path.
- `tools/__init__.py`: the existing `_TierRecorder` wrapper stamps `annotations=` on the way into `@mcp.tool()` for every decorator form. Tier modules are untouched; a tier that passes its own `annotations=` keeps them. Stdio mode gets it for free (same `register_tools`).
- Judgement calls are commented in the table: `update_*` count as destructive because a PUT replaces content (spec contrast is "destructive updates" vs "only additive"); `create_report`/`copy_report` because of `on_conflict="replace"`; `upload_data` is *not* destructive (409 on an existing table) but *is* open-world (`url` source); `query_data` is not destructive (SELECT-only screen) but not read-only either (starts work) — consistent with the existing classification.
- Landing page: each tool row now shows a `read-only` / `write` / `destructive` marker from the same hints, with a legend; a tool without annotations gets no marker (nothing invented).
- README: new "Tool annotations (what clients are told)" section under read-only mode. CHANGELOG `[Unreleased]`.

## Testing

- `tests/test_tool_annotations.py` (17 tests): set consistency (hint sets ⊆ write side), per-tool expectations for the judgement calls, `readOnlyHint` mirrors the partition for every name, pessimistic fallback returns a fresh object, every registered tool carries consistent hints **on the wire** via `fastmcp.Client`, no registered tool is unclassified, read-only mode yields only `readOnlyHint: true` tools, recorder covers all four decorator forms and preserves explicit annotations.
- `tests/test_landing.py`: `ToolEntry.kind`, markers + legend rendered, no claims when hints are absent, `collect_facts` picks hints from the real tools.
- Full unit suite: 661 passed, `_access.py` 100 % covered, overall 93 %; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
