### PR TITLE
Add Tier 9: Event Stream Processing (ESP) tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Tools are grouped into numbered tiers. By default the server exposes all of them
 | 6 | Model Management & Scoring |
 | 7 | Decisioning (SAS Intelligent Decisioning) |
 | 8 | Workbench (Execute Code Only) |
+| 9 | Event Stream Processing |
 
 ```sh
 # Example: expose only compute/discovery/data-ops and reporting
@@ -245,6 +246,17 @@ Build and manage SAS Intelligent Decisioning rule sets and decision flows end to
 
 #### Tier 8 — Workbench (Execute Code Only)
 - **execute_sas_code**: Execute SAS code snippets and retrieve execution results (log and listing output). Runs in a reusable compute session that is kept warm across calls, so SAS state (WORK tables, macro variables, assigned librefs) persists between successive calls
+
+#### Tier 9 — Event Stream Processing
+Wraps the SAS Event Stream Processing REST/XML layer (`/eventStreamProcessing/v1/...`). **Endpoint paths are not verified against a live environment** — ESP's REST API has historically lived directly on an ESP server process rather than uniformly behind the shared Viya gateway, so whether/where your deployment proxies it under `VIYA_ENDPOINT` depends on your specific setup. Always call `discover_esp_api` first to confirm the real base path before relying on the rest.
+- **discover_esp_api**: Probe a few candidate URLs under `VIYA_ENDPOINT` for the ESP API description/Swagger doc, to confirm (or correct) the base path the other tools assume
+- **list_esp_servers**: List ESP server instances known to this Viya environment
+- **list_esp_projects**: List deployed ESP projects, optionally scoped to one server
+- **get_esp_project**: Get a deployed project's model and status
+- **deploy_esp_project**: Deploy (load and start) a project from its XML model definition
+- **undeploy_esp_project**: Stop and remove a deployed project
+- **get_esp_window_schema**: Get a window's field schema within a running project
+- **publish_esp_events**: Publish a batch of events into a source window
 
 ### Prompt Templates
 

--- a/src/sas_mcp_server/tools/__init__.py
+++ b/src/sas_mcp_server/tools/__init__.py
@@ -28,6 +28,7 @@ from . import (
     data_ops,
     decisioning,
     discovery,
+    esp,
     jobs,
     model_scoring,
     reports,
@@ -46,6 +47,7 @@ _TIER_REGISTRARS: dict[int, Registrar] = {
     6: model_scoring.register,
     7: decisioning.register,
     8: workbench.register,
+    9: esp.register,
 }
 
 TIER_TITLES: dict[int, str] = {
@@ -58,6 +60,7 @@ TIER_TITLES: dict[int, str] = {
     6: "Model Management & Scoring",
     7: "Decisioning (SAS Intelligent Decisioning)",
     8: "Workbench (Execute Code Only)",
+    9: "Event Stream Processing",
 }
 
 ALL_TIERS: frozenset[int] = frozenset(_TIER_REGISTRARS)

--- a/src/sas_mcp_server/tools/esp.py
+++ b/src/sas_mcp_server/tools/esp.py
@@ -1,0 +1,232 @@
+# Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 9 — Event Stream Processing (ESP) tools.
+
+Wraps the SAS Event Stream Processing REST/XML layer
+(``/eventStreamProcessing/v1/...``) the same way the other tiers wrap their
+Viya microservice: reuse the shared ``viya_session`` helper for the
+authenticated ``httpx.AsyncClient``, so ESP calls ride the same SASLogon
+bearer token as every other tool in this server.
+
+IMPORTANT — verify the endpoint paths against your environment first.
+Unlike the other tiers (catalog, casManagement, reports, ...), ESP's REST API
+has historically been documented as living directly on an ESP *server*
+process (``http://ESPhost:http_port/eventStreamProcessing/v1/...``) rather
+than uniformly behind the shared Viya API gateway used by
+``VIYA_ENDPOINT``. Whether your deployment fronts it at
+``{VIYA_ENDPOINT}/eventStreamProcessing/v1/...`` (typical when SAS Event
+Stream Manager proxies ESP servers under Viya, e.g. as a "module" alongside
+Visual Analytics / Model Manager) depends on your specific Viya
+configuration. Call ``discover_esp_api`` first — it fetches the service's
+own API-documentation resource so you (or the calling model) can confirm the
+real base path and operation names before trusting any other tool below. If
+paths differ in your environment, only the URL fragments built inside this
+module need to change — the auth/session plumbing does not.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+from fastmcp import Context, FastMCP
+
+from ..config import VIYA_ENDPOINT
+from ..viya_client import get_json, post_json
+from ._common import make_session_helpers
+
+# Base path for the ESP REST/XML layer. Override here (or via env var, if you
+# add one) if `discover_esp_api` shows your environment mounts it elsewhere.
+_ESP_BASE = "/eventStreamProcessing/v1"
+
+
+def register(mcp: FastMCP, get_token: Callable[[Context], Awaitable[str]]) -> None:
+    """Register Tier 9 (Event Stream Processing) tools on *mcp*."""
+
+    viya_session, _ = make_session_helpers(get_token)
+
+    @mcp.tool()
+    async def discover_esp_api(ctx: Context) -> dict[str, Any]:
+        """Fetch the live ESP API description to confirm real paths for this environment.
+
+        Call this FIRST, before any other esp_* tool. SAS's ESP REST API has
+        varied its mount point across versions/deployments (standalone ESP
+        server vs. Event Stream Manager proxying it under Viya). This hits a
+        couple of likely candidate URLs under VIYA_ENDPOINT and reports which
+        one (if any) responded, plus the raw body, so you can confirm or
+        correct the base path this module assumes
+        (``{VIYA_ENDPOINT}/eventStreamProcessing/v1``).
+        """
+        candidates = [
+            f"{_ESP_BASE}/apiDoc?format=json",
+            f"{_ESP_BASE}",
+            "/eventStreamProcessing",
+            "/SASEventStreamProcessingServer",
+        ]
+        async with viya_session("discover_esp_api", ctx) as client:
+            results = []
+            for path in candidates:
+                url = f"{VIYA_ENDPOINT}{path}"
+                try:
+                    resp = await client.get(url, headers={"Accept": "application/json"})
+                    results.append({
+                        "path": path,
+                        "status_code": resp.status_code,
+                        "content_type": resp.headers.get("content-type", ""),
+                        "body_preview": resp.text[:1000],
+                    })
+                except httpx.HTTPError as e:
+                    results.append({"path": path, "error": str(e)})
+            return {
+                "viya_endpoint": VIYA_ENDPOINT,
+                "assumed_base_path": _ESP_BASE,
+                "candidates_tried": results,
+                "message": (
+                    "Look for a 2xx response with a JSON/Swagger-shaped body. "
+                    "If none of these succeed, ESP is likely not exposed through "
+                    "this Viya gateway/token — check with your Viya admin for the "
+                    "correct host, or whether Event Stream Manager is deployed."
+                ),
+            }
+
+    @mcp.tool()
+    async def list_esp_servers(ctx: Context) -> dict[str, Any]:
+        """List ESP server instances known to this Viya environment.
+
+        Returns the raw response alongside a best-effort parsed item list,
+        since the exact collection shape (name/id fields) is not verified
+        against a live environment — inspect ``raw`` if ``items`` looks wrong.
+        """
+        async with viya_session("list_esp_servers", ctx) as client:
+            data = await get_json(f"{_ESP_BASE}/servers", client)
+            items = data.get("items", data if isinstance(data, list) else [])
+            return {"items": items, "raw": data}
+
+    @mcp.tool()
+    async def list_esp_projects(ctx: Context, server_id: str | None = None) -> dict[str, Any]:
+        """List ESP projects deployed on a server (or across all servers if omitted).
+
+        Args:
+            server_id: Optional ESP server name/id to scope the listing (see
+                list_esp_servers). Omit to list projects across all servers.
+        """
+        params = {"server": server_id} if server_id else None
+        async with viya_session("list_esp_projects", ctx) as client:
+            resp = await client.get(
+                f"{VIYA_ENDPOINT}{_ESP_BASE}/projects",
+                params=params or {},
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            data = resp.json() if resp.content else {}
+            items = data.get("items", data if isinstance(data, list) else [])
+            return {"items": items, "raw": data}
+
+    @mcp.tool()
+    async def get_esp_project(project_name: str, ctx: Context, server_id: str | None = None) -> dict[str, Any]:
+        """Get an ESP project's model and status.
+
+        Args:
+            project_name: Name of the deployed ESP project.
+            server_id: Optional ESP server name/id the project runs on, if
+                required to disambiguate in your environment.
+        """
+        params = {"server": server_id} if server_id else None
+        async with viya_session("get_esp_project", ctx) as client:
+            resp = await client.get(
+                f"{VIYA_ENDPOINT}{_ESP_BASE}/projects/{project_name}",
+                params=params or {},
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            return resp.json() if resp.content else {}
+
+    @mcp.tool()
+    async def deploy_esp_project(
+        project_name: str,
+        project_xml: str,
+        ctx: Context,
+        server_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Deploy (load and start) an ESP project from its XML model definition.
+
+        Args:
+            project_name: Name to deploy the project under.
+            project_xml: The full ESP project XML (as produced by ESP Studio,
+                or hand-authored per the ESP XML modeling-language reference).
+            server_id: Optional target ESP server name/id (see list_esp_servers).
+        """
+        params = {"server": server_id} if server_id else None
+        async with viya_session("deploy_esp_project", ctx) as client:
+            resp = await client.post(
+                f"{VIYA_ENDPOINT}{_ESP_BASE}/projects/{project_name}",
+                params=params or {},
+                content=project_xml.encode(),
+                headers={"Content-Type": "application/xml", "Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            return {
+                "status": "deployed" if resp.status_code < 300 else "unknown",
+                "status_code": resp.status_code,
+                "project_name": project_name,
+                "response_body": resp.text[:2000],
+            }
+
+    @mcp.tool()
+    async def undeploy_esp_project(project_name: str, ctx: Context, server_id: str | None = None) -> dict[str, str]:
+        """Stop and remove a deployed ESP project.
+
+        Args:
+            project_name: Name of the ESP project to remove.
+            server_id: Optional ESP server name/id the project runs on.
+        """
+        params = {"server": server_id} if server_id else None
+        async with viya_session("undeploy_esp_project", ctx) as client:
+            resp = await client.delete(
+                f"{VIYA_ENDPOINT}{_ESP_BASE}/projects/{project_name}",
+                params=params or {},
+            )
+            resp.raise_for_status()
+            return {"status": "undeployed", "project_name": project_name}
+
+    @mcp.tool()
+    async def get_esp_window_schema(
+        project_name: str, cq_name: str, window_name: str, ctx: Context
+    ) -> dict[str, Any]:
+        """Get a window's schema (field names/types) within a running ESP project.
+
+        Args:
+            project_name: Name of the deployed ESP project.
+            cq_name: Name of the continuous query containing the window.
+            window_name: Name of the window.
+        """
+        async with viya_session("get_esp_window_schema", ctx) as client:
+            return await get_json(
+                f"{_ESP_BASE}/projects/{project_name}/queries/{cq_name}/windows/{window_name}/schema",
+                client,
+            )
+
+    @mcp.tool()
+    async def publish_esp_events(
+        project_name: str,
+        cq_name: str,
+        window_name: str,
+        events: list[dict[str, Any]],
+        ctx: Context,
+    ) -> dict[str, Any]:
+        """Publish a batch of events into a source window of a running ESP project.
+
+        Args:
+            project_name: Name of the deployed ESP project.
+            cq_name: Name of the continuous query containing the target window.
+            window_name: Name of the source window to publish into.
+            events: List of event field/value dicts, one per event, matching
+                the window's schema (see get_esp_window_schema).
+        """
+        body = {"events": events}
+        async with viya_session("publish_esp_events", ctx) as client:
+            return await post_json(
+                f"{_ESP_BASE}/projects/{project_name}/queries/{cq_name}/windows/{window_name}/events",
+                client,
+                body=body,
+            )

--- a/tests/test_tier_selection.py
+++ b/tests/test_tier_selection.py
@@ -33,7 +33,7 @@ def test_resolve_range_list_and_csv():
     assert tools.resolve_enabled_tiers([2, 3]) == {2, 3}
 
 
-@pytest.mark.parametrize("bad", ["0-99", "9", "abc", [42]])
+@pytest.mark.parametrize("bad", ["0-99", "10", "abc", [42]])
 def test_resolve_rejects_unknown_tiers(bad):
     with pytest.raises(ConfigError):
         tools.resolve_enabled_tiers(bad)
@@ -48,9 +48,10 @@ def test_env_var_drives_default(monkeypatch):
 
 async def test_register_all_tiers_registers_everything():
     names = await _register(None)
-    assert len(names) == 68
+    assert len(names) == 76
     assert "execute_sas_code" in names
     assert "publish_decision_flow" in names
+    assert "list_esp_projects" in names  # tier 9
 
 
 async def test_register_subset_excludes_other_tiers():


### PR DESCRIPTION
## Summary
Adds a new Tier 9 (Event Stream Processing) to the tiered tool registry, wrapping the SAS ESP REST/XML layer (`/eventStreamProcessing/v1/...`). Reuses the existing `viya_session` auth/session helpers shared by every other tier -- no changes to auth plumbing.

## New tools (8)
- `discover_esp_api` -- probes candidate URLs under `VIYA_ENDPOINT` to confirm ESP's real base path for a given environment
- `list_esp_servers`
- `list_esp_projects`
- `get_esp_project`
- `deploy_esp_project`
- `undeploy_esp_project`
- `get_esp_window_schema`
- `publish_esp_events`

## Testing
- `py_compile` clean
- Registered all 10 tiers against a live `FastMCP` instance, in-process and end-to-end over the stdio transport against a real Viya environment -- 76 tools total (was 68), all 8 ESP tools present, zero exceptions
- Updated `test_tier_selection.py`'s hardcoded tier-count/boundary assertions; full affected unit suite passes (42/42)

## Caveat -- please review before merging
ESP endpoint paths are grounded in SAS's published REST/XML layer docs but **not verified against a live ESP server**. Historically, ESP's REST API has lived directly on the ESP server process rather than uniformly behind the shared Viya gateway used by `VIYA_ENDPOINT` in this repo -- whether/where a given deployment proxies it depends on the environment. `discover_esp_api` is included specifically to let a caller confirm/correct the base path before relying on the other tools; endpoint paths may need adjustment for real ESP / Event Stream Manager deployments.

Generated with Claude Code (https://claude.com/claude-code)
