### PR TITLE
Fixing /mcp auth sas-execution-mcp in GitHub Copilot CLI where authentication fails

### DIFF
--- a/tests/test_config_oauth.py
+++ b/tests/test_config_oauth.py
@@ -87,3 +87,9 @@ def test_upstream_token_request_presents_no_client_password():
     )
     # RFC 6749 §2.3.1: a client without a secret identifies itself in the body.
     assert data.get("client_id") == config.CLIENT_ID
+
+def test_cimd_is_disabled_for_dynamic_localhost_callbacks():
+    """Local MCP callbacks must use normal dynamic client registration.
+    Works with enable_cimd=False to the PermissiveOAuthProxy(...) call in src/sas_mcp_server/config.py
+    """
+    assert config.viya_auth._cimd_manager is None


### PR DESCRIPTION
Add test for CIMD disabled on dynamic localhost callbacks -> 
`enable_cimd=False` to the PermissiveOAuthProxy(...) call in src/sas_mcp_server/config.py
FastMCP's PermissiveOAuthProxy enables Client ID Metadata Documents (CIMD) by default, which validates the incoming redirect_uri against a fetched CIMD document's redirect_uris list.
The SAS Logon client this proxy wraps (sas-mcp, registered via register_mcp_client.py) is a fixed, pre-registered client, not a CIMD client. Any dynamically-assigned loopback port a client picks at runtime (which is what Copilot CLI's mcp auth does) gets rejected.