### PR TITLE
fix(auth): declare the OAuth client as password-less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Browser sign-in failed at the last step on every HTTP deployment since v1.12.0.** (#54) The login completed, the callback ran, and the token exchange was then rejected by SAS Logon with `invalid_client: Missing credentials`. The FastMCP 4.0 upgrade replaced authlib's OAuth2 client with FastMCP's own, and the replacement defaults to `client_secret_basic` whether or not a client secret exists — where authlib had chosen `none` when there was none. `sas-mcp` is registered as a public client with no secret, so `upstream_client_secret=None` was interpolated into the credential and sent as `Basic base64("sas-mcp:None")`, offering the literal word "None" as the password. The proxy now declares `token_endpoint_auth_method="none"`, which is the RFC 6749 method for a public client and what authlib inferred on its own before the upgrade. Token *refresh* failed the same way and is fixed with it. stdio mode was never affected (it signs in through `auth_login.py`, which has its own token request), nor were clients presenting a raw Viya JWT with `ALLOW_RAW_BEARER`. Reported and fixed by @bteleuca.
+
 ## [1.14.0] - 2026-09-07
 
 ### Fixed

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -144,6 +144,16 @@ viya_auth = PermissiveOAuthProxy(
     upstream_token_endpoint=TOKEN_ENDPOINT,
     upstream_client_id=CLIENT_ID,
     upstream_client_secret=None,
+    # Keep in step with upstream_client_secret above: sas-mcp is registered as a
+    # public client (allowpublic, no secret — see examples/register_mcp_client.py),
+    # so the token exchange must present no password at all. Say so explicitly
+    # rather than leave it inferred. FastMCP 4.0 replaced authlib's OAuth2 client
+    # with its own, and the replacement defaults to client_secret_basic whether or
+    # not a secret exists, where authlib chose "none" when there was none. The
+    # None above was f-string interpolated into Basic base64("sas-mcp:None") and
+    # SAS Logon rejected every browser sign-in with "invalid_client: Missing
+    # credentials" (#54). If a client secret ever becomes configurable, this has
+    # to become conditional on it.
     token_endpoint_auth_method="none",
     jwt_signing_key=MCP_SIGNING_KEY,
     base_url=MCP_BASE_URL,

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -144,6 +144,7 @@ viya_auth = PermissiveOAuthProxy(
     upstream_token_endpoint=TOKEN_ENDPOINT,
     upstream_client_id=CLIENT_ID,
     upstream_client_secret=None,
+    token_endpoint_auth_method="none",
     jwt_signing_key=MCP_SIGNING_KEY,
     base_url=MCP_BASE_URL,
     forward_pkce=True,

--- a/tests/test_config_oauth.py
+++ b/tests/test_config_oauth.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for PermissiveOAuthProxy.load_access_token — the additive raw-bearer
-path gated by ALLOW_RAW_BEARER.
+Tests for the configured PermissiveOAuthProxy: the additive raw-bearer path
+gated by ALLOW_RAW_BEARER, and the credential the proxy presents to SAS Logon
+when it exchanges a code upstream.
 """
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -57,3 +58,32 @@ async def test_raw_bearer_enabled_rejects_invalid_token():
         mock_validator.verify_token = AsyncMock(return_value=None)
         result = await auth.load_access_token("bad-token")
     assert result is None
+
+
+def test_upstream_token_request_presents_no_client_password():
+    """sas-mcp is a public client, so the upstream exchange must send no secret.
+
+    This asserts the bytes rather than the setting, because the setting is not
+    what broke. FastMCP 4.0 replaced authlib's OAuth2 client with its own, and
+    the replacement defaults to ``client_secret_basic`` whether or not a secret
+    exists — where authlib had chosen ``none`` when there was none. Our
+    ``upstream_client_secret=None`` was therefore f-string interpolated into
+    ``Basic base64("sas-mcp:None")``, the literal word "None" as the password,
+    and SAS Logon rejected every browser sign-in with "invalid_client: Missing
+    credentials" (#54). Nothing else in the suite constructs the upstream
+    client, so the break shipped in three releases unnoticed.
+
+    It reaches into two FastMCP internals on purpose: they are what carries the
+    credential onto the wire, so if a future release renames them this test
+    should fail loudly rather than keep passing while the contract moves.
+    """
+    client = config.viya_auth._create_upstream_oauth_client()
+    data: dict = {}
+    headers: dict = {}
+    client._apply_client_auth(data, headers)
+
+    assert "Authorization" not in headers, (
+        f"public client sent a password: {headers.get('Authorization')!r}"
+    )
+    # RFC 6749 §2.3.1: a client without a secret identifies itself in the body.
+    assert data.get("client_id") == config.CLIENT_ID


### PR DESCRIPTION
## Problem

Signing in doesn't work. You get all the way through the browser login, it looks like it succeeded and then it fails at the last moment with "Missing credentials."

## Cause

Our server logs in to SAS on your behalf. Some apps prove who they are with a shared password; ours doesn't have one, and SAS knows it. It's registered as the kind of app that's allowed in without a password.

We told the login library "no password." But a recent upgrade of that library stopped checking whether a password was actually there. It assumed one existed, turned our empty value into the word "None," and handed that to SAS as the password.

SAS quite reasonably rejected it.

## Solution

Stop letting the library guess. Say it outright: this app has no password.

That's one line of configuration, it's a normal supported setting, and it's exactly what the library used to do on its own before the upgrade.

Sign-in now completes.