### PR TITLE
fix(auth): disable CIMD for dynamic loopback OAuth callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Signing in from GitHub Copilot CLI failed before Viya was ever contacted.** (#58) The callback was refused with `Redirect URI 'http://127.0.0.1:52505/' does not match CIMD redirect_uris`. An MCP client opens a fresh loopback port for every sign-in, and FastMCP 4.0 enables CIMD (Client ID Metadata Document) by default: a client whose `client_id` is an HTTPS URL has its callback checked against the redirect URIs in its own published document, with no exemption for varying loopback ports — so the check could never pass. It cannot be widened from this side either, since the document check runs first and `allowed_client_redirect_uris` only narrows what the document already permits. The proxy now sets `enable_cimd=False`, putting URL-shaped client IDs on the ordinary dynamic-registration path, which does allow loopback ports to vary (RFC 8252 §7.3) and is the path every other MCP client already uses. Verified against GitHub Copilot CLI 1.0.83. Note the trade: the server no longer advertises `client_id_metadata_document_supported`, and `private_key_jwt` drops out of the advertised token-endpoint auth methods — both accurate, since neither is supported with CIMD off. Reported and fixed by @bteleuca.
+
 ## [1.14.1] - 2026-09-09
 
 ### Fixed

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -157,9 +157,20 @@ viya_auth = PermissiveOAuthProxy(
     token_endpoint_auth_method="none",
     jwt_signing_key=MCP_SIGNING_KEY,
     base_url=MCP_BASE_URL,
-    # MCP clients use dynamically assigned localhost callback ports. Treating a
-    # URL-shaped client_id as a Client ID Metadata Document makes FastMCP reject
-    # those callbacks before the normal dynamic-registration path can handle them.
+    # An MCP client opens a fresh loopback port for every sign-in. FastMCP 4.0
+    # turns CIMD on by default, and a client whose client_id is an HTTPS URL
+    # (GitHub Copilot CLI is one) then has its callback checked against the
+    # redirect URIs in its own published metadata document — which lists fixed
+    # ports and gets no loopback exemption, so the check can never pass. It
+    # cannot be widened from here either: the document check runs first, and
+    # allowed_client_redirect_uris only narrows what the document already
+    # permits. Off, those client IDs take the ordinary dynamic-registration
+    # path, which does let loopback ports vary (RFC 8252 §7.3) and is what every
+    # other MCP client already uses. The trade is that this server no longer
+    # advertises client_id_metadata_document_supported or private_key_jwt —
+    # correct, since with CIMD off it supports neither (#58). The underlying
+    # asymmetry is FastMCP's: its DCR path implements the loopback rule and its
+    # CIMD path does not; drop this line if that is ever reconciled.
     enable_cimd=False,
     forward_pkce=True,
     token_verifier=token_verifier,

--- a/src/sas_mcp_server/config.py
+++ b/src/sas_mcp_server/config.py
@@ -157,6 +157,10 @@ viya_auth = PermissiveOAuthProxy(
     token_endpoint_auth_method="none",
     jwt_signing_key=MCP_SIGNING_KEY,
     base_url=MCP_BASE_URL,
+    # MCP clients use dynamically assigned localhost callback ports. Treating a
+    # URL-shaped client_id as a Client ID Metadata Document makes FastMCP reject
+    # those callbacks before the normal dynamic-registration path can handle them.
+    enable_cimd=False,
     forward_pkce=True,
     token_verifier=token_verifier,
     valid_scopes=["openid"],

--- a/tests/test_config_oauth.py
+++ b/tests/test_config_oauth.py
@@ -3,12 +3,15 @@
 
 """
 Tests for the configured PermissiveOAuthProxy: the additive raw-bearer path
-gated by ALLOW_RAW_BEARER, and the credential the proxy presents to SAS Logon
-when it exchanges a code upstream.
+gated by ALLOW_RAW_BEARER, the credential the proxy presents to SAS Logon when
+it exchanges a code upstream, and the redirect URIs it will accept back from an
+MCP client.
 """
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
 
 import sas_mcp_server.auth as auth_mod
 import sas_mcp_server.config as config
@@ -88,7 +91,44 @@ def test_upstream_token_request_presents_no_client_password():
     # RFC 6749 §2.3.1: a client without a secret identifies itself in the body.
     assert data.get("client_id") == config.CLIENT_ID
 
-def test_cimd_is_disabled_for_dynamic_localhost_callbacks():
-    """Local MCP callbacks must use normal dynamic client registration.
-    Test added for enable_cimd=False to the PermissiveOAuthProxy(...) call in src/sas_mcp_server/config.py"""
+
+def test_cimd_is_disabled_so_url_client_ids_go_through_registration():
+    """No CIMD manager: a URL-shaped client_id must not be resolved as a document.
+
+    ``OAuthProxy.get_client`` gates the whole CIMD path on this attribute, so
+    ``None`` here is what routes a client like GitHub Copilot CLI — whose
+    client_id is an HTTPS URL — down the ordinary dynamic-registration path
+    instead. That matters because CIMD validates the callback against the
+    redirect_uris in the client's *published* document, with no exemption for
+    loopback ports, and an MCP client opens a fresh ``127.0.0.1:<port>`` every
+    run. The document check runs first and is fatal, so it cannot be widened
+    from this side — ``allowed_client_redirect_uris`` only narrows what the
+    document already permits. Disabling CIMD is the only lever the server
+    has (#58).
+    """
     assert config.viya_auth._cimd_manager is None
+
+
+@pytest.mark.asyncio
+async def test_a_callback_may_come_back_on_a_different_loopback_port():
+    """The port an MCP client listens on changes every run; the callback must still work.
+
+    Companion to the test above, pinning the outcome rather than the mechanism:
+    whatever validates redirect URIs, a client that registered on one loopback
+    port has to be allowed back on another, or interactive sign-in only ever
+    works once. RFC 8252 §7.3 requires exactly this of an authorization server.
+    """
+    client_id = "https://example.invalid/copilot-cimd.json"
+    await config.viya_auth.register_client(
+        OAuthClientInformationFull(
+            client_id=client_id,
+            redirect_uris=[AnyUrl("http://127.0.0.1:8080/")],
+            grant_types=["authorization_code", "refresh_token"],
+            token_endpoint_auth_method="none",
+        )
+    )
+    stored = await config.viya_auth.get_client(client_id)
+    assert stored is not None, "the client we just registered should be retrievable"
+
+    # A different port than the one registered — what actually happens next run.
+    assert stored.validate_redirect_uri(AnyUrl("http://127.0.0.1:52505/"))

--- a/tests/test_config_oauth.py
+++ b/tests/test_config_oauth.py
@@ -87,3 +87,8 @@ def test_upstream_token_request_presents_no_client_password():
     )
     # RFC 6749 §2.3.1: a client without a secret identifies itself in the body.
     assert data.get("client_id") == config.CLIENT_ID
+
+def test_cimd_is_disabled_for_dynamic_localhost_callbacks():
+    """Local MCP callbacks must use normal dynamic client registration.
+    Test added for enable_cimd=False to the PermissiveOAuthProxy(...) call in src/sas_mcp_server/config.py"""
+    assert config.viya_auth._cimd_manager is None


### PR DESCRIPTION
Verified locally with GitHub Copilot CLI 1.0.83.

Copilot uses a dynamic `127.0.0.1:<port>` loopback redirect. With CIMD enabled,
FastMCP validates that callback against Copilot's published fixed URI and rejects
it before contacting SAS Viya. Disabling CIMD allows the normal registration flow;
the existing fixed upstream SASLogon callback remains unchanged.

Validation:
- `python -m pytest tests/test_config_oauth.py -q --no-cov`
- `copilot mcp auth sas-execution-mcp` completes successfully